### PR TITLE
fixed compilation errors on xcode 12.4

### DIFF
--- a/Sources/ViewInspector/SwiftUI/ActionSheet.swift
+++ b/Sources/ViewInspector/SwiftUI/ActionSheet.swift
@@ -124,8 +124,8 @@ extension ViewType.ActionSheet: SupplementaryChildren {
                 return try InspectableView<ViewType.Text>(
                     content, parent: parent, call: "title()")
             case 1:
-                let view = try Inspector.attribute(path: "sheet|message", value: parent.content.view, type: Text?.self)
-                guard let view = view else {
+                let maybeView = try Inspector.attribute(path: "sheet|message", value: parent.content.view, type: Text?.self)
+                guard let view = maybeView else {
                     throw InspectionError.viewNotFound(parent: "message")
                 }
                 let content = try Inspector.unwrap(content: Content(view, medium: medium))

--- a/Sources/ViewInspector/SwiftUI/Alert.swift
+++ b/Sources/ViewInspector/SwiftUI/Alert.swift
@@ -120,8 +120,8 @@ extension ViewType.Alert: SupplementaryChildren {
                 return try InspectableView<ViewType.Text>(
                     content, parent: parent, call: "title()")
             case 1:
-                let view = try Inspector.attribute(path: "alert|message", value: parent.content.view, type: Text?.self)
-                guard let view = view else {
+                let maybeView = try Inspector.attribute(path: "alert|message", value: parent.content.view, type: Text?.self)
+                guard let view = maybeView else {
                     throw InspectionError.viewNotFound(parent: "message")
                 }
                 let content = try Inspector.unwrap(content: Content(view, medium: medium))
@@ -133,9 +133,9 @@ extension ViewType.Alert: SupplementaryChildren {
                 return try InspectableView<ViewType.AlertButton>(
                     content, parent: parent, call: "primaryButton()")
             default:
-                let view = try Inspector.attribute(
+                let maybeView = try Inspector.attribute(
                     path: "alert|secondaryButton", value: parent.content.view, type: Alert.Button?.self)
-                guard let view = view else {
+                guard let view = maybeView else {
                     throw InspectionError.viewNotFound(parent: "secondaryButton")
                 }
                 let content = try Inspector.unwrap(content: Content(view, medium: medium))


### PR DESCRIPTION
Hi @nalexn 

I tried to use 5.7.6 but got compilation errors in the new features (ActionSheet/Alert).
I run Xcode 12.4 because I cannot upgrade to Big Sur (for other reasons) and therefore cannot upgrade to 12.5 in the near future.

I made this PR that compiles and completes all the tests on Xcode 12.4.

Would you consider merging this PR after checking that it compiles on Xcode 12.5?

Thanks!