### PR TITLE
Calling tap() on a disabled Button does not invoke its action callback

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Button.swift
+++ b/Sources/ViewInspector/SwiftUI/Button.swift
@@ -46,6 +46,10 @@ public extension InspectableView where View == ViewType.Button {
     
     func tap() throws {
         typealias Callback = () -> Void
+        do {
+            if (try self.isDisabled()) { return }
+        } catch {
+        }
         let callback = try Inspector
             .attribute(label: "action", value: content.view, type: Callback.self)
         callback()

--- a/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
@@ -42,12 +42,31 @@ final class ButtonTests: XCTestCase {
         XCTAssertEqual(try view.inspect().find(text: "abc").pathToRoot,
                        "group().button(0).labelView().anyView().text()")
     }
-    
-    func testCallback() throws {
+
+    func testWhenButtonDoesNotHaveTheDisabledModifier_InvokesCallback() throws {
         let exp = XCTestExpectation(description: "Callback")
         let button = Button(action: {
             exp.fulfill()
         }, label: { Text("Test") })
+        try button.inspect().button().tap()
+        wait(for: [exp], timeout: 0.5)
+    }
+
+    func testWhenButtonIsNotDisabled_InvokesCallback() throws {
+        let exp = XCTestExpectation(description: "Callback")
+        let button = Button(action: {
+            exp.fulfill()
+        }, label: { Text("Test") }).disabled(false)
+        try button.inspect().button().tap()
+        wait(for: [exp], timeout: 0.5)
+    }
+
+    func testWhenButtonIsDisabled_DoesNotInvokeCallback() throws {
+        let exp = XCTestExpectation(description: "Callback")
+        exp.isInverted = true
+        let button = Button(action: {
+            exp.fulfill()
+        }, label: { Text("Test") }).disabled(true)
         try button.inspect().button().tap()
         wait(for: [exp], timeout: 0.5)
     }


### PR DESCRIPTION
Resolves issue #106: https://github.com/nalexn/ViewInspector/issues/106