### PR TITLE
feat: mark public keyword to properties of rotation 3d

### DIFF
--- a/Sources/ViewInspector/Modifiers/TransformingModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/TransformingModifiers.swift
@@ -16,12 +16,12 @@ public extension InspectableView {
     }
     
     struct Rotation3D {
-        let angle: Angle
-        let axis: Axis
-        let anchor: UnitPoint
-        let anchorZ: CGFloat
-        let perspective: CGFloat
-        typealias Axis = (x: CGFloat, y: CGFloat, z: CGFloat)
+        public let angle: Angle
+        public let axis: Axis
+        public let anchor: UnitPoint
+        public let anchorZ: CGFloat
+        public let perspective: CGFloat
+        public typealias Axis = (x: CGFloat, y: CGFloat, z: CGFloat)
     }
     
     func rotation3D() throws -> Rotation3D {


### PR DESCRIPTION
In the latest release - `v0.9.1`, the properties of `Rotation3D` are not marked as `public` so that they cannot be accessed in other projects/modules that is reliant on `ViewInspect`. This PR includes the fix of exposing them to external modules by marking with `public` keyword. Thanks.