### PR TITLE
Implement callOnSubmit

### DIFF
--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -26,3 +26,16 @@ public extension InspectableView {
         callback(value)
     }
 }
+
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+public extension InspectableView {
+
+    func callOnSubmit() throws {
+        let callback = try modifierAttribute(
+            modifierName: "OnSubmitModifier",
+            path: "modifier|action",
+            type: (() -> Void).self,
+            call: "onSubmit")
+        callback()
+    }
+}

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -114,6 +114,23 @@ final class ViewEventsTests: XCTestCase {
         try sut.inspect().emptyView().callOnChange(newValue: 5)
         wait(for: [exp1, exp2], timeout: 0.1)
     }
+    
+    func testOnSubmit() throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+        else { throw XCTSkip() }
+        let sut = EmptyView().onSubmit { }
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testOnSubmitInspection() throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+        else { throw XCTSkip() }
+        let exp = XCTestExpectation(description: #function)
+        let binding = Binding(wrappedValue: "")
+        let sut = TextField("Title", text: binding).onSubmit { exp.fulfill() }
+        try sut.inspect().callOnSubmit()
+        wait(for: [exp], timeout: 0.1)
+    }
 }
 
 // MARK: - ViewPublisherEventsTests


### PR DESCRIPTION
With iOS 15, macOS 12, and related updates, SwiftUI added an `onSubmit` method to add an action to perform when the user submits a value to this view. ([onSubmit(of:_:) documentation](https://developer.apple.com/documentation/swiftui/texteditor/onsubmit(of:_:)))

This PR adds support to call `onSubmit` from ViewInspector, and thus test the `onSubmit` method has been correctly implemented for a view.

`onSubmit` does not require any parameters (other than the action to call) but does provide the option of limiting an `onSubmit` method to a specific `SubmitTriggers` instance, such as `.text` or `.search`, to limit the scope of an `onSubmit` modifier as these can be applied to an entire view hierarchy. The formal test here is only tested this with `TextField` at this point. I demonstrated in other testing (not in the PR) that the method I have implemented here for ViewInspector of `callOnSubmit` will call these trigger-specific `onSubmit` methods set on a view, as well as one set without an explicit submit trigger. The current implementation here of `callOnSubmit` will call the first defined `onSubmit` action, regardless of what trigger may be specified on it in the view. 

It would be a useful future feature of ViewInspector to be able to specifically emulate a submit event that occurred on these two separate types within a view. I was unable to determine whether this is possible with the current implementation of ViewInspector. Therefore, the current implementation calls any onSubmit handler present on a view. For many testing scenarios, this seems likely to be enough. If guidance can be provided on how to target text- vs. search-triggered submit events, I would be happy to extend this implementation.

In the meantime, I have scratched my own itch of being able to test my `onSubmit` methods.