### PR TITLE
Adds ForEach range support

### DIFF
--- a/Tests/ViewInspectorTests/SwiftUI/ForEachTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ForEachTests.swift
@@ -65,6 +65,16 @@ final class ForEachTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect().group().forEach(0).text(1))
         XCTAssertNoThrow(try view.inspect().group().forEach(1).text(0))
     }
+
+    func testRangeBased() throws {
+        let range = 0..<5
+        let view = ForEach(range) { Text(verbatim: "\($0)") }
+
+        let sut = try view.inspect().forEach()
+        XCTAssertEqual(sut.underestimatedCount, 5)
+        XCTAssertEqual(try sut.text(4).string(), "\(range.upperBound - 1)")
+        XCTAssertThrowsError(try sut.text(range.upperBound))
+    }
 }
 
 private struct TestStruct: Identifiable {


### PR DESCRIPTION
This change adds support for `ForEach`'s `Range<Int>`-based constructor. Because of `associatedtype`s, this was the cleanest way I could think of to allow both collection and range based `ForEach` inspection.

Fixes https://github.com/nalexn/ViewInspector/issues/12