### PR TITLE
Change platform to v11 for iOS to be able to use `ViewInspector` in apps with optional SwiftUI views

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ViewInspector",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+        .macOS(.v10_15), .iOS(.v11), .tvOS(.v13)
     ],
     products: [
         .library(

--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -6,6 +6,7 @@ public protocol Inspectable {
     var content: Any { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Inspectable where Self: View {
     var content: Any { body }
 }
@@ -26,8 +27,10 @@ public protocol CustomViewType {
     associatedtype T
 }
 
+@available(iOS 11.0, macOS 10.15, tvOS 13.0, *)
 public struct ViewType { }
 
+@available(iOS 11.0, macOS 10.15, tvOS 13.0, *)
 public struct Content {
     let view: Any
     let modifiers: [Any]
@@ -38,6 +41,7 @@ public struct Content {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Binding {
     init(wrappedValue: Value) {
         var value = wrappedValue

--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public struct InspectableView<View> where View: KnownViewType {
     
     internal let content: Content
@@ -11,12 +12,14 @@ public struct InspectableView<View> where View: KnownViewType {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension InspectableView where View: SingleViewContent {
     func child() throws -> Content {
         return try View.child(content)
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension InspectableView where View: MultipleViewContent {
     
     func child(at index: Int) throws -> Content {
@@ -28,6 +31,7 @@ internal extension InspectableView where View: MultipleViewContent {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension InspectableView: Sequence where View: MultipleViewContent {
     
     public typealias Element = InspectableView<ViewType.ClassifiedView>
@@ -57,6 +61,7 @@ extension InspectableView: Sequence where View: MultipleViewContent {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension InspectableView: Collection, BidirectionalCollection, RandomAccessCollection
     where View: MultipleViewContent {
     
@@ -85,6 +90,7 @@ extension InspectableView: Collection, BidirectionalCollection, RandomAccessColl
 
 // MARK: - Inspection of a Custom View
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension View {
     func inspect() throws -> InspectableView<ViewType.ClassifiedView> {
         return try .init(try Inspector.unwrap(view: self, modifiers: []))
@@ -100,6 +106,7 @@ public extension View {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension View where Self: Inspectable {
     
     func inspect() throws -> InspectableView<ViewType.View<Self>> {
@@ -118,6 +125,7 @@ public extension View where Self: Inspectable {
 
 // MARK: - Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension InspectableView {
     
     func modifierAttribute<Type>(modifierName: String, path: String,
@@ -143,10 +151,12 @@ internal extension InspectableView {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal protocol ModifierNameProvider {
     var modifierType: String { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension ModifiedContent: ModifierNameProvider {
     var modifierType: String {
         return Inspector.typeName(type: Modifier.self)

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Combine
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol InspectionEmissary: class {
     
     associatedtype V: View & Inspectable
@@ -25,6 +26,7 @@ public protocol InspectionEmissary: class {
 
 // MARK: - Default Implementation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectionEmissary {
     
     @discardableResult
@@ -75,6 +77,7 @@ public extension InspectionEmissary {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension View where Self: Inspectable {
     @discardableResult
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,

--- a/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - Accessibility
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func accessibilityLabel() throws -> InspectableView<ViewType.Text> {
@@ -87,6 +88,7 @@ public extension InspectableView {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension InspectableView {
     
     func accessibilityElement<T>(_ name: String, path: String = "value|some",

--- a/Sources/ViewInspector/Modifiers/AnimationModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AnimationModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - Animation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func callTransaction() throws {

--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -1,5 +1,6 @@
 // MARK: - ViewEvents
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func callOnAppear() throws {

--- a/Sources/ViewInspector/Modifiers/GestureModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/GestureModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - ViewGestures
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     func callOnTapGesture() throws {
         typealias Callback = ((()) -> Void)
@@ -23,6 +24,7 @@ public extension InspectableView {
 
 // MARK: - ViewHitTesting
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public struct ContentShape<S>: Equatable where S: Shape {
     public let shape: S
     public let eoFill: Bool
@@ -34,6 +36,7 @@ public struct ContentShape<S>: Equatable where S: Shape {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func allowsHitTesting() throws -> Bool {

--- a/Sources/ViewInspector/Modifiers/InteractionModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/InteractionModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - InteractionEvents
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     #if os(macOS)
@@ -108,6 +109,7 @@ internal extension InspectableView {
 
 // MARK: - ViewHover
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     /* Not supported

--- a/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - ViewPositioning
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func position() throws -> CGPoint {
@@ -31,6 +32,7 @@ public extension InspectableView {
 
 // MARK: - ViewLayering
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
 
     func overlay() throws -> InspectableView<ViewType.ClassifiedView> {

--- a/Sources/ViewInspector/Modifiers/PreviewModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/PreviewModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - ViewPreview
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func previewDevice() throws -> PreviewDevice {

--- a/Sources/ViewInspector/Modifiers/SizingModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/SizingModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - ViewSizing
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     func fixedFrame() throws -> (width: CGFloat, height: CGFloat, alignment: Alignment) {
         let width = try modifierAttribute(
@@ -52,6 +53,7 @@ public extension InspectableView {
 
 // MARK: - ViewPadding
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func padding() throws -> EdgeInsets {

--- a/Sources/ViewInspector/Modifiers/VisualEffectModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/VisualEffectModifiers.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - ViewGraphicalEffects
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func blur() throws -> (radius: CGFloat, isOpaque: Bool) {
@@ -103,6 +104,7 @@ public extension InspectableView {
 
 // MARK: - ViewMasking
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func clipShape<S>(_ shape: S.Type) throws -> S where S: Shape {
@@ -140,6 +142,7 @@ public extension InspectableView {
 
 // MARK: - ViewHiding
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func isHidden() -> Bool {

--- a/Sources/ViewInspector/SwiftUI/AngularGradient.swift
+++ b/Sources/ViewInspector/SwiftUI/AngularGradient.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func angularGradient() throws -> InspectableView<ViewType.AngularGradient> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func angularGradient(_ index: Int) throws -> InspectableView<ViewType.AngularGradient> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.AngularGradient {
     
     func gradient() throws -> Gradient {

--- a/Sources/ViewInspector/SwiftUI/AnyView.swift
+++ b/Sources/ViewInspector/SwiftUI/AnyView.swift
@@ -19,6 +19,7 @@ extension ViewType.AnyView: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func anyView() throws -> InspectableView<ViewType.AnyView> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func anyView(_ index: Int) throws -> InspectableView<ViewType.AnyView> {

--- a/Sources/ViewInspector/SwiftUI/Button.swift
+++ b/Sources/ViewInspector/SwiftUI/Button.swift
@@ -19,6 +19,7 @@ extension ViewType.Button: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func button() throws -> InspectableView<ViewType.Button> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func button(_ index: Int) throws -> InspectableView<ViewType.Button> {
@@ -37,6 +39,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Button {
     
     func tap() throws {

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -23,6 +23,7 @@ extension ViewType.View: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func view<T>(_ type: T.Type) throws -> InspectableView<ViewType.View<T>>
@@ -36,6 +37,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func view<T>(_ type: T.Type, _ index: Int) throws -> InspectableView<ViewType.View<T>>
@@ -49,6 +51,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: CustomViewType {
     
     func actualView() throws -> View.T {
@@ -72,12 +75,14 @@ public extension NSViewControllerRepresentable where Self: Inspectable {
     }
 }
 #else
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension UIViewRepresentable where Self: Inspectable {
     func uiView() throws -> UIViewType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension UIViewControllerRepresentable where Self: Inspectable {
     func viewController() throws -> UIViewControllerType {
         return try ViewHosting.lookup(Self.self)

--- a/Sources/ViewInspector/SwiftUI/DatePicker.swift
+++ b/Sources/ViewInspector/SwiftUI/DatePicker.swift
@@ -21,6 +21,7 @@ extension ViewType.DatePicker: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func datePicker() throws -> InspectableView<ViewType.DatePicker> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func datePicker(_ index: Int) throws -> InspectableView<ViewType.DatePicker> {

--- a/Sources/ViewInspector/SwiftUI/Divider.swift
+++ b/Sources/ViewInspector/SwiftUI/Divider.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func divider() throws -> InspectableView<ViewType.Divider> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func divider(_ index: Int) throws -> InspectableView<ViewType.Divider> {

--- a/Sources/ViewInspector/SwiftUI/EditButton.swift
+++ b/Sources/ViewInspector/SwiftUI/EditButton.swift
@@ -11,6 +11,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func editButton() throws -> InspectableView<ViewType.EditButton> {
@@ -20,6 +21,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func editButton(_ index: Int) throws -> InspectableView<ViewType.EditButton> {
@@ -29,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.EditButton {
     
     func editMode() throws -> Binding<EditMode>? {

--- a/Sources/ViewInspector/SwiftUI/EmptyView.swift
+++ b/Sources/ViewInspector/SwiftUI/EmptyView.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func emptyView() throws -> InspectableView<ViewType.EmptyView> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func emptyView(_ index: Int) throws -> InspectableView<ViewType.EmptyView> {

--- a/Sources/ViewInspector/SwiftUI/EnvironmentReaderView.swift
+++ b/Sources/ViewInspector/SwiftUI/EnvironmentReaderView.swift
@@ -15,6 +15,7 @@ extension ViewType.EnvironmentReaderView: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func navigationBarItems() throws -> InspectableView<ViewType.ClassifiedView> {
@@ -29,6 +30,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func navigationBarItems(_ index: Int = 0) throws -> InspectableView<ViewType.ClassifiedView> {
@@ -43,6 +45,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Unwrapping the EnvironmentReaderView
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension InspectableView {
     
     func navigationBarItems<V>(viewType: V.Type, content: Content) throws ->

--- a/Sources/ViewInspector/SwiftUI/ForEach.swift
+++ b/Sources/ViewInspector/SwiftUI/ForEach.swift
@@ -23,6 +23,7 @@ extension ViewType.ForEach: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func forEach() throws -> InspectableView<ViewType.ForEach> {
@@ -32,6 +33,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func forEach(_ index: Int) throws -> InspectableView<ViewType.ForEach> {
@@ -45,6 +47,7 @@ private protocol ForEachContentProvider {
     func views() throws -> LazyGroup<Any>
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension ForEach: ForEachContentProvider {
     
     func views() throws -> LazyGroup<Any> {

--- a/Sources/ViewInspector/SwiftUI/Form.swift
+++ b/Sources/ViewInspector/SwiftUI/Form.swift
@@ -19,6 +19,7 @@ extension ViewType.Form: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func form() throws -> InspectableView<ViewType.Form> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func form(_ index: Int) throws -> InspectableView<ViewType.Form> {

--- a/Sources/ViewInspector/SwiftUI/GeometryReader.swift
+++ b/Sources/ViewInspector/SwiftUI/GeometryReader.swift
@@ -21,6 +21,7 @@ extension ViewType.GeometryReader: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func geometryReader() throws -> InspectableView<ViewType.GeometryReader> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func geometryReader(_ index: Int) throws -> InspectableView<ViewType.GeometryReader> {
@@ -43,6 +45,7 @@ private protocol GeometryReaderContentProvider {
     func view() throws -> Any
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension GeometryReader: GeometryReaderContentProvider {
     func view() throws -> Any {
         typealias Builder = (GeometryProxy) -> Content
@@ -52,6 +55,7 @@ extension GeometryReader: GeometryReaderContentProvider {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension GeometryProxy {
     struct Allocator {
         let data: (Int64, Int64, Int64, Int64, Int64, Int64) = (0, 0, 0, 0, 0, 0)

--- a/Sources/ViewInspector/SwiftUI/Group.swift
+++ b/Sources/ViewInspector/SwiftUI/Group.swift
@@ -19,6 +19,7 @@ extension ViewType.Group: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func group() throws -> InspectableView<ViewType.Group> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func group(_ index: Int) throws -> InspectableView<ViewType.Group> {

--- a/Sources/ViewInspector/SwiftUI/HStack.swift
+++ b/Sources/ViewInspector/SwiftUI/HStack.swift
@@ -19,6 +19,7 @@ extension ViewType.HStack: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func hStack() throws -> InspectableView<ViewType.HStack> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func hStack(_ index: Int) throws -> InspectableView<ViewType.HStack> {

--- a/Sources/ViewInspector/SwiftUI/IDView.swift
+++ b/Sources/ViewInspector/SwiftUI/IDView.swift
@@ -25,6 +25,7 @@ private struct IDViewModifier: ModifierNameProvider {
 
 // MARK: - Global View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func id() throws -> AnyHashable {

--- a/Sources/ViewInspector/SwiftUI/Image.swift
+++ b/Sources/ViewInspector/SwiftUI/Image.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func image() throws -> InspectableView<ViewType.Image> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func image(_ index: Int) throws -> InspectableView<ViewType.Image> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Image {
     
     func imageName() throws -> String? {

--- a/Sources/ViewInspector/SwiftUI/LinearGradient.swift
+++ b/Sources/ViewInspector/SwiftUI/LinearGradient.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func linearGradient() throws -> InspectableView<ViewType.LinearGradient> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func linearGradient(_ index: Int) throws -> InspectableView<ViewType.LinearGradient> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.LinearGradient {
     
     func gradient() throws -> Gradient {

--- a/Sources/ViewInspector/SwiftUI/List.swift
+++ b/Sources/ViewInspector/SwiftUI/List.swift
@@ -19,6 +19,7 @@ extension ViewType.List: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func list() throws -> InspectableView<ViewType.List> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func list(_ index: Int) throws -> InspectableView<ViewType.List> {

--- a/Sources/ViewInspector/SwiftUI/NavigationLink.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationLink.swift
@@ -34,6 +34,7 @@ extension ViewType.NavigationLink.Label: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func navigationLink() throws -> InspectableView<ViewType.NavigationLink> {
@@ -43,6 +44,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func navigationLink(_ index: Int) throws -> InspectableView<ViewType.NavigationLink> {
@@ -52,6 +54,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.NavigationLink {
     
     func label() throws -> InspectableView<ViewType.NavigationLink.Label> {
@@ -84,6 +87,7 @@ public extension InspectableView where View == ViewType.NavigationLink {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension InspectableView where View == ViewType.NavigationLink {
     func internalIsActive() throws -> State<Bool> {
         return try Inspector

--- a/Sources/ViewInspector/SwiftUI/NavigationView.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationView.swift
@@ -21,6 +21,7 @@ extension ViewType.NavigationView: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func navigationView() throws -> InspectableView<ViewType.NavigationView> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func navigationView(_ index: Int) throws -> InspectableView<ViewType.NavigationView> {

--- a/Sources/ViewInspector/SwiftUI/Picker.swift
+++ b/Sources/ViewInspector/SwiftUI/Picker.swift
@@ -34,6 +34,7 @@ extension ViewType.Picker.Label: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func picker() throws -> InspectableView<ViewType.Picker> {
@@ -43,6 +44,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func picker(_ index: Int) throws -> InspectableView<ViewType.Picker> {
@@ -52,6 +54,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Picker {
     
     func label() throws -> InspectableView<ViewType.Picker.Label> {

--- a/Sources/ViewInspector/SwiftUI/RadialGradient.swift
+++ b/Sources/ViewInspector/SwiftUI/RadialGradient.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func radialGradient() throws -> InspectableView<ViewType.RadialGradient> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func radialGradient(_ index: Int) throws -> InspectableView<ViewType.RadialGradient> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.RadialGradient {
     
     func gradient() throws -> Gradient {

--- a/Sources/ViewInspector/SwiftUI/ScrollView.swift
+++ b/Sources/ViewInspector/SwiftUI/ScrollView.swift
@@ -19,6 +19,7 @@ extension ViewType.ScrollView: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func scrollView() throws -> InspectableView<ViewType.ScrollView> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func scrollView(_ index: Int) throws -> InspectableView<ViewType.ScrollView> {
@@ -37,6 +39,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.ScrollView {
     
     func contentInsets() throws -> EdgeInsets {

--- a/Sources/ViewInspector/SwiftUI/Section.swift
+++ b/Sources/ViewInspector/SwiftUI/Section.swift
@@ -19,6 +19,7 @@ extension ViewType.Section: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func section() throws -> InspectableView<ViewType.Section> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func section(_ index: Int) throws -> InspectableView<ViewType.Section> {

--- a/Sources/ViewInspector/SwiftUI/SecureField.swift
+++ b/Sources/ViewInspector/SwiftUI/SecureField.swift
@@ -19,6 +19,7 @@ extension ViewType.SecureField: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func secureField() throws -> InspectableView<ViewType.SecureField> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func secureField(_ index: Int) throws -> InspectableView<ViewType.SecureField> {
@@ -37,6 +39,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.SecureField {
     
     func callOnCommit() throws {

--- a/Sources/ViewInspector/SwiftUI/Shape.swift
+++ b/Sources/ViewInspector/SwiftUI/Shape.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func shape() throws -> InspectableView<ViewType.Shape> {
@@ -20,6 +21,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func shape(_ index: Int) throws -> InspectableView<ViewType.Shape> {
@@ -31,6 +33,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Shape {
     
     func path(in rect: CGRect) throws -> Path {
@@ -90,6 +93,7 @@ public extension InspectableView where View == ViewType.Shape {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension InspectableView {
     
     func guardShapeIsInspectable(_ view: Any) throws {
@@ -119,23 +123,51 @@ private extension InspectableView {
 
 // MARK: - InspectableShape
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol InspectableShape {
     func path(in rect: CGRect) -> Path
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Rectangle: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Circle: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Ellipse: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Capsule: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Path: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension RoundedRectangle: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension TransformedShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension OffsetShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension RotatedShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension ScaledShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension _SizedShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension _StrokedShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension _TrimmedShape: InspectableShape { }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension _ShapeView: InspectableShape {
     public func path(in rect: CGRect) -> Path {
         return shape.path(in: rect)

--- a/Sources/ViewInspector/SwiftUI/Slider.swift
+++ b/Sources/ViewInspector/SwiftUI/Slider.swift
@@ -21,6 +21,7 @@ extension ViewType.Slider: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func slider() throws -> InspectableView<ViewType.Slider> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func slider(_ index: Int) throws -> InspectableView<ViewType.Slider> {
@@ -39,6 +41,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Slider {
     
     func callOnEditingChanged() throws {

--- a/Sources/ViewInspector/SwiftUI/Spacer.swift
+++ b/Sources/ViewInspector/SwiftUI/Spacer.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func spacer() throws -> InspectableView<ViewType.Spacer> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func spacer(_ index: Int) throws -> InspectableView<ViewType.Spacer> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Spacer {
     
     func minLength() throws -> CGFloat? {

--- a/Sources/ViewInspector/SwiftUI/Stepper.swift
+++ b/Sources/ViewInspector/SwiftUI/Stepper.swift
@@ -21,6 +21,7 @@ extension ViewType.Stepper: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func stepper() throws -> InspectableView<ViewType.Stepper> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func stepper(_ index: Int) throws -> InspectableView<ViewType.Stepper> {
@@ -39,6 +41,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Stepper {
     
     func increment() throws {

--- a/Sources/ViewInspector/SwiftUI/TabView.swift
+++ b/Sources/ViewInspector/SwiftUI/TabView.swift
@@ -21,6 +21,7 @@ extension ViewType.TabView: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func tabView() throws -> InspectableView<ViewType.TabView> {
@@ -30,6 +31,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func tabView(_ index: Int) throws -> InspectableView<ViewType.TabView> {
@@ -41,6 +43,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Global View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func tag() throws -> AnyHashable {

--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -9,6 +9,7 @@ public extension ViewType {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func text() throws -> InspectableView<ViewType.Text> {
@@ -18,6 +19,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func text(_ index: Int) throws -> InspectableView<ViewType.Text> {
@@ -27,6 +29,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.Text {
     
     func string() throws -> String? {

--- a/Sources/ViewInspector/SwiftUI/TextField.swift
+++ b/Sources/ViewInspector/SwiftUI/TextField.swift
@@ -19,6 +19,7 @@ extension ViewType.TextField: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func textField() throws -> InspectableView<ViewType.TextField> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func textField(_ index: Int) throws -> InspectableView<ViewType.TextField> {
@@ -37,6 +39,7 @@ public extension InspectableView where View: MultipleViewContent {
 
 // MARK: - Custom Attributes
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View == ViewType.TextField {
     
     func callOnEditingChanged() throws {

--- a/Sources/ViewInspector/SwiftUI/Toggle.swift
+++ b/Sources/ViewInspector/SwiftUI/Toggle.swift
@@ -19,6 +19,7 @@ extension ViewType.Toggle: SingleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func toggle() throws -> InspectableView<ViewType.Toggle> {
@@ -28,6 +29,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func toggle(_ index: Int) throws -> InspectableView<ViewType.Toggle> {

--- a/Sources/ViewInspector/SwiftUI/VStack.swift
+++ b/Sources/ViewInspector/SwiftUI/VStack.swift
@@ -18,6 +18,7 @@ extension ViewType.VStack: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func vStack() throws -> InspectableView<ViewType.VStack> {
@@ -27,6 +28,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func vStack(_ index: Int) throws -> InspectableView<ViewType.VStack> {

--- a/Sources/ViewInspector/SwiftUI/ZStack.swift
+++ b/Sources/ViewInspector/SwiftUI/ZStack.swift
@@ -18,6 +18,7 @@ extension ViewType.ZStack: MultipleViewContent {
 
 // MARK: - Extraction from SingleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
     func zStack() throws -> InspectableView<ViewType.ZStack> {
@@ -27,6 +28,7 @@ public extension InspectableView where View: SingleViewContent {
 
 // MARK: - Extraction from MultipleViewContent parent
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
     func zStack(_ index: Int) throws -> InspectableView<ViewType.ZStack> {

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -5,6 +5,7 @@ import UIKit
 
 public struct ViewHosting { }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewHosting {
     
     static func host<V>(view: V, size: CGSize? = nil, viewId: String = #function) where V: View {
@@ -38,6 +39,7 @@ public extension ViewHosting {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension ViewHosting {
     
     #if os(macOS)
@@ -161,6 +163,7 @@ private class RootViewController: NSViewController {
 
 // MARK: - UIView lookup
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension ViewHosting {
     #if os(macOS)
     static func lookup<V>(_ view: V.Type) throws -> V.NSViewType

--- a/Tests/ViewInspectorTests/BaseTypesTests.swift
+++ b/Tests/ViewInspectorTests/BaseTypesTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class BaseTypesTests: XCTestCase {
     
     func testInspectionErrorDescription() throws {
@@ -30,6 +31,7 @@ final class BaseTypesTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SequenceTests: XCTestCase {
     
     func testLazyGroupEmpty() {
@@ -74,6 +76,7 @@ final class SequenceTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class RandomAccessCollectionTests: XCTestCase {
     
     func testMultipleViewContentSequence() throws {

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class InspectionEmissaryTests: XCTestCase {
     
     func testOnFunction() throws {
@@ -53,6 +54,7 @@ final class InspectionEmissaryTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 class Inspection<V>: InspectionEmissary where V: View & Inspectable {
     let notice = PassthroughSubject<UInt, Never>()
     var callbacks = [UInt: (V) -> Void]()
@@ -64,6 +66,7 @@ class Inspection<V>: InspectionEmissary where V: View & Inspectable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct TestView: View, Inspectable {
     
     @State private(set) var flag: Bool

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Combine
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class InspectorTests: XCTestCase {
     
     private let testString = "abc"
@@ -94,6 +95,7 @@ final class InspectorTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class InspectableViewModifiersTests: XCTestCase {
     
     func testModifierIsNotPresent() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/AngularGradientTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AngularGradientTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class AngularGradientTests: XCTestCase {
     
     let gradient = Gradient(colors: [.red])

--- a/Tests/ViewInspectorTests/SwiftUI/AnyViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AnyViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class AnyViewTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ButtonTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -42,6 +43,7 @@ final class ButtonTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForButton: XCTestCase {
     
     func testButtonStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ConditionalContentTests: XCTestCase {
     
     func testConditionalView() throws {
@@ -20,6 +21,7 @@ final class ConditionalContentTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct ConditionalView: View, Inspectable {
     
     @ObservedObject var viewModel = ViewModel()

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class CustomViewTests: XCTestCase {
     
     func testLocalStateChanges() throws {
@@ -130,12 +131,14 @@ final class CustomViewTests: XCTestCase {
 
 // MARK: - Test Views
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct SimpleTestView: View, Inspectable {
     var body: some View {
         EmptyView()
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct LocalStateTestView: View, Inspectable {
     
     @State private(set) var flag: Bool
@@ -149,6 +152,7 @@ private struct LocalStateTestView: View, Inspectable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct ObservedStateTestView: View, Inspectable {
     
     @ObservedObject var viewModel: ExternalState
@@ -158,6 +162,7 @@ private struct ObservedStateTestView: View, Inspectable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct EnvironmentStateTestView: View, Inspectable {
     
     @EnvironmentObject var viewModel: ExternalState
@@ -182,6 +187,7 @@ private struct NSTestView: NSViewRepresentable, Inspectable {
     }
 }
 #else
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct UITestView: UIViewRepresentable, Inspectable {
     
     func makeUIView(context: UIViewRepresentableContext<Self>) -> UIView {
@@ -197,14 +203,17 @@ private struct UITestView: UIViewRepresentable, Inspectable {
 
 // MARK: - Misc
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private class ExternalState: ObservableObject {
     @Published var value = "obj1"
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct EnvironmentParameter {
     let state = CurrentValueSubject<String, Never>("obj2")
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension EnvironmentParameter {
     struct EnvKey: EnvironmentKey {
         let state: EnvironmentParameter
@@ -212,6 +221,7 @@ extension EnvironmentParameter {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension EnvironmentValues {
     fileprivate var state3: EnvironmentParameter.EnvKey {
         get { self[EnvironmentParameter.EnvKey.self] }

--- a/Tests/ViewInspectorTests/SwiftUI/DatePickerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/DatePickerTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(iOS) || os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class DatePickerTests: XCTestCase {
     
     class StateObject: ObservableObject {
@@ -46,6 +47,7 @@ final class DatePickerTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForDatePicker: XCTestCase {
     
     func testDatePickerStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/DelayedPreferenceViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/DelayedPreferenceViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(iOS) || os(tvOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class DelayedPreferenceViewTests: XCTestCase {
     
     func testUnwrapDelayedPreferenceView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/DividerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/DividerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class DividerTests: XCTestCase {
     
     func testInspect() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/EditButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EditButtonTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(iOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class EditButtonTests: XCTestCase {
     
     func testInspect() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/EmptyViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EmptyViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class EmptyViewTests: XCTestCase {
     
     func testInspect() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentReaderViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentReaderViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class EnvironmentReaderViewTests: XCTestCase {
     
     #if os(iOS) || os(tvOS)

--- a/Tests/ViewInspectorTests/SwiftUI/EquatableViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EquatableViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class EquatableViewTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -34,6 +35,7 @@ final class EquatableViewTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForEquatableView: XCTestCase {
     
     func testEquatable() throws {
@@ -42,6 +44,7 @@ final class GlobalModifiersForEquatableView: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct TestView: View, Equatable, Inspectable {
     
     var body: some View { EmptyView() }

--- a/Tests/ViewInspectorTests/SwiftUI/ForEachTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ForEachTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ForEachTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/FormTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FormTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class FormTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/GeometryReaderTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/GeometryReaderTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GeometryReaderTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/GroupBoxTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/GroupBoxTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GroupBoxTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/GroupTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/GroupTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GroupTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/HSplitViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/HSplitViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class HSplitViewTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/HStackTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/HStackTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class HStackTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/IDViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/IDViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class IDViewTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -41,6 +42,7 @@ final class IDViewTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForIDView: XCTestCase {
     
     func testID() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ImageTests: XCTestCase {
     
     let testImage = testColor.image(CGSize(width: 100, height: 80))

--- a/Tests/ViewInspectorTests/SwiftUI/LinearGradientTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/LinearGradientTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class LinearGradientTests: XCTestCase {
     
     let gradient = Gradient(colors: [.red])

--- a/Tests/ViewInspectorTests/SwiftUI/ListTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ListTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ListTests: XCTestCase {
     
     func testSingleEnclosedView() throws {
@@ -64,6 +65,7 @@ final class ListTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForList: XCTestCase {
     
     func testListRowInsets() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/MenuButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/MenuButtonTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class MenuButtonTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -40,6 +41,7 @@ final class MenuButtonTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForMenuMenuButton: XCTestCase {
     
     func testMenuButtonStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ModifiedContentTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ModifiedContentTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ModifiedContentTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -49,12 +50,14 @@ final class ModifiedContentTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct TestModifier: ViewModifier {
     func body(content: Self.Content) -> some View {
         content.onAppear()
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct InspectableTestModifier: ViewModifier {
     
     var didAppear: ((Self.Body) -> Void)?
@@ -68,6 +71,7 @@ private struct InspectableTestModifier: ViewModifier {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForModifiedContent: XCTestCase {
     
     func testModifier() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class NavigationLinkTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -99,6 +100,7 @@ final class NavigationLinkTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct TestView: View, Inspectable {
     @ObservedObject var state = NavigationState()
     
@@ -115,6 +117,7 @@ private struct TestView: View, Inspectable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension TestView {
     class NavigationState: ObservableObject {
         @Published var selection: String?

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if !os(watchOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class NavigationViewTests: XCTestCase {
     
     func testSingleEnclosedView() throws {
@@ -51,6 +52,7 @@ final class NavigationViewTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForNavigationView: XCTestCase {
     
     func testNavigationViewStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/OpaqueViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/OpaqueViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class OpaqueViewTests: XCTestCase {
     
     func testOpaqueStandardView() throws {
@@ -33,12 +34,14 @@ final class OpaqueViewTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct InspectableTestView: View, Inspectable {
     var body: some View {
         Text("Test")
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct EnvInspectableTestView: View, Inspectable {
     
     var body: some View {

--- a/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class OptionalViewTests: XCTestCase {
     
     func testOptionalViewWhenExists() throws {
@@ -43,6 +44,7 @@ final class OptionalViewTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct OptionalView: View, Inspectable {
     
     let flag: Bool
@@ -53,6 +55,7 @@ private struct OptionalView: View, Inspectable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct MixedOptionalView: View, Inspectable {
     
     let flag: Bool

--- a/Tests/ViewInspectorTests/SwiftUI/PasteButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PasteButtonTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class PasteButtonTests: XCTestCase {
     
     func testExtractionFromSingleViewContainer() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/PickerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PickerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class PickerTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -58,6 +59,7 @@ final class PickerTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForPicker: XCTestCase {
     
     func testPickerStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/RadialGradientTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/RadialGradientTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class RadialGradientTests: XCTestCase {
     
     let gradient = Gradient(colors: [.red])

--- a/Tests/ViewInspectorTests/SwiftUI/ScrollViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ScrollViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ScrollViewTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/SectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SectionTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SectionTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/SecureFieldTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SecureFieldTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SecureFieldTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ShapeTests: XCTestCase {
     
     func testExtractionFromSingleViewContainer() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/SliderTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SliderTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if !os(tvOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SliderTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/SpacerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SpacerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SpacerTests: XCTestCase {
     
     func testExtractionFromSingleViewContainer() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/StepperTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/StepperTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(iOS) || os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class StepperTests: XCTestCase {
     
     func testEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/SubscriptionViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SubscriptionViewTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Combine
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class SubscriptionViewTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -23,6 +24,7 @@ final class SubscriptionViewTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct SubscriptionTestView: View, Inspectable {
     
     let publisher: AnyPublisher<Void, Never>

--- a/Tests/ViewInspectorTests/SwiftUI/TabViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TabViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if !os(watchOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class TabViewTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -48,6 +49,7 @@ final class TabViewTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForTabView: XCTestCase {
     
     func testTag() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/TextFieldTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextFieldTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class TextFieldTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -57,6 +58,7 @@ final class TextFieldTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForTextField: XCTestCase {
     
     func testTextFieldStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class TextTests: XCTestCase {
     
     // MARK: - string()
@@ -45,6 +46,7 @@ final class TextTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForText: XCTestCase {
     
     func testFont() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ToggleTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ToggleTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ToggleTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -37,6 +38,7 @@ final class ToggleTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForToggle: XCTestCase {
     
     func testToggleStyle() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/TouchBarTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TouchBarTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class TouchBarTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -21,6 +22,7 @@ final class TouchBarTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForTouchBar: XCTestCase {
     
     func testTouchBar() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if !os(tvOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class TreeViewTests: XCTestCase {
     
     func testEnclosedView() throws {
@@ -24,6 +25,7 @@ final class TreeViewTests: XCTestCase {
 
 // MARK: - View Modifiers
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class GlobalModifiersForTreeView: XCTestCase {
     
     func testContextMenu() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/VSplitViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/VSplitViewTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 #if os(macOS)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class VSplitViewTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/VStackTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/VStackTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class VStackTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/ZStackTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ZStackTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ZStackTests: XCTestCase {
     
     func testSingleEnclosedView() throws {

--- a/Tests/ViewInspectorTests/ViewHostingTests.swift
+++ b/Tests/ViewInspectorTests/ViewHostingTests.swift
@@ -7,6 +7,7 @@ import UIKit
 @testable import ViewInspector
 
 #if os(macOS)
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewHostingTests: XCTestCase {
 
     func testNSViewUpdate() throws {
@@ -78,6 +79,7 @@ final class ViewHostingTests: XCTestCase {
     }
 }
 #else
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewHostingTests: XCTestCase {
     
     func testUIViewUpdate() throws {
@@ -191,6 +193,7 @@ extension NSTestView {
     }
 }
 #else
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct UITestView: UIViewRepresentable, Inspectable {
     
     typealias UpdateContext = UIViewRepresentableContext<Self>
@@ -211,6 +214,7 @@ private struct UITestView: UIViewRepresentable, Inspectable {
     static let onTag: Int = 43
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension UITestView {
     struct WrapperView: View, Inspectable {
         
@@ -255,6 +259,7 @@ private struct NSTestVC: NSViewControllerRepresentable, Inspectable {
     }
 }
 #else
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct UITestVC: UIViewControllerRepresentable, Inspectable {
     
     class TestVC: UIViewController { }

--- a/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
@@ -5,6 +5,7 @@ import Combine
 
 // MARK: - ViewAccessibilityTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewAccessibilityTests: XCTestCase {
     
     func testAccessibilityLabel() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/AnimationModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/AnimationModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewAnimationsTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewAnimationsTests: XCTestCase {
     
     func testAnimation() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/ConfigurationModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/ConfigurationModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewControlAttributesTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewControlAttributesTests: XCTestCase {
     
     func testLabelsHidden() throws {
@@ -33,6 +34,7 @@ final class ViewControlAttributesTests: XCTestCase {
 
 // MARK: - StatusBarConfigurationTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class StatusBarConfigurationTests: XCTestCase {
     
     #if os(iOS)

--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewEnvironmentTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewEnvironmentTests: XCTestCase {
     
     func testEnvironment() throws {
@@ -23,12 +24,14 @@ final class ViewEnvironmentTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private class TestEnvObject: ObservableObject { }
 
 private struct TestEnvKey: EnvironmentKey {
     static var defaultValue: Self { .init() }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension EnvironmentValues {
     var testKey: TestEnvKey {
         get { self[TestEnvKey.self] }
@@ -38,6 +41,7 @@ private extension EnvironmentValues {
 
 // MARK: - ViewPreferenceTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPreferenceTests: XCTestCase {
     
     func testPreference() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -5,6 +5,7 @@ import Combine
 
 // MARK: - ViewEventsTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewEventsTests: XCTestCase {
     
     func testOnAppear() throws {
@@ -39,6 +40,7 @@ final class ViewEventsTests: XCTestCase {
 
 // MARK: - ViewPublisherEventsTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPublisherEventsTests: XCTestCase {
     
     func testOnReceive() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/GestureModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/GestureModifiersTests.swift
@@ -5,6 +5,7 @@ import Combine
 
 // MARK: - ViewGesturesTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewGesturesTests: XCTestCase {
     
     #if !os(tvOS)
@@ -69,6 +70,7 @@ final class ViewGesturesTests: XCTestCase {
 
 // MARK: - ViewHitTestingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewHitTestingTests: XCTestCase {
     
     func testAllowsHitTesting() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/InteractionModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/InteractionModifiersTests.swift
@@ -5,6 +5,7 @@ import Combine
 
 // MARK: - InteractionTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class InteractionTests: XCTestCase {
     
     #if os(macOS)
@@ -157,6 +158,7 @@ final class InteractionTests: XCTestCase {
 
 // MARK: - ViewHoverTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewHoverTests: XCTestCase {
     
     #if os(macOS)
@@ -199,6 +201,7 @@ final class ViewHoverTests: XCTestCase {
 
 // MARK: - ViewDragDropTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewDragDropTests: XCTestCase {
     
     #if os(macOS)

--- a/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewPositioningTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPositioningTests: XCTestCase {
     
     func testPosition() throws {
@@ -79,6 +80,7 @@ final class ViewPositioningTests: XCTestCase {
 
 // MARK: - ViewAligningTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewAligningTests: XCTestCase {
     
     func testHorizontalAlignmentGuide() throws {
@@ -94,6 +96,7 @@ final class ViewAligningTests: XCTestCase {
 
 // MARK: - ViewLayeringTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewLayeringTests: XCTestCase {
     
     func testOverlay() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/PresentationModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/PresentationModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewPresentationTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPresentationTests: XCTestCase {
     
     func testSheet() throws {
@@ -37,6 +38,7 @@ final class ViewPresentationTests: XCTestCase {
 
 // MARK: - ViewColorTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewColorTests: XCTestCase {
     
     func testForegroundColor() throws {
@@ -66,6 +68,7 @@ final class ViewColorTests: XCTestCase {
 
 // MARK: - ViewPreviewTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPreviewTests: XCTestCase {
     
     func testPreviewDevice() throws {
@@ -104,4 +107,5 @@ final class ViewPreviewTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension PreviewLayout: BinaryEquatable { }

--- a/Tests/ViewInspectorTests/ViewModifiers/SizingModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/SizingModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewSizingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewSizingTests: XCTestCase {
     
     func testFrameWidthHeightAlignment() throws {
@@ -79,6 +80,7 @@ final class ViewSizingTests: XCTestCase {
 
 // MARK: - ViewPaddingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewPaddingTests: XCTestCase {
     
     func testPadding() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/TransformingModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/TransformingModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewTransformingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewTransformingTests: XCTestCase {
     
     func testRotationEffect() throws {
@@ -30,6 +31,7 @@ final class ViewTransformingTests: XCTestCase {
 
 // MARK: - ViewScalingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewScalingTests: XCTestCase {
     
     func testScaledToFill() throws {

--- a/Tests/ViewInspectorTests/ViewModifiers/VisualEffectModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/VisualEffectModifiersTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ViewGraphicalEffectsTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewGraphicalEffectsTests: XCTestCase {
     
     func testBlur() throws {
@@ -161,10 +162,12 @@ final class ViewGraphicalEffectsTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension LinearGradient: BinaryEquatable { }
 
 // MARK: - ViewMaskingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewMaskingTests: XCTestCase {
     
     func testClipped() throws {
@@ -218,6 +221,7 @@ final class ViewMaskingTests: XCTestCase {
 
 // MARK: - ViewHidingTests
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewHidingTests: XCTestCase {
     
     func testHidden() throws {


### PR DESCRIPTION
We have a use case where our app has a build target below iOS 13. We use SwiftUI for views that show only on devices running at iOS 13 and above. 

I think being able to unit test views during a period of transition between UIKit and SwiftUI based apps is quite essential. Therefore it is useful to not require iOS 13 for `ViewInspector`.

I have marked all iOS 13 only features with `@available` to be able to use the package with projects that use SwiftUI only optionally.