### PR TITLE
Map support

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Map.swift
+++ b/Sources/ViewInspector/SwiftUI/Map.swift
@@ -45,19 +45,23 @@ public extension InspectableView where View: MultipleViewContent {
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension InspectableView where View == ViewType.Map {
     func coordinateRegion() throws -> Binding<MKCoordinateRegion> {
-        return try ViewType.Map.extractCoordinateRegion(from: self)
+        try ViewType.Map.extractCoordinateRegion(from: self)
     }
 
     func interactionModes() throws -> MapInteractionModes {
-        return try ViewType.Map.extractInteractionModes(from: self)
+        try ViewType.Map.extractInteractionModes(from: self)
     }
 
     func showsUserLocation() throws -> Bool {
-        return try ViewType.Map.extractShowsUserLocation(from: self)
+        try ViewType.Map.extractShowsUserLocation(from: self)
     }
 
     func userTrackingMode() throws -> Binding<MapUserTrackingMode>? {
-        return try ViewType.Map.extractUserTrackingMode(from: self)
+        try ViewType.Map.extractUserTrackingMode(from: self)
+    }
+
+    func mapRect() throws -> Binding<MKMapRect> {
+        try ViewType.Map.extractMapRect(from: self)
     }
 }
 
@@ -84,6 +88,14 @@ private extension ViewType.Map {
         return try Inspector.attribute(label: "userTrackingMode",
                                        value: provider,
                                        type: Binding<MapUserTrackingMode>?.self)
+    }
+
+    static func extractMapRect(from view: InspectableView<ViewType.Map>) throws -> Binding<MKMapRect> {
+        let provider = try Inspector.attribute(label: "provider", value: view.content.view)
+        let regionContainer = try Inspector.attribute(label: "region", value: provider)
+        return try Inspector.attribute(label: "rect",
+                                       value: regionContainer,
+                                       type: Binding<MKMapRect>.self)
     }
 }
 #endif

