### PR TITLE
attributedString inspection support

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -65,4 +65,48 @@ public extension InspectableView where View == ViewType.Text {
         }
         return String(format: format, arguments: values)
     }
+
+    func attributedString() throws -> NSAttributedString? {
+        if let first = try? Inspector.attribute(path: "storage|anyTextStorage|first", value: content.view) as? Text,
+            let second = try? Inspector.attribute(path: "storage|anyTextStorage|second", value: content.view) as? Text {
+            let combination = NSMutableAttributedString()
+            combination.append(try first.inspect().text().attributedString() ?? NSAttributedString(string: ""))
+            combination.append(try second.inspect().text().attributedString() ?? NSAttributedString(string: ""))
+            return combination
+        }
+        if let string = try string() {
+            let attributedString = NSMutableAttributedString(string: string)
+            let range = NSRange(location: 0, length: attributedString.length)
+
+            let viewModifiers = (try? Inspector.attribute(path: "modifiers", value: content.view) as? [Any]) ?? []
+            for viewModifier in viewModifiers {
+                if String(describing: viewModifier) == "anyTextModifier(SwiftUI.BoldTextModifier)" {
+                    attributedString.addAttributes([
+                        NSAttributedString.Key("Bold"): true,
+                    ], range: range)
+                } else if String(describing: viewModifier) == "italic" {
+                    attributedString.addAttributes([
+                        NSAttributedString.Key("Italic"): true,
+                    ], range: range)
+                } else if let fontProvider = try? Inspector.attribute(path: "font|some|provider|base", value: viewModifier) {
+                    if String(describing: type(of: fontProvider)) == "SystemProvider" {
+                        let size = try Inspector.attribute(path: "size", value: fontProvider) as! CGFloat
+                        let weight = try Inspector.attribute(path: "weight", value: fontProvider) as! Font.Weight
+                        let design = try Inspector.attribute(path: "design", value: fontProvider) as! Font.Design
+                        attributedString.addAttributes([
+                            NSAttributedString.Key("Font"): Font.system(size: size, weight: weight, design: design),
+                        ], range: range)
+                    }
+                } else if let fontWeight = try? Inspector.attribute(path: "weight|some", value: viewModifier) as? Font.Weight {
+                    attributedString.addAttributes([
+                        NSAttributedString.Key("FontWeight"): fontWeight,
+                    ], range: range)
+                } else {
+                    throw InspectionError.notSupported(String(describing: viewModifier))
+                }
+            }
+            return attributedString
+        }
+        return nil
+    }
 }

--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -33,18 +33,18 @@ public extension InspectableView where View: MultipleViewContent {
 public extension InspectableView where View == ViewType.Text {
     
     func string() throws -> String? {
+        if let first = try? Inspector.attribute(path: "storage|anyTextStorage|first", value: content.view) as? Text,
+            let second = try? Inspector.attribute(path: "storage|anyTextStorage|second", value: content.view) as? Text {
+            let firstText = try first.inspect().text().string() ?? ""
+            let secondText = try second.inspect().text().string() ?? ""
+            return firstText + secondText
+        }
         if let externalString = try? Inspector
             .attribute(path: "storage|verbatim", value: content.view) as? String {
             return externalString
         }
         let textStorage = try Inspector
             .attribute(path: "storage|anyTextStorage", value: content.view)
-        if let first = try? Inspector.attribute(path: "first", value: textStorage) as? Text,
-            let second = try? Inspector.attribute(path: "second", value: textStorage) as? Text {
-            let firstText = try first.inspect().text().string() ?? ""
-            let secondText = try second.inspect().text().string() ?? ""
-            return firstText + secondText
-        }
         let localizedStringKey = try Inspector
             .attribute(path: "key", value: textStorage)
         guard let baseString = try Inspector

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -48,6 +48,86 @@ final class TextTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect().hStack().text(0))
         XCTAssertNoThrow(try view.inspect().hStack().text(1))
     }
+
+    func testAttributedString() throws {
+        let view = Text("Test")
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test"))
+    }
+
+    func testAttributedStringWithFontWeight() throws {
+        let view = Text("Test").fontWeight(.heavy)
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("FontWeight"): Font.Weight.heavy,
+        ]))
+    }
+
+    func testAttributedStringWithBold() throws {
+        let view = Text("Test").bold()
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("Bold"): true,
+        ]))
+    }
+
+    func testAttributedStringWithItalic() throws {
+        let view = Text("Test").italic()
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("Italic"): true,
+        ]))
+    }
+
+    func testAttributedStringWithBoldAndItalic() throws {
+        let view = Text("Test").bold().italic()
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("Bold"): true,
+            NSAttributedString.Key("Italic"): true,
+        ]))
+    }
+
+    func testAttributedStringWithFont() throws {
+        let view = Text("Test").font(.system(size: 17))
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("Font"): Font.system(size: 17),
+        ]))
+    }
+
+    func testAttributedStringForConcatenatedTextsWithNoTraits() throws {
+        let view = Text("Te") + Text("st")
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test"))
+    }
+
+    func testAttributedStringForConcatenatedTextsWithSameTraits() throws {
+        let view = Text("Te").bold() + Text("st").bold()
+        let sut = try view.inspect().text().attributedString()
+        XCTAssertEqual(sut, NSAttributedString(string: "Test", attributes: [
+            NSAttributedString.Key("Bold"): true,
+        ]))
+    }
+
+    func testAttributedStringForConcatenatedTextsWithDifferentTraits() throws {
+        let view = Text("Te").bold() + Text("st").italic()
+        let sut = try view.inspect().text().attributedString()
+
+        let attributedString = NSMutableAttributedString(string: "Test")
+        attributedString.addAttribute(
+            NSAttributedString.Key("Bold"),
+            value: true,
+            range: NSRange(location: 0, length: 2)
+        )
+        attributedString.addAttribute(
+            NSAttributedString.Key("Italic"),
+            value: true,
+            range: NSRange(location: 2, length: 2)
+        )
+
+        XCTAssertEqual(sut, attributedString)
+    }
 }
 
 // MARK: - View Modifiers


### PR DESCRIPTION
Add support for a "pseudo-inspector" that converts `Text` views in `NSAttributedString` objects, making it easier to test their styles.