### PR TITLE
Added a failing test that adds multiple accessibility modifiers

### DIFF
--- a/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
@@ -186,4 +186,17 @@ final class ViewAccessibilityTests: XCTestCase {
             .inspect().emptyView().accessibilitySortPriority()
         XCTAssertEqual(sut, 6)
     }
+
+    func testAccessibilityMultipleAttributes() throws {
+        let label = "letters"
+        let value = "abc"
+
+        let sut = try EmptyView()
+            .accessibility(label: Text(label))
+            .accessibility(value: Text(value))
+            .inspect().emptyView()
+
+        XCTAssertEqual(try sut.accessibilityValue().string(), value)
+        XCTAssertEqual(try sut.accessibilityLabel().string(), label)
+    }
 }


### PR DESCRIPTION
This creates a test that adds an accessibility value and label and queries them both. It is currently failing but should be used to assert that a fix for accessibility modifiers is working properly.