--- a/Sources/ViewInspector/SwiftUI/Map.swift
+++ b/Sources/ViewInspector/SwiftUI/Map.swift
@@ -1,0 +1,108 @@
+//
+//  Map.swift
+//  ViewInspectorTests
+//
+//  Created by Tyler Thompson on 5/25/21.
+//
+
+#if canImport(MapKit)
+import MapKit
+import SwiftUI
+
+@available(iOS 14.0, *)
+public extension ViewType {
+    struct Map: KnownViewType {
+        public static let typePrefix: String = "Map"
+        public static var namespacedPrefixes: [String] {
+            return ["_MapKit_SwiftUI." + typePrefix]
+        }
+    }
+}
+
+// MARK: - Extraction from SingleViewContent parent
+
+@available(iOS 14.0, *)
+public extension InspectableView where View: SingleViewContent {
+    func map() throws -> InspectableView<ViewType.Map> {
+        return try .init(try child(), parent: self)
+    }
+//    static func child(_ content: Content) throws -> Content {
+//        let view = try Inspector.attribute(path: "storage|view", value: content.view)
+//        let medium = content.medium.resettingViewModifiers()
+//        return try Inspector.unwrap(view: view, medium: medium)
+//    }
+}
+
+@available(iOS 14.0, *)
+public extension InspectableView where View == ViewType.Map {
+//    static func child(_ content: Content) throws -> Content {
+//        let view = try Inspector.attribute(label: "content", value: content.view)
+//        let medium = content.medium.resettingViewModifiers()
+//        return try Inspector.unwrap(view: view, medium: medium)
+//    }
+}
+
+//@available(iOS 14.0, *)
+//extension ViewType.Map: SingleViewContent {
+//
+//    public static func child(_ content: Content) throws -> Content {
+//        let view = try Inspector.attribute(path: "storage|view", value: content.view)
+//        let medium = content.medium.resettingViewModifiers()
+//        return try Inspector.unwrap(view: view, medium: medium)
+//    }
+//}
+
+// MARK: - Extraction from MultipleViewContent parent
+
+@available(iOS 14.0, *)
+public extension InspectableView where View: MultipleViewContent {
+    func map(_ index: Int) throws -> InspectableView<ViewType.Map> {
+        return try .init(try child(at: index), parent: self, index: index)
+    }
+}
+
+// MARK: - Custom Attributes
+
+@available(iOS 14.0, *)
+public extension InspectableView where View == ViewType.Map {
+    func coordinateRegion() throws -> Binding<MKCoordinateRegion> {
+        return try ViewType.Map.extractCoordinateRegion(from: self)
+    }
+
+    func interactionModes() throws -> MapInteractionModes {
+        return try ViewType.Map.extractInteractionModes(from: self)
+    }
+
+    func showsUserLocation() throws -> Bool {
+        return try ViewType.Map.extractShowsUserLocation(from: self)
+    }
+
+    func userTrackingMode() throws -> Binding<MapUserTrackingMode>? {
+        return try ViewType.Map.extractUserTrackingMode(from: self)
+    }
+}
+
+@available(iOS 14.0, *)
+private extension ViewType.Map {
+    static func extractCoordinateRegion(from view: InspectableView<ViewType.Map>) throws -> Binding<MKCoordinateRegion> {
+        let provider = try Inspector.attribute(label: "provider", value: view.content.view)
+        let regionContainer = try Inspector.attribute(label: "region", value: provider)
+        return try Inspector.attribute(label: "region", value: regionContainer, type: Binding<MKCoordinateRegion>.self)
+    }
+
+    static func extractInteractionModes(from view: InspectableView<ViewType.Map>) throws -> MapInteractionModes {
+        let provider = try Inspector.attribute(label: "provider", value: view.content.view)
+        return try Inspector.attribute(label: "interactionModes", value: provider, type: MapInteractionModes.self)
+    }
+
+    static func extractShowsUserLocation(from view: InspectableView<ViewType.Map>) throws -> Bool {
+        let provider = try Inspector.attribute(label: "provider", value: view.content.view)
+        return try Inspector.attribute(label: "showsUserLocation", value: provider, type: Bool.self)
+    }
+
+    static func extractUserTrackingMode(from view: InspectableView<ViewType.Map>) throws -> Binding<MapUserTrackingMode>? {
+        let provider = try Inspector.attribute(label: "provider", value: view.content.view)
+        return try Inspector.attribute(label: "userTrackingMode", value: provider, type: Binding<MapUserTrackingMode>?.self)
+    }
+}
+#endif

--- a/Sources/ViewInspector/SwiftUI/Map.swift
+++ b/Sources/ViewInspector/SwiftUI/Map.swift
@@ -9,61 +9,40 @@
 import MapKit
 import SwiftUI
 
-@available(iOS 14.0, *)
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewType {
     struct Map: KnownViewType {
         public static let typePrefix: String = "Map"
         public static var namespacedPrefixes: [String] {
             return ["_MapKit_SwiftUI." + typePrefix]
         }
+        public static func inspectionCall(typeName: String) -> String {
+            return "map(\(ViewType.indexPlaceholder))"
+        }
     }
 }
 
 // MARK: - Extraction from SingleViewContent parent
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension InspectableView where View: SingleViewContent {
     func map() throws -> InspectableView<ViewType.Map> {
-        return try .init(try child(), parent: self)
+        let call = ViewType.inspectionCall(
+            base: ViewType.Map.inspectionCall(typeName: ""), index: nil)
+        return try .init(try child(), parent: self, call: call)
     }
-//    static func child(_ content: Content) throws -> Content {
-//        let view = try Inspector.attribute(path: "storage|view", value: content.view)
-//        let medium = content.medium.resettingViewModifiers()
-//        return try Inspector.unwrap(view: view, medium: medium)
-//    }
 }
 
