### PR TITLE
Adds support for FullScreenCover

### DIFF
--- a/Sources/ViewInspector/SwiftUI/ActionSheet.swift
+++ b/Sources/ViewInspector/SwiftUI/ActionSheet.swift
@@ -43,7 +43,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the ActionSheet: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
                 """)
         }
         let sheet = try sheetBuilder.buildSheet()

--- a/Sources/ViewInspector/SwiftUI/ActionSheet.swift
+++ b/Sources/ViewInspector/SwiftUI/ActionSheet.swift
@@ -43,7 +43,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the ActionSheet: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#actionsheet
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
                 """)
         }
         let sheet = try sheetBuilder.buildSheet()

--- a/Sources/ViewInspector/SwiftUI/Alert.swift
+++ b/Sources/ViewInspector/SwiftUI/Alert.swift
@@ -41,7 +41,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the Alert: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
                 """)
         }
         let alert = try alertBuilder.buildAlert()

--- a/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
+++ b/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
@@ -67,12 +67,12 @@ internal extension Content {
         else {
             _ = try self.modifier({
                 $0.modifierType == "IdentifiedPreferenceTransformModifier<Key>"
-                || $0.modifierType.contains("FullScreenCoverPresentationModifier")
+                || $0.modifierType.contains("SheetPresentationModifier")
             }, call: "fullScreenCover")
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the FullScreenCover: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#fullScreenCover
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#guide.md#alert-sheet-actionsheet-and-fullscreencover
                 """)
         }
         let view = try fullScreenCoverBuilder.buildFullScreenCover()

