### PR TITLE
Environment modifier

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal struct Inspector { }
+public struct Inspector { }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Inspector {

--- a/Sources/ViewInspector/Modifiers/CustomModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/CustomModifiers.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+// MARK: - Custom Modifiers
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectableView {
+
+    func customModifier<T>(keyPath: WritableKeyPath<EnvironmentValues, T>) throws -> T {
+        let environmentValues = EnvironmentValues()
+        let defaultValue = environmentValues[keyPath: keyPath]
+        let reference = EmptyView().environment(keyPath, defaultValue)
+        let keyPath = try Inspector.environmentKeyPath(T.self, reference)
+        return try environmentModifier(keyPath: keyPath, call: "resizableFrameMinWidth")
+    }
+}

--- a/Sources/ViewInspector/Modifiers/CustomModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/CustomModifiers.swift
@@ -10,6 +10,6 @@ public extension InspectableView {
         let defaultValue = environmentValues[keyPath: keyPath]
         let reference = EmptyView().environment(keyPath, defaultValue)
         let keyPath = try Inspector.environmentKeyPath(T.self, reference)
-        return try environmentModifier(keyPath: keyPath, call: "resizableFrameMinWidth")
+        return try environmentModifier(keyPath: keyPath, call: "")
     }
 }

--- a/Sources/ViewInspector/Modifiers/EnvironmentModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EnvironmentModifiers.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-// MARK: - Custom Modifiers
+// MARK: - Environment Modifiers
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
 
-    func customModifier<T>(keyPath: WritableKeyPath<EnvironmentValues, T>) throws -> T {
+    func environment<T>(keyPath: WritableKeyPath<EnvironmentValues, T>) throws -> T {
         let environmentValues = EnvironmentValues()
         let defaultValue = environmentValues[keyPath: keyPath]
         let reference = EmptyView().environment(keyPath, defaultValue)

--- a/Sources/ViewInspector/Modifiers/TextInputModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/TextInputModifiers.swift
@@ -93,7 +93,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal extension InspectableView {
+public extension InspectableView {
     func environmentModifier<T>(keyPath reference: WritableKeyPath<EnvironmentValues, T>, call: String) throws -> T {
         let name = Inspector.typeName(type: T.self)
         return try modifierAttribute(modifierLookup: { modifier -> Bool in
@@ -106,7 +106,7 @@ internal extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal extension Inspector {
+public extension Inspector {
     static func environmentKeyPath<T>(_ type: T.Type, _ value: Any) throws -> WritableKeyPath<EnvironmentValues, T> {
         return try Inspector.attribute(path: "modifier|keyPath", value: value,
                                        type: WritableKeyPath<EnvironmentValues, T>.self)

--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -11,6 +11,7 @@ final class ViewEnvironmentTests: XCTestCase {
         let key = TestEnvKey()
         let sut = EmptyView().environment(\.testKey, key)
         XCTAssertNoThrow(try sut.inspect().emptyView())
+        XCTAssertNoThrow(try sut.inspect().emptyView().environment(keyPath: \.testKey))
     }
     
     func testEnvironmentObject() throws {


### PR DESCRIPTION
Added support for the environment modifier. This support gives the unit test access to the value modified by the .environment(_:_:) view modifier.