### PR TITLE
Updated the flexFrame() inspector that it also works when only value was set at the frame

### DIFF
--- a/Sources/ViewInspector/Modifiers/SizingModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/SizingModifiers.swift
@@ -36,10 +36,16 @@ public extension InspectableView {
         let floatAttrNames = ["minWidth", "idealWidth", "maxWidth",
                               "minHeight", "idealHeight", "maxHeight"]
         let call = "frame(minWidth: idealWidth: maxWidth: minHeight: idealHeight: maxHeight: alignment:)"
-        let floats = try floatAttrNames.map { name in
-            return try modifierAttribute(
-                modifierName: "_FlexFrameLayout", path: "modifier|\(name)",
-                type: CGFloat.self, call: call)
+        var floats = [CGFloat]()
+        for name in floatAttrNames {
+            do {
+                let value = try modifierAttribute(
+                    modifierName: "_FlexFrameLayout", path: "modifier|\(name)",
+                    type: CGFloat.self, call: call)
+                floats.append(value)
+            } catch {
+                floats.append(CGFloat.nan)
+            }
         }
         let alignment = try modifierAttribute(
             modifierName: "_FlexFrameLayout", path: "modifier|alignment",

--- a/Tests/ViewInspectorTests/ViewModifiers/SizingModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/SizingModifiersTests.swift
@@ -63,6 +63,21 @@ final class ViewSizingTests: XCTestCase {
         XCTAssertEqual(sut.idealHeight, frame.4); XCTAssertEqual(sut.maxHeight, frame.5)
         XCTAssertEqual(sut.alignment, frame.6)
     }
+
+    func testFrameMaxWidth() throws {
+        let sut = try EmptyView().frame(maxWidth: 100)
+            .inspect().emptyView().flexFrame()
+        XCTAssertEqual(sut.maxWidth, 100)
+        XCTAssertTrue(sut.minWidth.isNaN)
+    }
+
+    func testFrameMinWidth() throws {
+        let sut = try EmptyView().frame(minWidth: 100)
+            .inspect().emptyView().flexFrame()
+        XCTAssertEqual(sut.minWidth, 100);
+        XCTAssertTrue(sut.maxWidth.isNaN)
+    }
+
     
     func testFixedSize() throws {
         let sut = EmptyView().fixedSize()


### PR DESCRIPTION
When in a view only one frame parameter was set, the `flexFrame()` inspector did throw an exception. I have updated the code, so that not exception is thrown and for all the missing values `CGFloat.nan` is used. This was the simplest approach that does not brake and compatibility.