--- a/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
+++ b/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
@@ -72,7 +72,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the FullScreenCover: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#guide.md#alert-sheet-actionsheet-and-fullscreencover
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
                 """)
         }
         let view = try fullScreenCoverBuilder.buildFullScreenCover()

--- a/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
+++ b/Sources/ViewInspector/SwiftUI/FullScreenCover.swift
@@ -1,0 +1,181 @@
+//
+//  FullScreenCover.swift
+//  ViewInspector
+//
+//  Created by Richard Gist on 9/2/21.
+//
+
+import SwiftUI
+
+// MARK: - FullScreenCover
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension ViewType {
+
+    struct FullScreenCover: KnownViewType {
+        public static var typePrefix: String = "ViewType.FullScreenCover.Container"
+        public static var namespacedPrefixes: [String] {
+            return ["ViewInspector." + typePrefix]
+        }
+        public static func inspectionCall(typeName: String) -> String {
+            return "fullScreenCover(\(ViewType.indexPlaceholder))"
+        }
+    }
+}
+
+// MARK: - Content Extraction
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.FullScreenCover: SingleViewContent {
+
+    public static func child(_ content: Content) throws -> Content {
+        let view = try Inspector.attribute(label: "view", value: content.view)
+        let medium = content.medium.resettingViewModifiers()
+        return try Inspector.unwrap(view: view, medium: medium)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.FullScreenCover: MultipleViewContent {
+
+    public static func children(_ content: Content) throws -> LazyGroup<Content> {
+        let view = try Inspector.attribute(label: "view", value: content.view)
+        let medium = content.medium.resettingViewModifiers()
+        return try Inspector.viewsInContainer(view: view, medium: medium)
+    }
+}
+
+// MARK: - Extraction
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public extension InspectableView {
+
+    func fullScreenCover(_ index: Int? = nil) throws -> InspectableView<ViewType.FullScreenCover> {
+        return try contentForModifierLookup.fullScreenCover(parent: self, index: index)
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+internal extension Content {
+
+    func fullScreenCover(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.FullScreenCover> {
+        guard let fullScreenCoverBuilder = try? self.modifierAttribute(
+                modifierLookup: { isFullScreenCoverBuilder(modifier: $0) }, path: "modifier",
+                type: FullScreenCoverBuilder.self, call: "", index: index ?? 0)
+        else {
+            _ = try self.modifier({
+                $0.modifierType == "IdentifiedPreferenceTransformModifier<Key>"
+                || $0.modifierType.contains("FullScreenCoverPresentationModifier")
+            }, call: "fullScreenCover")
+            throw InspectionError.notSupported(
+                """
+                Please refer to the Guide for inspecting the FullScreenCover: \
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#fullScreenCover
+                """)
+        }
+        let view = try fullScreenCoverBuilder.buildFullScreenCover()
+        let container = ViewType.FullScreenCover.Container(view: view, builder: fullScreenCoverBuilder)
+        let medium = self.medium.resettingViewModifiers()
+        let content = Content(container, medium: medium)
+        let call = ViewType.inspectionCall(
+            base: ViewType.FullScreenCover.inspectionCall(typeName: ""), index: index)
+        return try .init(content, parent: parent, call: call, index: index)
+    }
+
+    func fullScreenCoversForSearch() -> [ViewSearch.ModifierIdentity] {
+        let count = medium.viewModifiers
+            .compactMap { isFullScreenCoverBuilder(modifier: $0) }
+            .count
+        return Array(0..<count).map { _ in
+            .init(name: "", builder: { parent, index in
+                try parent.content.fullScreenCover(parent: parent, index: index)
+            })
+        }
+    }
+
+    private func isFullScreenCoverBuilder(modifier: Any) -> Bool {
+        return (try? Inspector.attribute(
+            label: "modifier", value: modifier, type: FullScreenCoverBuilder.self)) != nil
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+internal extension ViewType.FullScreenCover {
+    struct Container: CustomViewIdentityMapping {
+        let view: Any
+        let builder: FullScreenCoverBuilder
+
+        var viewTypeForSearch: KnownViewType.Type { ViewType.FullScreenCover.self }
+    }
+}
+
+// MARK: - Custom Attributes
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public extension InspectableView where View == ViewType.FullScreenCover {
+
+    func callOnDismiss() throws {
+        let fullScreenCover = try Inspector.cast(value: content.view, type: ViewType.FullScreenCover.Container.self)
+        fullScreenCover.builder.dismissPopup()
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public protocol FullScreenCoverBuilder: SystemPopupPresenter {
+    var onDismiss: (() -> Void)? { get }
+    func buildFullScreenCover() throws -> Any
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public protocol FullScreenCoverProvider: FullScreenCoverBuilder {
+    var isPresented: Binding<Bool> { get }
+    var fullScreenCoverBuilder: () -> Any { get }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public protocol FullScreenCoverItemProvider: FullScreenCoverBuilder {
+    associatedtype Item: Identifiable
+    var item: Binding<Item?> { get }
+    var fullScreenCoverBuilder: (Item) -> Any { get }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public extension FullScreenCoverProvider {
+
+    func buildFullScreenCover() throws -> Any {
+        guard isPresented.wrappedValue else {
+            throw InspectionError.viewNotFound(parent: "FullScreenCover")
+        }
+        return fullScreenCoverBuilder()
+    }
+
+    func dismissPopup() {
+        isPresented.wrappedValue = false
+        onDismiss?()
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+public extension FullScreenCoverItemProvider {
+
+    func buildFullScreenCover() throws -> Any {
+        guard let value = item.wrappedValue else {
+            throw InspectionError.viewNotFound(parent: "FullScreenCover")
+        }
+        return fullScreenCoverBuilder(value)
+    }
+
+    func dismissPopup() {
+        item.wrappedValue = nil
+        onDismiss?()
+    }
+}

--- a/Sources/ViewInspector/SwiftUI/Sheet.swift
+++ b/Sources/ViewInspector/SwiftUI/Sheet.swift
@@ -63,7 +63,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the Sheet: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#sheet
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
                 """)
         }
         let view = try sheetBuilder.buildSheet()