-@available(iOS 14.0, *)
-public extension InspectableView where View == ViewType.Map {
-//    static func child(_ content: Content) throws -> Content {
-//        let view = try Inspector.attribute(label: "content", value: content.view)
-//        let medium = content.medium.resettingViewModifiers()
-//        return try Inspector.unwrap(view: view, medium: medium)
-//    }
-}
-
-//@available(iOS 14.0, *)
-//extension ViewType.Map: SingleViewContent {
-//
-//    public static func child(_ content: Content) throws -> Content {
-//        let view = try Inspector.attribute(path: "storage|view", value: content.view)
-//        let medium = content.medium.resettingViewModifiers()
-//        return try Inspector.unwrap(view: view, medium: medium)
-//    }
-//}
-
-// MARK: - Extraction from MultipleViewContent parent
-
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension InspectableView where View: MultipleViewContent {
     func map(_ index: Int) throws -> InspectableView<ViewType.Map> {
-        return try .init(try child(at: index), parent: self, index: index)
+        let call = ViewType.inspectionCall(
+            base: ViewType.Map.inspectionCall(typeName: ""), index: index)
+        return try .init(try child(at: index), parent: self, call: call, index: index)
     }
 }
 
-// MARK: - Custom Attributes
-
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension InspectableView where View == ViewType.Map {
     func coordinateRegion() throws -> Binding<MKCoordinateRegion> {
         return try ViewType.Map.extractCoordinateRegion(from: self)
@@ -82,7 +61,7 @@ public extension InspectableView where View == ViewType.Map {
     }
 }
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 private extension ViewType.Map {
     static func extractCoordinateRegion(from view: InspectableView<ViewType.Map>) throws -> Binding<MKCoordinateRegion> {
         let provider = try Inspector.attribute(label: "provider", value: view.content.view)
@@ -102,7 +81,9 @@ private extension ViewType.Map {
 
     static func extractUserTrackingMode(from view: InspectableView<ViewType.Map>) throws -> Binding<MapUserTrackingMode>? {
         let provider = try Inspector.attribute(label: "provider", value: view.content.view)
-        return try Inspector.attribute(label: "userTrackingMode", value: provider, type: Binding<MapUserTrackingMode>?.self)
+        return try Inspector.attribute(label: "userTrackingMode",
+                                       value: provider,
+                                       type: Binding<MapUserTrackingMode>?.self)
     }
 }
 #endif

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -25,6 +25,7 @@ internal extension ViewSearch {
             .init(ViewType.LinearGradient.self),
             .init(ViewType.Link.self), .init(ViewType.List.self),
             .init(ViewType.Menu.self), .init(ViewType.MenuButton.self),
+            .init(ViewType.Map.self),
             .init(ViewType.NavigationLink.self), .init(ViewType.NavigationView.self),
             .init(ViewType.OutlineGroup.self),
             .init(ViewType.PasteButton.self), .init(ViewType.Picker.self),

--- a/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
@@ -33,9 +33,7 @@ class MapTests: XCTestCase {
         XCTAssertEqual(try view.inspect().find(ViewType.Map.self).pathToRoot, "anyView().map()")
     }
 
-    // MARK: - coordinateRegion()
-
-    func testExternalCoordinateRegionValue() throws {
+    func testExtractingCoordinateRegionValue() throws {
         let region = MKCoordinateRegion()
         let sut = Map(coordinateRegion: .constant(MKCoordinateRegion()))
         let value = try sut.inspect().map().coordinateRegion().wrappedValue
@@ -74,5 +72,17 @@ class MapTests: XCTestCase {
         let value = try sut.inspect().map().userTrackingMode()
         XCTAssertEqual(value?.wrappedValue, .follow)
     }
+
+    func testExtractingMapRectValue() throws {
+        let rect = MKMapRect()
+        let sut = Map(mapRect: .constant(rect),
+                      interactionModes: .all,
+                      showsUserLocation: false,
+                      userTrackingMode: .constant(.none))
+        let value = try sut.inspect().map().mapRect().wrappedValue
+        XCTAssertEqual(value.size.height, rect.size.height)
+        XCTAssertEqual(value.size.width, rect.size.width)
+    }
+
 }
 #endif

--- a/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
@@ -1,0 +1,78 @@
+//
+//  MapTests.swift
+//  ViewInspectorTests
+//
+//  Created by Tyler Thompson on 5/25/21.
+//
+
+#if canImport(MapKit)
+import MapKit
+import SwiftUI
+import XCTest
+
+@testable import ViewInspector
+
+@available(iOS 14.0, *)
+class MapTests: XCTestCase {
+    func testExtractionFromSingleViewContainer() throws {
+        let sut = AnyView(Map(coordinateRegion: .constant(MKCoordinateRegion())))
+        XCTAssertNoThrow(try sut.inspect().anyView().map())
+    }
+
+    func testExtractionFromMultipleViewContainer() throws {
+        let view = HStack {
+            Map(coordinateRegion: .constant(MKCoordinateRegion()))
+            Map(coordinateRegion: .constant(MKCoordinateRegion()))
+        }
+        XCTAssertNoThrow(try view.inspect().hStack().map(0))
+        XCTAssertNoThrow(try view.inspect().hStack().map(1))
+    }
+
+//    func testSearch() throws {
+//        let view = AnyView(Map(coordinateRegion: .constant(MKCoordinateRegion())))
+//        XCTAssertEqual(try view.inspect().find(ViewType.Map.self).pathToRoot, "anyView().map()")
+//    }
+
+    // MARK: - coordinateRegion()
+
+    func testExternalCoordinateRegionValue() throws {
+        let region = MKCoordinateRegion()
+        let sut = Map(coordinateRegion: .constant(MKCoordinateRegion()))
+        let value = try sut.inspect().map().coordinateRegion().wrappedValue
+        XCTAssertEqual(value.center.latitude, region.center.latitude)
+        XCTAssertEqual(value.center.longitude, region.center.longitude)
+        XCTAssertEqual(value.span.latitudeDelta, region.span.latitudeDelta)
+        XCTAssertEqual(value.span.longitudeDelta, region.span.longitudeDelta)
+    }
+
+    func testExtractingInteractionModes() throws {
+        let region = MKCoordinateRegion()
+        let sut = Map(coordinateRegion: .constant(region),
+                      interactionModes: .pan,
+                      showsUserLocation: false,
+                      userTrackingMode: .constant(.none))
+        let value = try sut.inspect().map().interactionModes()
+        XCTAssertEqual(value, .pan)
+    }
+
+    func testExtractingShowsUserLocation() throws {
+        let region = MKCoordinateRegion()
+        let sut = Map(coordinateRegion: .constant(region),
+                      interactionModes: .all,
+                      showsUserLocation: true,
+                      userTrackingMode: .constant(.none))
+        let value = try sut.inspect().map().showsUserLocation()
+        XCTAssertEqual(value, true)
+    }
+
+    func testExtractingUserTrackingMode() throws {
+        let region = MKCoordinateRegion()
+        let sut = Map(coordinateRegion: .constant(region),
+                      interactionModes: .all,
+                      showsUserLocation: true,
+                      userTrackingMode: .constant(.follow))
+        let value = try sut.inspect().map().userTrackingMode()
+        XCTAssertEqual(value?.wrappedValue, .follow)
+    }
+}
+#endif

--- a/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/MapTests.swift
@@ -28,10 +28,10 @@ class MapTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect().hStack().map(1))
     }
 
-//    func testSearch() throws {
-//        let view = AnyView(Map(coordinateRegion: .constant(MKCoordinateRegion())))
-//        XCTAssertEqual(try view.inspect().find(ViewType.Map.self).pathToRoot, "anyView().map()")
-//    }
+    func testSearch() throws {
+        let view = AnyView(Map(coordinateRegion: .constant(MKCoordinateRegion())))
+        XCTAssertEqual(try view.inspect().find(ViewType.Map.self).pathToRoot, "anyView().map()")
+    }
 
     // MARK: - coordinateRegion()
 

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		52A5CA0425E1139E00773CF5 /* EnvironmentModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A5CA0325E1139E00773CF5 /* EnvironmentModifiers.swift */; };
 		52D37480262B1F0C00B1BFBA /* NestedModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D3747F262B1F0C00B1BFBA /* NestedModifiersTests.swift */; };
 		79069A6B238E8490000F6B58 /* OptionalContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79069A6A238E8490000F6B58 /* OptionalContent.swift */; };
