### PR TITLE
fix macro to work with Mac Catalyst

### DIFF
--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-#if os(macOS) && !MAC_OS_VERSION_13_0
+#if (os(macOS) || targetEnvironment(macCatalyst)) && !MAC_OS_VERSION_13_0
 struct ToolbarPlacement {
     static var navigationBar: ToolbarPlacement { .init() }
 }


### PR DESCRIPTION
Fixes #199 since the Mac Catalyst target environment is iOS, not macOS.