### PR TITLE
Carthage build fix

### DIFF
--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -822,7 +822,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if command -v swiftlint > /dev/null; then\n  swiftlint lint --config \"${SRCROOT}/.swiftlint.yml\"\nelse\n  echo \"Please install swiftlint: 'brew install swiftlint'\"\n  exit -1\nfi\n";
+			shellScript = "if command -v swiftlint > /dev/null; then\n  swiftlint lint --config \"${SRCROOT}/.swiftlint.yml\"\nelse\n\tif [ ${CARTHAGE} == 'YES' ]; then\n\t\texit 0\n\tfi\n\techo \"Please install swiftlint: 'brew install swiftlint'\"\n  exit -1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
I use carthage for my dependencies and this also runs on my build server(s). Here it does not make sense to install swiftlint, just to build the ViewInspector dependency. 
So I updated the build script, that when the build is perform by carthage the swiftlint command check is ignored. When the project is build in Xcode the build will still fail because of a swiftlint.

I think the same problem could occur when using Cocoapods. I do not use Cocoapods, therefore I have not investigated this futher.