+		CA924CDC265DE87000976FEB /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA924CDB265DE87000976FEB /* MapTests.swift */; };
+		CA924CDF265DE9A000976FEB /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA924CDD265DE97800976FEB /* Map.swift */; };
 		CDA8444D262B6A7100C56C98 /* HitTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA8443D262B68E100C56C98 /* HitTestingTests.swift */; };
 		CDA84452262B6A7A00C56C98 /* GestureActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA84443262B693C00C56C98 /* GestureActionTests.swift */; };
 		CDA8445F262B6ABB00C56C98 /* GestureModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA84433262B688F00C56C98 /* GestureModifierTests.swift */; };
@@ -277,6 +279,8 @@
 		52A5CA0325E1139E00773CF5 /* EnvironmentModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentModifiers.swift; sourceTree = "<group>"; };
 		52D3747F262B1F0C00B1BFBA /* NestedModifiersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedModifiersTests.swift; sourceTree = "<group>"; };
 		79069A6A238E8490000F6B58 /* OptionalContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalContent.swift; sourceTree = "<group>"; };
+		CA924CDB265DE87000976FEB /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
+		CA924CDD265DE97800976FEB /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		CDA84433262B688F00C56C98 /* GestureModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureModifierTests.swift; sourceTree = "<group>"; };
 		CDA8443D262B68E100C56C98 /* HitTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTestingTests.swift; sourceTree = "<group>"; };
 		CDA84443262B693C00C56C98 /* GestureActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureActionTests.swift; sourceTree = "<group>"; };
@@ -646,6 +650,7 @@
 				F6D933B22385ED1400358E0E /* VSplitView.swift */,
 				F60EEBC92382EED0007DB53A /* VStack.swift */,
 				F60EEBC12382EED0007DB53A /* ZStack.swift */,
