### PR TITLE
Allow using other range types when accessing attributes by Int

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -86,9 +86,10 @@ public extension InspectableView where View == ViewType.Text {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView.TextAttributes {
     
-    subscript(_ range: Range<Int>) -> Self {
+    subscript<Range>(_ range: Range) -> Self where Range: RangeExpression, Range.Bound == Int {
+        let relativeRange = range.relative(to: 0..<string.count)
         let chunksInRange = zip(chunkRanges, chunks)
-            .filter { range.overlaps($0.0) }
+            .filter { relativeRange.overlaps($0.0) }
             .map { $0.1 }
         return .init(chunks: chunksInRange)
     }

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -147,6 +147,10 @@ final class TextTests: XCTestCase {
         XCTAssertTrue(try sut[3..<5].isItalic())
         XCTAssertThrows(try sut[0..<4].isItalic(), "Modifier 'italic' is applied only to a subrange")
         XCTAssertThrows(try sut.isBold(), "Modifier 'bold' is applied only to a subrange")
+        XCTAssertTrue(try sut[..<2].isBold())
+        XCTAssertTrue(try sut[0...1].isBold())
+        XCTAssertTrue(try sut[...1].isBold())
+        XCTAssertTrue(try sut[5...].isBold())
     }
     
     func testAttributeLookupErrors() throws {


### PR DESCRIPTION
Just a small improvement for the `Int` range based attribute checker to allow using other range types. Example usage has been added to existing test.