### PR TITLE
Support access to Text attributes based on Range<String.Index>

### DIFF
--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -158,6 +158,31 @@ final class TextTests: XCTestCase {
         let sut2 = try view2.inspect().text().attributes()
         XCTAssertThrows(try sut2.kerning(), "Modifier 'kerning' has different values in subranges")
     }
+
+    func testAttributeRangesForConcatenatedTextUsingStringRange() throws {
+        let text = Text("bold").bold() + Text(" ") + Text("italic").italic()
+        let inspectableText = try text.inspect().text()
+        let string = try XCTUnwrap(try inspectableText.string())
+        let attributes = try inspectableText.attributes()
+
+        let boldTextRange = try XCTUnwrap(string.range(of: "bold"))
+        XCTAssertTrue(try attributes[boldTextRange].isBold())
+
+        let italicTextRange = try XCTUnwrap(string.range(of: "italic"))
+        XCTAssertTrue(try attributes[italicTextRange].isItalic())
+    }
+
+    func testAttributeRangesForConcatenatedTextUsingRangeExpressions() throws {
+        let text = Text("bold").bold() + Text(" ") + Text("italic").italic()
+        let inspectableText = try text.inspect().text()
+        let string = try XCTUnwrap(try inspectableText.string())
+        let attributes = try inspectableText.attributes()
+
+        let endOfBoldIndex = string.index(string.startIndex, offsetBy: 4)
+        XCTAssertTrue(try attributes[..<endOfBoldIndex].isBold())
+        XCTAssertThrows(try attributes[string.startIndex...endOfBoldIndex].isBold(), "Modifier 'bold' is applied only to a subrange")
+        XCTAssertTrue(try attributes[string.index(endOfBoldIndex, offsetBy: 2)...].isItalic())
+    }
 }
 
 // MARK: - View Modifiers


### PR DESCRIPTION
This is an implementation of idea described in #41, which allows to access `Text` attributes by using ranges created from strings.

I've implemented it as a subscript which accepts types conforming to `RangeExpression` protocol. That way it's also possible to use closed, partial or other ranges. Similar thing could be done for subscript which accepts regular `Range<Int>` but that's out of scope of this pull request.