--- a/Sources/ViewInspector/SwiftUI/Sheet.swift
+++ b/Sources/ViewInspector/SwiftUI/Sheet.swift
@@ -63,7 +63,7 @@ internal extension Content {
             throw InspectionError.notSupported(
                 """
                 Please refer to the Guide for inspecting the Sheet: \
-                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
+                https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
                 """)
         }
         let view = try sheetBuilder.buildSheet()

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -15,6 +15,7 @@ internal extension ViewSearch {
             .init(ViewType.Divider.self),
             .init(ViewType.EditButton.self), .init(ViewType.EmptyView.self),
             .init(ViewType.ForEach.self), .init(ViewType.Form.self),
+            .init(ViewType.Sheet.self, genericTypeName: nil),
             .init(ViewType.GeometryReader.self),
             .init(ViewType.Group.self), .init(ViewType.GroupBox.self),
             .init(ViewType.HSplitView.self), .init(ViewType.HStack.self),
@@ -312,8 +313,10 @@ internal extension Content {
         let sheetModifiers = sheetsForSearch()
         #if os(macOS)
         let actionSheetModifiers: [ViewSearch.ModifierIdentity] = []
+        let fullScreenCoverModifiers: [ViewSearch.ModifierIdentity] = []
         #else
         let actionSheetModifiers = actionSheetsForSearch()
+        let fullScreenCoverModifiers = fullScreenCoversForSearch()
         #endif
         let alertModifiers = alertsForSearch()
         return .init(count: sheetModifiers.count, { index -> UnwrappedView in
@@ -322,6 +325,8 @@ internal extension Content {
             try actionSheetModifiers[index].builder(parent, index)
         }) + .init(count: alertModifiers.count, { index -> UnwrappedView in
             try alertModifiers[index].builder(parent, index)
+        }) + .init(count: fullScreenCoverModifiers.count, { index -> UnwrappedView in
+            try fullScreenCoverModifiers[index].builder(parent, index)
         })
     }
 }

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -15,7 +15,7 @@ internal extension ViewSearch {
             .init(ViewType.Divider.self),
             .init(ViewType.EditButton.self), .init(ViewType.EmptyView.self),
             .init(ViewType.ForEach.self), .init(ViewType.Form.self),
-            .init(ViewType.Sheet.self, genericTypeName: nil),
+            .init(ViewType.FullScreenCover.self, genericTypeName: nil),
             .init(ViewType.GeometryReader.self),
             .init(ViewType.Group.self), .init(ViewType.GroupBox.self),
             .init(ViewType.HSplitView.self), .init(ViewType.HStack.self),

--- a/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
@@ -24,7 +24,7 @@ final class ActionSheetTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().emptyView().actionSheet(),
             """
             Please refer to the Guide for inspecting the ActionSheet: \
-            https://github.com/nalexn/ViewInspector/blob/master/guide.md#actionsheet
+            https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
             """)
     }
     