+				CA924CDD265DE97800976FEB /* Map.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -750,6 +755,7 @@
 				F6D933B42385ED2700358E0E /* VSplitViewTests.swift */,
 				F60EEBF02382F004007DB53A /* VStackTests.swift */,
 				F60EEBE72382F004007DB53A /* ZStackTests.swift */,
+				CA924CDB265DE87000976FEB /* MapTests.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -959,6 +965,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				CA924CDF265DE9A000976FEB /* Map.swift in Sources */,
 				F60EEBCE2382EED0007DB53A /* BaseTypes.swift in Sources */,
 				F60EEBD22382EED0007DB53A /* Image.swift in Sources */,
 				F660849B2594AA6800AF59A2 /* ViewSearchIndex.swift in Sources */,
@@ -1162,6 +1169,7 @@
 				CDA844C2262B7EEE00C56C98 /* RotationGestureTests.swift in Sources */,
 				F60EEBF82382F004007DB53A /* BaseTypesTests.swift in Sources */,
 				F66EDB5D23EDC1D800A01B9F /* SpacerTests.swift in Sources */,
+				CA924CDC265DE87000976FEB /* MapTests.swift in Sources */,
 				F6026A31256A7E3D00CA31E5 /* TextAttributesTests.swift in Sources */,
 				F609EFC523A4350700B9256A /* IDViewTests.swift in Sources */,
 				F6684BF423AA55C100DECCB3 /* PasteButtonTests.swift in Sources */,

--- a/readiness.md
+++ b/readiness.md
@@ -56,7 +56,7 @@ Visit [this discussion](https://github.com/nalexn/ViewInspector/discussions/60) 
 |:white_check_mark:| LinearGradient | `gradient: Gradient`, `startPoint: UnitPoint`, `endPoint: UnitPoint` |
 |:white_check_mark:| Link | `label view`, `url: URL` |
 |:white_check_mark:| List | `contained view` |
-|:technologist:| Map | |
+|:white_check_mark:| Map | `coordinateRegion: Binding<MKCoordinateRegion>`, `interactionModes: MapInteractionModes`, `showsUserLocation: Bool`, `userTrackingMode: Binding<MapUserTrackingMode>?`, `mapRect: Binding<MKMapRect>` |
 |:technologist:| MapAnnotation | |
 |:white_check_mark:| Menu | `contained view`, `label view` |
 |:white_check_mark:| MenuButton | `contained view`, `label view` |


### PR DESCRIPTION
#59 requests the ability to inspect a SwiftUI Map, this adds that ability but does not yet add the ability to inspect annotations.

I was going to add support for annotations as well before I submitted the PR but annotations are a bit more tricky than I had originally suspected. I figured it might be better to just have 2 PRs, one for supporting the map and one for annotations. 