### PR TITLE
Support for accessing Image wrapped in Text

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -298,3 +298,24 @@ public extension InspectableView {
         }
     }
 }
+
+// MARK: - Wrapped images
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+public extension InspectableView where View == ViewType.Text {
+
+    /// Extracts image wrapped inside of the current `Text` instance.
+    ///
+    /// # Example
+    /// ```
+    /// try Text(Image("someImage")).inspect().text().image()
+    /// ```
+    ///
+    func image() throws -> InspectableView<ViewType.Image> {
+        let textStorage = try Inspector
+            .attribute(path: "storage|anyTextStorage", value: content.view)
+        let view = try Inspector.attribute(label: "image", value: textStorage)
+        let content = try Inspector.unwrap(view: view, modifiers: [])
+        return try .init(content)
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -235,3 +235,12 @@ final class GlobalModifiersForText: XCTestCase {
         XCTAssertNoThrow(try sut.inspect().emptyView())
     }
 }
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+final class TextImageTests: XCTestCase {
+
+    func testTextImage() throws {
+        let text = Text(Image("someImage"))
+        XCTAssertNoThrow(try text.inspect().text().image())
+    }
+}


### PR DESCRIPTION
New in iOS 14 (and similar for other platforms) is support in SwiftUI for wrapping images inside of `Text` for easy concatenation (as brought to my attention by [this tweet](https://twitter.com/dsteppenbeck/status/1288541626818846720?s=20)).

In this pull request I've introduced a method to get image in the most simple case: when there is just an image and nothing else. Unfortunately the other, more interesting cases, are harder to implement due to the fact that we are now dealing with varying types contained in the text. To be fair I don't have any ideas how to nicely structure an API for such cases so I'm just creating this pull request to possibly initiate a discussion 😁.

Here is an example of few possible constructions (they probably can be combined too):

<details>
<summary>Click to expand</summary>

`Text(Image("someImage"))`
```
Text
  modifiers: Array<Modifier> = []
  storage: Storage
    anyTextStorage: AttachmentTextStorage
      image: Image
        ...
```

`Text("a") + Text(Image("someImage"))`
```
Text
  modifiers: Array<Modifier> = []
  storage: Storage
    anyTextStorage: ConcatenatedTextStorage
      first: Text
        modifiers: Array<Modifier> = []
        storage: Storage
          anyTextStorage: LocalizedTextStorage
            bundle: Optional<NSBundle> = nil
            key: LocalizedStringKey
              arguments: Array<FormatArgument> = []
              hasFormatting: Bool = false
              key: String = a
            table: Optional<String> = nil
      second: Text
        modifiers: Array<Modifier> = []
        storage: Storage
          anyTextStorage: AttachmentTextStorage
            image: Image
              ...
```

`Text("a \(Text(Image("someImage")))")`
```
Text
  modifiers: Array<Modifier> = []
  storage: Storage
    anyTextStorage: LocalizedTextStorage
      bundle: Optional<NSBundle> = nil
      key: LocalizedStringKey
        arguments: Array<FormatArgument>
          [0]
            storage: Storage
              text: (Text, Token)
                .0: Text
                  modifiers: Array<Modifier> = []
                  storage: Storage
                    anyTextStorage: AttachmentTextStorage
                      image: Image
                        ...
                .1: Token
                  id: Int = 0
        hasFormatting: Bool = true
        key: String = a %@
      table: Optional<String> = nil
```
</details>

___

Other than that, right now test code no longer compiles on anything earlier than Xcode 12 beta. ~~That's because `@available` attribute doesn't help when the older API accepts an argument of different type. I wonder whether there is a known solution for that or that's an unknown bug worth reporting...~~ Nvm, `@available` is a runtime check so that's why it's not working, will have to resolve that differently.