--- a/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
@@ -23,7 +23,7 @@ final class AlertTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().emptyView().alert(),
             """
             Please refer to the Guide for inspecting the Alert: \
-            https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-and-actionsheet
+            https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
             """)
     }
     

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -1,0 +1,236 @@
+//
+//  FullScreenCoverTests.swift
+//  ViewInspector
+//
+//  Created by Richard Gist on 9/2/21.
+//
+
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+#if !os(macOS)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+final class FullScreenCoverTests: XCTestCase {
+
+    func testFullScreenCover() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("") }
+        print("\(Inspector.print(sut) as AnyObject)")
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testInspectionErrorNoModifier() throws {
+        let sut = EmptyView().offset()
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+                        "EmptyView does not have 'fullScreenCover' modifier")
+    }
+
+    func testInspectionErrorCustomModifierRequired() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("") }
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+            """
+            Please refer to the Guide for inspecting the FullScreenCover: \
+            https://github.com/nalexn/ViewInspector/blob/master/guide.md#fullScreenCover
+            """)
+    }
+
+    func testInspectionErrorFullScreenCoverNotPresented() throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = EmptyView().fullScreenCover2(isPresented: binding) { Text("") }
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+                        "View for FullScreenCover is absent")
+    }
+
+    func testInspectionErrorFullScreenCoverWithItemNotPresented() throws {
+        let binding = Binding<Int?>(wrappedValue: nil)
+        let sut = EmptyView().fullScreenCover2(item: binding) { Text("\($0)") }
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+                        "View for FullScreenCover is absent")
+    }
+
+    func testContentInspection() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover2(isPresented: binding) {
+            Text("abc")
+        }
+        let title = try sut.inspect().emptyView().fullScreenCover().text()
+        XCTAssertEqual(try title.string(), "abc")
+        XCTAssertEqual(title.pathToRoot, "emptyView().fullScreenCover().text()")
+    }
+
+    func testContentInteraction() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover2(isPresented: binding) {
+            Text("abc")
+            Button("xyz", action: { binding.wrappedValue = false })
+        }
+        let button = try sut.inspect().emptyView().fullScreenCover().button(1)
+        try button.tap()
+        XCTAssertFalse(binding.wrappedValue)
+        XCTAssertEqual(button.pathToRoot, "emptyView().fullScreenCover().button(1)")
+    }
+
+    func testOnDismiss() throws {
+        let exp = XCTestExpectation(description: #function)
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover2(isPresented: binding, onDismiss: {
+            exp.fulfill()
+        }, content: { Text("") })
+        XCTAssertTrue(binding.wrappedValue)
+        try sut.inspect().fullScreenCover().callOnDismiss()
+        XCTAssertFalse(binding.wrappedValue)
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testContentWithItemInspection() throws {
+        let binding = Binding<Int?>(wrappedValue: 6)
+        let sut = EmptyView().fullScreenCover2(item: binding) { Text("\($0)") }
+        let fullScreenCover = try sut.inspect().emptyView().fullScreenCover()
+        XCTAssertEqual(try fullScreenCover.text().string(), "6")
+        XCTAssertEqual(binding.wrappedValue, 6)
+        try fullScreenCover.callOnDismiss()
+        XCTAssertNil(binding.wrappedValue)
+    }
+
+    func testMultipleFullScreenCoversInspection() throws {
+        let binding1 = Binding(wrappedValue: true)
+        let binding2 = Binding(wrappedValue: true)
+        let binding3 = Binding(wrappedValue: true)
+        let sut = FullScreenCoverFindTestView(fullScreenCover1: binding1, fullScreenCover2: binding2, fullScreenCover3: binding3)
+        let title1 = try sut.inspect().hStack().emptyView(0).fullScreenCover().text(0)
+        XCTAssertEqual(try title1.string(), "title_1")
+        XCTAssertEqual(title1.pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover().text(0)")
+        let title2 = try sut.inspect().hStack().emptyView(0).fullScreenCover(1).text(0)
+        XCTAssertEqual(try title2.string(), "title_3")
+        XCTAssertEqual(title2.pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover(1).text(0)")
+
+        XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self).text(0).string(), "title_1")
+        binding1.wrappedValue = false
+        XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self).text(0).string(), "title_3")
+        binding3.wrappedValue = false
+        XCTAssertThrows(try sut.inspect().find(ViewType.FullScreenCover.self),
+                        "Search did not find a match")
+    }
+
+    func testFindAndPathToRoots() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = FullScreenCoverFindTestView(fullScreenCover1: binding, fullScreenCover2: binding, fullScreenCover3: binding)
+
+        // 1
+        XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover().text(0)")
+        XCTAssertEqual(try sut.inspect().find(text: "button_1").pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover().button(1).labelView().text()")
+        // 2
+        XCTAssertThrows(try sut.inspect().find(text: "title_2").pathToRoot,
+            "Search did not find a match")
+
+        // 3
+        XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover(1).text(0)")
+
+        XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
+            "Search did not find a match")
+        XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover(1).button(1).labelView().text()")
+    }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+private extension View {
+    func fullScreenCover2<FullScreenCover>(isPresented: Binding<Bool>,
+                       onDismiss: (() -> Void)? = nil,
+                       @ViewBuilder content: @escaping () -> FullScreenCover
+    ) -> some View where FullScreenCover: View {
+        return self.modifier(InspectableFullScreenCover(isPresented: isPresented, onDismiss: onDismiss, content: content))
+    }
+
+    func fullScreenCover2<Item, FullScreenCover>(item: Binding<Item?>,
+                             onDismiss: (() -> Void)? = nil,
+                             content: @escaping (Item) -> FullScreenCover
+    ) -> some View where Item: Identifiable, FullScreenCover: View {
+        return self.modifier(InspectableFullScreenCoverWithItem(item: item, onDismiss: onDismiss, content: content))
+    }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+private struct InspectableFullScreenCover<FullScreenCover>: ViewModifier, FullScreenCoverProvider where FullScreenCover: View {
+
+    let isPresented: Binding<Bool>
+    let onDismiss: (() -> Void)?
+    let content: () -> FullScreenCover
+    let fullScreenCoverBuilder: () -> Any
+
+    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)?, content: @escaping () -> FullScreenCover) {
+        self.isPresented = isPresented
+        self.onDismiss = onDismiss
+        self.content = content
+        self.fullScreenCoverBuilder = { content() as Any }
+    }
+
+    func body(content: Self.Content) -> some View {
+        content.fullScreenCover(isPresented: isPresented, content: self.content)
+    }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+private struct InspectableFullScreenCoverWithItem<Item, FullScreenCover>: ViewModifier, FullScreenCoverItemProvider
+where Item: Identifiable, FullScreenCover: View {
+
+    let item: Binding<Item?>
+    let onDismiss: (() -> Void)?
+    let content: (Item) -> FullScreenCover
+    let fullScreenCoverBuilder: (Item) -> Any
+
+    init(item: Binding<Item?>, onDismiss: (() -> Void)?, content: @escaping (Item) -> FullScreenCover) {
+        self.item = item
+        self.onDismiss = onDismiss
+        self.content = content
+        self.fullScreenCoverBuilder = { content($0) as Any }
+    }
+
+    func body(content: Self.Content) -> some View {
+        content.fullScreenCover(item: item, onDismiss: onDismiss, content: self.content)
+    }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+private struct FullScreenCoverFindTestView: View, Inspectable {
+
+    @Binding var isFullScreenCover1Presented = false
+    @Binding var isFullScreenCover2Presented = false
+    @Binding var isFullScreenCover3Presented = false
+
+    init(fullScreenCover1: Binding<Bool>, fullScreenCover2: Binding<Bool>, fullScreenCover3: Binding<Bool>) {
+        _isFullScreenCover1Presented = fullScreenCover1
+        _isFullScreenCover2Presented = fullScreenCover2
+        _isFullScreenCover3Presented = fullScreenCover3
+    }
+
+    var body: some View {
+        HStack {
+            EmptyView()
+                .fullScreenCover2(isPresented: $isFullScreenCover1Presented) {
+                    Text("title_1")
+                    Button("button_1", action: { })
+                }
+                .fullScreenCover(isPresented: $isFullScreenCover2Presented) {
+                    Text("title_2")
+                }
+                .fullScreenCover2(isPresented: $isFullScreenCover3Presented) {
+                    Text("title_3")
+                    Button("button_3", action: { })
+                }
+        }
+    }
+}
+#endif

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -33,7 +33,7 @@ final class FullScreenCoverTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
             """
             Please refer to the Guide for inspecting the FullScreenCover: \
-            https://github.com/nalexn/ViewInspector/blob/master/guide.md#fullScreenCover
+            https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
             """)
     }
 

