### PR TITLE
DatePicker - Added function to select date

### DIFF
--- a/Sources/ViewInspector/SwiftUI/DatePicker.swift
+++ b/Sources/ViewInspector/SwiftUI/DatePicker.swift
@@ -44,6 +44,18 @@ public extension InspectableView where View == ViewType.DatePicker {
     func labelView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 0)
     }
+    
+    func selectDate<SelectionValue>(value: SelectionValue) throws where SelectionValue: Hashable {
+        let binding = try Inspector.attribute(path: "selection", value: content.view)
+        let typeName = Inspector.typeName(value: binding)
+        guard let casted = binding as? Binding<SelectionValue> else {
+            let expected = String(Array(Array(typeName)[8..<typeName.count - 1]))
+            let factual = Inspector.typeName(type: SelectionValue.self)
+            throw InspectionError
+            .notSupported("select(value:) expects a value of type \(expected) but received \(factual)")
+        }
+        casted.wrappedValue = value
+    }
 }
 
 // MARK: - Global View Modifiers

--- a/Tests/ViewInspectorTests/SwiftUI/DatePickerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/DatePickerTests.swift
@@ -23,6 +23,16 @@ final class DatePickerTests: XCTestCase {
         XCTAssertEqual(sut, sampleView)
     }
     
+    func testValueSelection() throws {
+        let binding = Binding<Date>(wrappedValue: Date())
+        let view = DatePicker("Title", selection: binding)
+        let expectedDate = Date().advanced(by: 100)
+        
+        try view.inspect().datePicker().selectDate(value: expectedDate)
+        
+        XCTAssertEqual(binding.wrappedValue, expectedDate)
+    }
+    
     func testResetsModifiers() throws {
         let view = DatePicker("Test", selection: $state.selectedDate1).padding()
         let sut = try view.inspect().datePicker().labelView().text()


### PR DESCRIPTION
A standard picker had the ability to select an item. This adds the capability to select a date in a DatePicker.