### PR TITLE
This should probably use vStack()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func testVStackOfTexts() throws {
         Text("2")
         Text("3")
     }
-    let text = try view.inspect().hStack().text(2).string()
+    let text = try view.inspect().vStack().text(2).string()
     XCTAssertEqual(text, "3")
 }
 ```


### PR DESCRIPTION
If this test is supposed to pass (and hopefully it is, because it's the first example), I would imagine it needs `vStack()` here rather than `hStack()`.