--- a/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
@@ -24,7 +24,7 @@ final class SheetTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().emptyView().sheet(),
             """
             Please refer to the Guide for inspecting the Sheet: \
-            https://github.com/nalexn/ViewInspector/blob/master/guide.md#sheet
+            https://github.com/nalexn/ViewInspector/blob/master/guide.md#alert-sheet-actionsheet-and-fullscreencover
             """)
     }
     

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		CDA8450C262CBF5700C56C98 /* CommonComposedGestureEndedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA8450B262CBF5700C56C98 /* CommonComposedGestureEndedTests.swift */; };
 		CDA84516262CC1F800C56C98 /* CommonComposedGestureUpdatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA84515262CC1F800C56C98 /* CommonComposedGestureUpdatingTests.swift */; };
 		CDA8451C262CC34D00C56C98 /* CommonComposedGestureChangedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA8451B262CC34D00C56C98 /* CommonComposedGestureChangedTests.swift */; };
+		D766E67026E17F01004AAA80 /* FullScreenCoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D766E66F26E17F01004AAA80 /* FullScreenCoverTests.swift */; };
+		D7A6CE8926E17AE900599824 /* FullScreenCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A6CE8826E17AE900599824 /* FullScreenCover.swift */; };
 		F6026A27256A7D1900CA31E5 /* TextAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A26256A7D1900CA31E5 /* TextAttributes.swift */; };
 		F6026A31256A7E3D00CA31E5 /* TextAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */; };
 		F60385D523D3C74B008F31BD /* InspectionEmissary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60385D423D3C74B008F31BD /* InspectionEmissary.swift */; };
