### PR TITLE
Inspector emissary for view modifier

### DIFF
--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -2,15 +2,89 @@ import SwiftUI
 import Combine
 import XCTest
 
-// MARK: - InspectionEmissaryBase
+// MARK: - InspectionEmissary for Inspectable Views
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public protocol InspectionEmissaryBase: AnyObject {
+public protocol InspectionEmissary: AnyObject {
+    
+    associatedtype V: View & Inspectable
+    typealias Inspection = (InspectableView<ViewType.View<V>>) throws -> Void
+    
+    var notice: PassthroughSubject<UInt, Never> { get }
+    var callbacks: [UInt: (V) -> Void] { get set }
+    
+    @discardableResult
+    func inspect(after delay: TimeInterval,
+                 function: String, file: StaticString, line: UInt,
+                 _ inspection: @escaping Inspection
+    ) -> XCTestExpectation
+    
+    @discardableResult
+    func inspect<P>(onReceive publisher: P,
+                    function: String, file: StaticString, line: UInt,
+                    _ inspection: @escaping Inspection
+    ) -> XCTestExpectation where P: Publisher, P.Failure == Never
+}
 
-    associatedtype V
-    associatedtype Body
-    associatedtype InspectedBody
-    typealias Inspection = (InspectedBody) throws -> Void
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectionEmissary {
+    
+    @discardableResult
+    func inspect(after delay: TimeInterval = 0,
+                 function: String = #function, file: StaticString = #file, line: UInt = #line,
+                 _ inspection: @escaping Inspection
+    ) -> XCTestExpectation {
+        let exp = XCTestExpectation(description: "Inspection at line \(line)")
+        setup(inspection: inspection, expectation: exp, function: function, file: file, line: line)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak notice] in
+            notice?.send(line)
+        }
+        return exp
+    }
+    
+    @discardableResult
+    func inspect<P>(onReceive publisher: P,
+                    function: String = #function, file: StaticString = #file, line: UInt = #line,
+                    _ inspection: @escaping Inspection
+    ) -> XCTestExpectation where P: Publisher, P.Failure == Never {
+        let exp = XCTestExpectation(description: "Inspection at line \(line)")
+        setup(inspection: inspection, expectation: exp, function: function, file: file, line: line)
+        var subscription: AnyCancellable?
+        _ = subscription
+        subscription = publisher.sink { [weak notice] _ in
+            subscription = nil
+            DispatchQueue.main.async {
+                notice?.send(line)
+            }
+        }
+        return exp
+    }
+    
+    private func setup(inspection: @escaping Inspection,
+                       expectation: XCTestExpectation,
+                       function: String, file: StaticString, line: UInt) {
+        callbacks[line] = { [weak self] view in
+            do {
+                try inspection(try view.inspect(function: function))
+            } catch let error {
+                XCTFail("\(error.localizedDescription)", file: file, line: line)
+            }
+            if self?.callbacks.count == 0 {
+                ViewHosting.expel(function: function)
+            }
+            expectation.fulfill()
+        }
+    }
+}
+
+// MARK: - InspectionEmissary for View Modifiers
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public protocol InspectionEmissaryForViewModifier: AnyObject {
+    
+    associatedtype V: ViewModifier & Inspectable
+    associatedtype Body: View & Inspectable
+    typealias Inspection = (InspectableView<ViewType.View<Body>>) throws -> Void
     
     var notice: PassthroughSubject<UInt, Never> { get }
     var callbacks: [UInt: (Body) -> Void] { get set }
@@ -26,15 +100,11 @@ public protocol InspectionEmissaryBase: AnyObject {
                     function: String, file: StaticString, line: UInt,
                     _ inspection: @escaping Inspection
     ) -> XCTestExpectation where P: Publisher, P.Failure == Never
-
-    func setup(inspection: @escaping (InspectedBody) throws -> Void,
-               expectation: XCTestExpectation,
-               function: String, file: StaticString, line: UInt)
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectionEmissaryBase {
-
+public extension InspectionEmissaryForViewModifier {
+    
     @discardableResult
     func inspect(after delay: TimeInterval = 0,
                  function: String = #function, file: StaticString = #file, line: UInt = #line,
@@ -65,50 +135,12 @@ public extension InspectionEmissaryBase {
         }
         return exp
     }
-}
-
-// MARK: - InspectionEmissary for Inspectable Views
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public protocol InspectionEmissary: InspectionEmissaryBase where
-    V: View & Inspectable, Body == V, InspectedBody == InspectableView<ViewType.View<V>> {
-}
-
-extension InspectionEmissary {
 
     func setup(inspection: @escaping Inspection,
                expectation: XCTestExpectation,
                function: String, file: StaticString, line: UInt) {
         callbacks[line] = { [weak self] view in
             do {
-                try inspection(try view.inspect(function: function))
-            } catch let error {
-                XCTFail("\(error.localizedDescription)", file: file, line: line)
-            }
-            if self?.callbacks.count == 0 {
-                ViewHosting.expel(function: function)
-            }
-            expectation.fulfill()
-        }
-    }
-}
-
-// MARK: - InspectionEmissary for View Modifiers
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public protocol InspectionEmissaryForViewModifier: InspectionEmissaryBase where
-    V: ViewModifier & Inspectable, V.Body: Inspectable, Body == V.Body,
-    InspectedBody == InspectableView<ViewType.View<Self.Body>> {
-}
-
-extension InspectionEmissaryForViewModifier {
-    
-    func setup(inspection: @escaping Inspection,
-               expectation: XCTestExpectation,
-               function: String, file: StaticString, line: UInt) {
-        callbacks[line] = { [weak self] view in
-            do {
-                //try inspection(try view.inspect(function: function))
                 let view: InspectableView<ViewType.ClassifiedView> = try view.inspect(function: function)
                 let body = try view.view(Body.self)
                 try inspection(body)

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -24,10 +24,83 @@ public protocol InspectionEmissary: class {
     ) -> XCTestExpectation where P: Publisher, P.Failure == Never
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public protocol InspectionEmissaryForViewModifier: class {
+    
+    associatedtype V: ViewModifier & Inspectable
+    typealias Inspection = (InspectableView<ViewType.ClassifiedView>) throws -> Void
+    
+    var notice: PassthroughSubject<UInt, Never> { get }
+    var callbacks: [UInt: (V.Body) -> Void] { get set }
+    
+    @discardableResult
+    func inspect(after delay: TimeInterval,
+                 function: String, file: StaticString, line: UInt,
+                 _ inspection: @escaping Inspection
+    ) -> XCTestExpectation
+    
+    @discardableResult
+    func inspect<P>(onReceive publisher: P,
+                    function: String, file: StaticString, line: UInt,
+                    _ inspection: @escaping Inspection
+    ) -> XCTestExpectation where P: Publisher, P.Failure == Never
+}
+
 // MARK: - Default Implementation
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectionEmissary {
+    
+    @discardableResult
+    func inspect(after delay: TimeInterval = 0,
+                 function: String = #function, file: StaticString = #file, line: UInt = #line,
+                 _ inspection: @escaping Inspection
+    ) -> XCTestExpectation {
+        let exp = XCTestExpectation(description: "Inspection at line \(line)")
+        setup(inspection: inspection, expectation: exp, function: function, file: file, line: line)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak notice] in
+            notice?.send(line)
+        }
+        return exp
+    }
+    
+    @discardableResult
+    func inspect<P>(onReceive publisher: P,
+                    function: String = #function, file: StaticString = #file, line: UInt = #line,
+                    _ inspection: @escaping Inspection
+    ) -> XCTestExpectation where P: Publisher, P.Failure == Never {
+        let exp = XCTestExpectation(description: "Inspection at line \(line)")
+        setup(inspection: inspection, expectation: exp, function: function, file: file, line: line)
+        var subscription: AnyCancellable?
+        _ = subscription
+        subscription = publisher.sink { [weak notice] _ in
+            subscription = nil
+            DispatchQueue.main.async {
+                notice?.send(line)
+            }
+        }
+        return exp
+    }
+    
+    private func setup(inspection: @escaping Inspection,
+                       expectation: XCTestExpectation,
+                       function: String, file: StaticString, line: UInt) {
+        callbacks[line] = { [weak self] view in
+            do {
+                try inspection(try view.inspect(function: function))
+            } catch let error {
+                XCTFail("\(error.localizedDescription)", file: file, line: line)
+            }
+            if self?.callbacks.count == 0 {
+                ViewHosting.expel(function: function)
+            }
+            expectation.fulfill()
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectionEmissaryForViewModifier {
     
     @discardableResult
     func inspect(after delay: TimeInterval = 0,

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -61,7 +61,8 @@ final class InspectionEmissaryTests: XCTestCase {
             try body.hStack().button(1).tap()
             XCTAssertEqual(try body.hStack().button(1).labelView().text().string(), "true")
         }
-        ViewHosting.host(view: Circle().modifier(sut))
+        let view = EmptyView().modifier(sut)
+        ViewHosting.host(view: view)
         wait(for: [exp], timeout: 3.2)
     }
 

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -127,7 +127,13 @@ final class InspectionEmissaryTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-class Inspection<V>: InspectionEmissary where V: View & Inspectable {
+extension Inspection: InspectionEmissaryBase where V: Inspectable {}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension Inspection: InspectionEmissary where V: Inspectable {}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+class Inspection<V> where V: View {
     let notice = PassthroughSubject<UInt, Never>()
     var callbacks = [UInt: (V) -> Void]()
 
@@ -139,8 +145,13 @@ class Inspection<V>: InspectionEmissary where V: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-class InspectionForViewModifier<V>: InspectionEmissaryForViewModifier where
-    V: ViewModifier & Inspectable, V.Body: Inspectable {
+extension InspectionForViewModifier: InspectionEmissaryBase where V: Inspectable, V.Body: Inspectable {}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension InspectionForViewModifier: InspectionEmissaryForViewModifier where V: Inspectable, V.Body: Inspectable {}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+class InspectionForViewModifier<V> where V: ViewModifier {
     let notice = PassthroughSubject<UInt, Never>()
     var callbacks = [UInt: (V.Body) -> Void]()
 

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -127,9 +127,6 @@ final class InspectionEmissaryTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension Inspection: InspectionEmissaryBase where V: Inspectable {}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Inspection: InspectionEmissary where V: Inspectable {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -144,10 +141,6 @@ class Inspection<V> where V: View {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension InspectionForViewModifier: InspectionEmissaryBase where V: Inspectable, V.Body: Inspectable {}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension InspectionForViewModifier: InspectionEmissaryForViewModifier where V: Inspectable, V.Body: Inspectable {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -77,13 +77,18 @@ final class InspectionEmissaryTests: XCTestCase {
         let flag = Binding<Bool>(wrappedValue: false)
 
         let sut = InspectableTestModifier(title: title, flag: flag)
-        let exp1 = sut.inspection.inspect { view in
-            let text = try view.hStack().button(1).labelView().text().string()
+        let exp1 = sut.inspection.inspect { body in
+            let content = try body.hStack().viewModifierContent(0)
+            XCTAssertEqual(try content.offset(), CGSize(width: 10, height: 10))
+            let object = content.content.medium.environmentObjects[0] as? Title
+            XCTAssertEqual(object?.value, "Monkey Wrench")
+
+            let text = try body.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "false")
             sut.publisher.send(true)
         }
-        let exp2 = sut.inspection.inspect(after: 0.1) { view in
-            let text = try view.hStack().button(1).labelView().text().string()
+        let exp2 = sut.inspection.inspect(after: 0.1) { body in
+            let text = try body.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "true")
         }
         let view = EmptyView().modifier(sut)
@@ -96,18 +101,23 @@ final class InspectionEmissaryTests: XCTestCase {
         let flag = Binding<Bool>(wrappedValue: false)
         
         let sut = InspectableTestModifier(title: title, flag: flag)
-        let exp1 = sut.inspection.inspect { view in
-            let text = try view.hStack().button(1).labelView().text().string()
+        let exp1 = sut.inspection.inspect { body in
+            let text = try body.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "false")
             sut.publisher.send(true)
         }
-        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
-            let text = try view.hStack().button(1).labelView().text().string()
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { body in
+            let content = try body.hStack().viewModifierContent(0)
+            XCTAssertEqual(try content.offset(), CGSize(width: 10, height: 10))
+            let object = content.content.medium.environmentObjects[0] as? Title
+            XCTAssertEqual(object?.value, "Monkey Wrench")
+
+            let text = try body.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "true")
             sut.publisher.send(false)
         }
-        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
-            let text = try view.hStack().button(1).labelView().text().string()
+        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { body in
+            let text = try body.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "false")
         }
         let view = EmptyView().modifier(sut)

--- a/guide.md
+++ b/guide.md
@@ -338,6 +338,7 @@ This code is intentionally not included in the **ViewInspector** so that your bu
 After you add that `class Inspection<V>` to the build target, you should extend it in the **test target** with conformance to `InspectionEmissary` protocol:
 
 ```swift
+extension Inspection: InspectionEmissaryBase where V: Inspectable { }
 extension Inspection: InspectionEmissary where V: Inspectable { }
 ```
 
@@ -511,8 +512,8 @@ struct MyViewModifier: ViewModifier {
 In order to inspect `MyViewModifier`, extend it and its body to conform to the  `Inspectable` protocol in the test's scope.
 
 ```swift
-extension MyViewModifier: Inspectable {}
-extension MyViewModifier.Body: Inspectable {}
+extension MyViewModifier: Inspectable { }
+extension MyViewModifier.Body: Inspectable { }
 ```
 
 Here is how you'd verify  `MyViewModifier`:

--- a/guide.md
+++ b/guide.md
@@ -338,7 +338,6 @@ This code is intentionally not included in the **ViewInspector** so that your bu
 After you add that `class Inspection<V>` to the build target, you should extend it in the **test target** with conformance to `InspectionEmissary` protocol:
 
 ```swift
-extension Inspection: InspectionEmissaryBase where V: Inspectable { }
 extension Inspection: InspectionEmissary where V: Inspectable { }
 ```
 


### PR DESCRIPTION
@nalexn I have created this PR with the changes I made to InspectionEmissary to support view modifiers. It works great. However, the `testViewModifierOnFunction` test fails. I left it this way on purpose in order that you can look at the difference between this and the `InspectionEmissaryForViewModifier`. I do not see a difference. I dumped the body of the modifier in the debugger, and they seem identical and cannot ascertain why the ViewInspector would treat them differently.