### PR TITLE
[onchange-modifier] - Add in inspection of onChange modifier.

### DIFF
--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -247,9 +247,10 @@ internal extension Content {
     }
 
     func modifier(_ modifierLookup: ModifierLookupClosure, call: String, index: Int = 0) throws -> Any {
-        let modifiers = medium.viewModifiers.lazy
+        let modifiers: [ModifierNameProvider] = medium.viewModifiers.lazy
             .compactMap({ $0 as? ModifierNameProvider })
             .filter(modifierLookup)
+            .reversed()
 
         if index < modifiers.count {
             return modifiers[index]

--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -16,4 +16,19 @@ public extension InspectableView {
             type: (() -> Void).self, call: "onDisappear")
         callback()
     }
+
+    func callOnChange<E: Equatable>(newValue value: E, index: UInt = 0) throws {
+        let modifierName = "_ValueActionModifier<\(type(of: value))>"
+        let path = "modifier|action"
+        let call = "onChange"
+
+        let callback = try modifierAttribute(
+            modifierName: modifierName,
+            path: path,
+            type: ((E) -> Void).self,
+            call: call,
+            index: Int(index))
+
+        callback(value)
+    }
 }

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -36,6 +36,60 @@ final class ViewEventsTests: XCTestCase {
         try sut.inspect().emptyView().callOnDisappear()
         wait(for: [exp], timeout: 0.1)
     }
+
+    @available(iOS 14.0, *)
+    func testOnChange() throws {
+        let val = ""
+        let sut = EmptyView().onChange(of: val) { value in }
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    @available(iOS 14.0, *)
+    func testOnChangeInspection() throws {
+        let val = "initial"
+        let exp = XCTestExpectation(description: "onAppear")
+        let sut = EmptyView().padding().onChange(of: val) { [val] value in
+            exp.fulfill()
+            XCTAssertEqual(val, "initial")
+            XCTAssertEqual(value, "expected")
+        }.padding()
+        try sut.inspect().emptyView().callOnChange(newValue: "expected")
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    @available(iOS 14.0, *)
+    func testOnChangeInspectionWithMultipleOnChangeModifiersOfTheSameType() throws {
+        var val = "initial"
+        let other = ""
+        let exp = XCTestExpectation(description: "onAppear")
+        let sut = EmptyView().padding().onChange(of: val) { [val] value in
+            exp.fulfill()
+            XCTAssertEqual(val, "initial")
+            XCTAssertEqual(value, "expected")
+        }.onChange(of: other) { value in
+            XCTFail("This should never have been called")
+        }.padding()
+        val = "expected"
+        try sut.inspect().emptyView().callOnChange(newValue: val)
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    @available(iOS 14.0, *)
+    func testOnChangeInspectionWithMultipleOnChangeModifiersOfTheSameType_CanCallOnChangeByIndex() throws {
+        var val = "initial"
+        let other = ""
+        let exp = XCTestExpectation(description: "onAppear")
+        let sut = EmptyView().padding().onChange(of: other) { value in
+            XCTFail("This should never have been called")
+        }.onChange(of: val) { [val] value in
+            exp.fulfill()
+            XCTAssertEqual(val, "initial")
+            XCTAssertEqual(value, "expected")
+        }.padding()
+        val = "expected"
+        try sut.inspect().emptyView().callOnChange(newValue: val, index: 1)
+        wait(for: [exp], timeout: 0.1)
+    }
 }
 
 // MARK: - ViewPublisherEventsTests


### PR DESCRIPTION
Inspection of onChange modifiers. Users have the capability of directly calling onChange and optionally can pass in an index indicating which modifier they'd like to call.