@@ -310,6 +312,8 @@
 		CDA8450B262CBF5700C56C98 /* CommonComposedGestureEndedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonComposedGestureEndedTests.swift; sourceTree = "<group>"; };
 		CDA84515262CC1F800C56C98 /* CommonComposedGestureUpdatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonComposedGestureUpdatingTests.swift; sourceTree = "<group>"; };
 		CDA8451B262CC34D00C56C98 /* CommonComposedGestureChangedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonComposedGestureChangedTests.swift; sourceTree = "<group>"; };
+		D766E66F26E17F01004AAA80 /* FullScreenCoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCoverTests.swift; sourceTree = "<group>"; };
+		D7A6CE8826E17AE900599824 /* FullScreenCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCover.swift; sourceTree = "<group>"; };
 		F6026A26256A7D1900CA31E5 /* TextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributes.swift; sourceTree = "<group>"; };
 		F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributesTests.swift; sourceTree = "<group>"; };
 		F60385D423D3C74B008F31BD /* InspectionEmissary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectionEmissary.swift; sourceTree = "<group>"; };
@@ -656,6 +660,7 @@
 				F6D933B22385ED1400358E0E /* VSplitView.swift */,
 				F60EEBC92382EED0007DB53A /* VStack.swift */,
 				F60EEBC12382EED0007DB53A /* ZStack.swift */,
+				D7A6CE8826E17AE900599824 /* FullScreenCover.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -711,6 +716,7 @@
 				5214800225F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift */,
 				F60EEBED2382F004007DB53A /* ForEachTests.swift */,
 				F60EEBEB2382F004007DB53A /* FormTests.swift */,
+				D766E66F26E17F01004AAA80 /* FullScreenCoverTests.swift */,
 				F6D9339C2385ADA500358E0E /* GeometryReaderTests.swift */,
 				F60EEBF12382F004007DB53A /* GroupTests.swift */,
 				F6D933AC2385EB0100358E0E /* GroupBoxTests.swift */,
@@ -1021,6 +1027,7 @@
 				F6ECF6C823A66E54000FC591 /* InteractionModifiers.swift in Sources */,
 				52A5CA0425E1139E00773CF5 /* EnvironmentModifiers.swift in Sources */,
 				F60EEBDC2382EED0007DB53A /* Text.swift in Sources */,
+				D7A6CE8926E17AE900599824 /* FullScreenCover.swift in Sources */,
 				F620C7FB2537B090006D856D /* ConfigurationModifiers.swift in Sources */,
 				F6684BFE23AA863400DECCB3 /* RadialGradient.swift in Sources */,
 				F60EEBD42382EED0007DB53A /* ScrollView.swift in Sources */,
@@ -1196,6 +1203,7 @@
 				F64057F1238DBB120029D9BA /* EmptyViewTests.swift in Sources */,
 				CDA844C8262B7F3100C56C98 /* TapGestureTests.swift in Sources */,
 				F6D933B12385EC5F00358E0E /* HSplitViewTests.swift in Sources */,
+				D766E67026E17F01004AAA80 /* FullScreenCoverTests.swift in Sources */,
 				F64057F3238E9F600029D9BA /* OptionalViewTests.swift in Sources */,
 				F6684BFC23AA842000DECCB3 /* LinearGradientTests.swift in Sources */,
 				F62AEAFC23E705D6003E69D9 /* ViewHostingTests.swift in Sources */,


### PR DESCRIPTION
I basically duplicated what Sheet was doing to make FullScreenCover.  I've tested this out in SwiftCurrent, and it seems like it will work.

I also tried to update the documentation and fix existing error links to the guide section I updated.

Feel free to make any edits you need to before pulling it in.