### PR TITLE
[Do not merge] Exploration into removing `Inspectable` conformance requirement

### DIFF
--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -8,38 +8,6 @@ public protocol InspectableProtocol {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectableProtocol where Self: View {
-    
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
-        var copy = self
-        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
-        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
-        if missingObjects.count > 0 {
-            let view = Inspector.typeName(value: self)
-            throw InspectionError
-                .missingEnvironmentObjects(view: view, objects: missingObjects)
-        }
-        return copy.body
-    }
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectableProtocol where Self: ViewModifier {
-    
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
-        var copy = self
-        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
-        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
-        if missingObjects.count > 0 {
-            let view = Inspector.typeName(value: self)
-            throw InspectionError
-                .missingEnvironmentObjects(view: view, objects: missingObjects)
-        }
-        return copy.body()
-    }
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol SingleViewContent {
     static func child(_ content: Content) throws -> Content
 }

--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -3,12 +3,12 @@ import SwiftUI
 // MARK: - Protocols
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public protocol Inspectable {
+public protocol InspectableProtocol {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: View {
+public extension InspectableProtocol where Self: View {
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
@@ -24,7 +24,7 @@ public extension Inspectable where Self: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: ViewModifier {
+public extension InspectableProtocol where Self: ViewModifier {
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self

--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -4,22 +4,11 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol Inspectable {
-    var entity: Content.InspectableEntity { get }
     func extractContent(environmentObjects: [AnyObject]) throws -> Any
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Content {
-    enum InspectableEntity {
-        case view
-        case viewModifier
-        case gesture
-    }
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Inspectable where Self: View {
-    var entity: Content.InspectableEntity { .view }
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
@@ -36,8 +25,6 @@ public extension Inspectable where Self: View {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Inspectable where Self: ViewModifier {
-    
-    var entity: ViewInspector.Content.InspectableEntity { .viewModifier }
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self

--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -4,7 +4,8 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol InspectableProtocol {
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any
+    // Intentionally empty to prove that we don't need a conformance to this protocol to enable
+    // extracting content from an `Any`.
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -12,8 +12,8 @@ public extension InspectableProtocol where Self: View {
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
-        environmentObjects.forEach { copy.inject(environmentObject: $0) }
-        let missingObjects = copy.missingEnvironmentObjects
+        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
         if missingObjects.count > 0 {
             let view = Inspector.typeName(value: self)
             throw InspectionError
@@ -28,8 +28,8 @@ public extension InspectableProtocol where Self: ViewModifier {
     
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
-        environmentObjects.forEach { copy.inject(environmentObject: $0) }
-        let missingObjects = copy.missingEnvironmentObjects
+        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
         if missingObjects.count > 0 {
             let view = Inspector.typeName(value: self)
             throw InspectionError

--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -1,0 +1,39 @@
+// Created by Michael Bachand on 12/18/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectableProtocol where Self: View {
+
+    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        var copy = self
+        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
+        if missingObjects.count > 0 {
+            let view = Inspector.typeName(value: self)
+            throw InspectionError
+                .missingEnvironmentObjects(view: view, objects: missingObjects)
+        }
+        return copy.body
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectableProtocol where Self: ViewModifier {
+
+    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        var copy = self
+        environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
+        if missingObjects.count > 0 {
+            let view = Inspector.typeName(value: self)
+            throw InspectionError
+                .missingEnvironmentObjects(view: view, objects: missingObjects)
+        }
+        return copy.body()
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension Gesture where Self: InspectableProtocol {
+    func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
+}

--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -1,6 +1,8 @@
 // Created by Michael Bachand on 12/18/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+import SwiftUI
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableProtocol where Self: View {
 

--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -3,6 +3,95 @@
 
 import SwiftUI
 
+struct ContentExtractor {
+
+    init(source: Any) throws {
+        guard let contentSource = Self.contentSource(from: source) else {
+            throw SourceNotContentExtractable()
+        }
+        self.contentSource = contentSource
+    }
+
+    struct SourceNotContentExtractable: Error { }
+
+    static func isContentExtractable(from source: Any) -> Bool {
+        contentSource(from: source) != nil
+    }
+
+    private static func contentSource(from source: Any) -> ContentSource? {
+        switch source {
+        case let view as any View:
+            return .view(view)
+        case let viewModifier as any ViewModifier:
+            return .viewModifier(viewModifier)
+        case let gesture as any Gesture:
+            return .gesture(gesture)
+        default:
+            return nil
+        }
+    }
+
+    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        try validateSource()
+
+        switch contentSource {
+        case .view(let view):
+            return try view.extractContent(environmentObjects: environmentObjects)
+        case .viewModifier(let viewModifier):
+            return try viewModifier.extractContent(environmentObjects: environmentObjects)
+        case .gesture(let gesture):
+            return try gesture.extractContent(environmentObjects: environmentObjects)
+        }
+    }
+
+    private func validateSource() throws {
+        switch contentSource.source {
+        #if os(macOS)
+        case is any NSViewRepresentable:
+            throw InspectionError.notSupported(
+                "Please use `.actualView().nsView()` for inspecting the contents of NSViewRepresentable")
+        case is any NSViewControllerRepresentable:
+            throw InspectionError.notSupported(
+                "Please use `.actualView().viewController()` for inspecting the contents of NSViewControllerRepresentable")
+        #endif
+        #if os(iOS) || os(tvOS)
+        case is any UIViewRepresentable:
+            throw InspectionError.notSupported(
+                "Please use `.actualView().uiView()` for inspecting the contents of UIViewRepresentable")
+        case is any UIViewControllerRepresentable:
+            throw InspectionError.notSupported(
+                "Please use `.actualView().viewController()` for inspecting the contents of UIViewControllerRepresentable")
+        #endif
+        #if os(watchOS)
+        case is any WKInterfaceObjectRepresentable:
+            throw InspectionError.notSupported(
+                """
+                Please use `.actualView().interfaceObject()` for inspecting \
+                the contents of WKInterfaceObjectRepresentable
+                """)
+        #endif
+        default:
+            return
+        }
+    }
+
+    private enum ContentSource {
+        case view(any View)
+        case viewModifier(any ViewModifier)
+        case gesture(any Gesture)
+
+        var source: Any {
+            switch self {
+            case .view(let source): return source
+            case .viewModifier(let source): return source
+            case .gesture(let source): return source
+            }
+        }
+    }
+
+    private let contentSource: ContentSource
+}
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension View {
 

--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectableProtocol where Self: View {
+public extension View {
 
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
@@ -20,7 +20,7 @@ public extension InspectableProtocol where Self: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectableProtocol where Self: ViewModifier {
+public extension ViewModifier {
 
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         var copy = self
@@ -36,6 +36,6 @@ public extension InspectableProtocol where Self: ViewModifier {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Gesture where Self: InspectableProtocol {
+public extension Gesture {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
 }

--- a/Sources/ViewInspector/EnvironmentInjection.swift
+++ b/Sources/ViewInspector/EnvironmentInjection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - EnvironmentObject injection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal extension Inspectable {
+internal extension InspectableProtocol {
     var missingEnvironmentObjects: [String] {
         let prefix = "SwiftUI.EnvironmentObject<"
         let mirror = Mirror(reflecting: self)

--- a/Sources/ViewInspector/EnvironmentInjection.swift
+++ b/Sources/ViewInspector/EnvironmentInjection.swift
@@ -3,10 +3,10 @@ import SwiftUI
 // MARK: - EnvironmentObject injection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal extension InspectableProtocol {
-    var missingEnvironmentObjects: [String] {
+internal enum EnvironmentInjection {
+    static func missingEnvironmentObjects(for entity: Any) -> [String] {
         let prefix = "SwiftUI.EnvironmentObject<"
-        let mirror = Mirror(reflecting: self)
+        let mirror = Mirror(reflecting: entity)
         return mirror.children.compactMap {
             let fullName = Inspector.typeName(value: $0.value, namespaced: true)
             guard fullName.hasPrefix(prefix),
@@ -18,24 +18,24 @@ internal extension InspectableProtocol {
             return "\(ivarName[1..<ivarName.count]): \(objName)"
         }
     }
-    mutating func inject(environmentObject: AnyObject) {
+    static func inject<T>(environmentObject: AnyObject, into entity: T) -> T {
         let type = "SwiftUI.EnvironmentObject<\(Inspector.typeName(value: environmentObject, namespaced: true))>"
-        let mirror = Mirror(reflecting: self)
+        let mirror = Mirror(reflecting: entity)
         guard let label = mirror.children
                 .first(where: {
                     Inspector.typeName(value: $0.value, namespaced: true) == type
                 })?.label
-        else { return }
+        else { return entity }
         let envObjSize = EnvObject.structSize
-        let viewSize = MemoryLayout<Self>.size
-        var offset = MemoryLayout<Self>.stride - envObjSize
-        let step = MemoryLayout<Self>.alignment
+        let viewSize = MemoryLayout<T>.size
+        var offset = MemoryLayout<T>.stride - envObjSize
+        let step = MemoryLayout<T>.alignment
         while offset + envObjSize > viewSize {
             offset -= step
         }
-        withUnsafeBytes(of: EnvObject.Forgery(object: nil)) { reference in
+        return withUnsafeBytes(of: EnvObject.Forgery(object: nil)) { reference in
             while offset >= 0 {
-                var copy = self
+                var copy = entity
                 withUnsafeMutableBytes(of: &copy) { bytes in
                     guard bytes[offset..<offset + envObjSize].elementsEqual(reference)
                     else { return }
@@ -50,11 +50,11 @@ internal extension InspectableProtocol {
                         let pointerToValue = rawPointer.assumingMemoryBound(to: EnvObject.Forgery.self)
                         pointerToValue.pointee = .init(object: environmentObject)
                     }
-                    self = copy
-                    return
+                    return copy
                 }
                 offset -= step
             }
+            return entity
         }
     }
 }

--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -174,7 +174,7 @@ public extension View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension View where Self: Inspectable {
+public extension View where Self: InspectableProtocol {
     
     func inspect(function: String = #function) throws -> InspectableView<ViewType.View<Self>> {
         let call = "view(\(ViewType.View<Self>.typePrefix).self)"
@@ -196,7 +196,7 @@ public extension View where Self: Inspectable {
 // MARK: - Modifiers
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension ViewModifier where Self: Inspectable {
+public extension ViewModifier where Self: InspectableProtocol {
     func inspect(function: String = #function) throws -> InspectableView<ViewType.ViewModifier<Self>> {
         let medium = ViewHosting.medium(function: function)
         let content = try Inspector.unwrap(view: self, medium: medium)
@@ -310,7 +310,7 @@ internal extension Content {
 internal protocol ModifierNameProvider {
     var modifierType: String { get }
     func modifierType(prefixOnly: Bool) -> String
-    var customModifier: Inspectable? { get }
+    var customModifier: InspectableProtocol? { get }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -325,8 +325,8 @@ extension ModifiedContent: ModifierNameProvider {
         return Inspector.typeName(type: Modifier.self, generics: prefixOnly ? .remove : .keep)
     }
     
-    var customModifier: Inspectable? {
-        return try? Inspector.attribute(label: "modifier", value: self, type: Inspectable.self)
+    var customModifier: InspectableProtocol? {
+        return try? Inspector.attribute(label: "modifier", value: self, type: InspectableProtocol.self)
     }
 }
 

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -13,7 +13,7 @@ public protocol InspectionEmissary: AnyObject {
 // MARK: - InspectionEmissary for View
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectionEmissary where V: View & Inspectable {
+public extension InspectionEmissary where V: View & InspectableProtocol {
     
     typealias ViewInspection = (InspectableView<ViewType.View<V>>) throws -> Void
     
@@ -41,7 +41,7 @@ public extension InspectionEmissary where V: View & Inspectable {
 // MARK: - InspectionEmissary for ViewModifier
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension InspectionEmissary where V: ViewModifier & Inspectable {
+public extension InspectionEmissary where V: ViewModifier & InspectableProtocol {
     
     typealias ViewModifierInspection = (InspectableView<ViewType.ViewModifier<V>>) throws -> Void
     
@@ -122,7 +122,7 @@ private extension InspectionEmissary {
 // MARK: - on keyPath inspection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension View where Self: Inspectable {
+public extension View where Self: InspectableProtocol {
     @discardableResult
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,
                      function: String = #function, file: StaticString = #file, line: UInt = #line,
@@ -135,7 +135,7 @@ public extension View where Self: Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension ViewModifier where Self: Inspectable {
+public extension ViewModifier where Self: InspectableProtocol {
     @discardableResult
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,
                      function: String = #function, file: StaticString = #file, line: UInt = #line,
@@ -148,7 +148,7 @@ public extension ViewModifier where Self: Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private extension Inspectable {
+private extension InspectableProtocol {
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,
                      function: String, file: StaticString, line: UInt,
                      inspect: @escaping ((Self) -> Void)

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -164,7 +164,7 @@ public extension Inspector {
             dict[childName + ": " + childType] = attributesTree(
                 value: child.element.value, medium: medium, visited: visited)
         }
-        if let inspectable = value as? Inspectable,
+        if let inspectable = value as? InspectableProtocol,
            let content = try? inspectable.extractContent(environmentObjects: medium.environmentObjects) {
             let childType = typeName(value: content)
             dict["body: " + childType] = attributesTree(value: content, medium: medium, visited: visited)

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -165,7 +165,8 @@ public extension Inspector {
                 value: child.element.value, medium: medium, visited: visited)
         }
         if let inspectable = value as? InspectableProtocol,
-           let content = try? inspectable.extractContent(environmentObjects: medium.environmentObjects) {
+           let contentExtractor = try? ContentExtractor(source: inspectable),
+           let content = try? contentExtractor.extractContent(environmentObjects: medium.environmentObjects) {
             let childType = typeName(value: content)
             dict["body: " + childType] = attributesTree(value: content, medium: medium, visited: visited)
         }

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol CustomViewType {
-    associatedtype T: Inspectable
+    associatedtype T: InspectableProtocol
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -10,7 +10,7 @@ public extension ViewType {
     
     internal static let customViewGenericsPlaceholder = "<EmptyView>"
     
-    struct View<T>: KnownViewType, CustomViewType where T: Inspectable {
+    struct View<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
         public static var typePrefix: String {
             guard T.self != ViewType.Stub.self
             else { return "" }
@@ -50,18 +50,18 @@ extension ViewType.View: MultipleViewContent {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension Content {
     var isCustomView: Bool {
-        return view is Inspectable
+        return view is InspectableProtocol
     }
     
     func extractCustomView() throws -> Content {
-        let inspectable = try Inspector.cast(value: view, type: Inspectable.self)
+        let inspectable = try Inspector.cast(value: view, type: InspectableProtocol.self)
         let view = try inspectable.extractContent(environmentObjects: medium.environmentObjects)
         let medium = self.medium.resettingViewModifiers()
         return try Inspector.unwrap(view: view, medium: medium)
     }
     
     func extractCustomViewGroup() throws -> LazyGroup<Content> {
-        let inspectable = try Inspector.cast(value: view, type: Inspectable.self)
+        let inspectable = try Inspector.cast(value: view, type: InspectableProtocol.self)
         let view = try inspectable.extractContent(environmentObjects: medium.environmentObjects)
         return try Inspector.viewsInContainer(view: view, medium: medium)
     }
@@ -72,7 +72,7 @@ internal extension Content {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
-    func view<T>(_ type: T.Type) throws -> InspectableView<ViewType.View<T>> where T: Inspectable {
+    func view<T>(_ type: T.Type) throws -> InspectableView<ViewType.View<T>> where T: InspectableProtocol {
         let child = try View.child(content)
         let prefix = Inspector.typeName(type: type, namespaced: true, generics: .remove)
         let base = ViewType.View<T>.inspectionCall(typeName: Inspector.typeName(type: type))
@@ -87,7 +87,7 @@ public extension InspectableView where View: SingleViewContent {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
-    func view<T>(_ type: T.Type, _ index: Int) throws -> InspectableView<ViewType.View<T>> where T: Inspectable {
+    func view<T>(_ type: T.Type, _ index: Int) throws -> InspectableView<ViewType.View<T>> where T: InspectableProtocol {
         let content = try child(at: index)
         let prefix = Inspector.typeName(type: type, namespaced: true, generics: .remove)
         let base = ViewType.View<T>.inspectionCall(typeName: Inspector.typeName(type: type))
@@ -113,21 +113,21 @@ public extension InspectableView where View: CustomViewType {
 
 #if os(macOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension NSViewRepresentable where Self: Inspectable {
+public extension NSViewRepresentable where Self: InspectableProtocol {
     func nsView() throws -> NSViewType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension NSViewControllerRepresentable where Self: Inspectable {
+public extension NSViewControllerRepresentable where Self: InspectableProtocol {
     func viewController() throws -> NSViewControllerType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: NSViewRepresentable {
+public extension InspectableProtocol where Self: NSViewRepresentable {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         throw InspectionError.notSupported(
             "Please use `.actualView().nsView()` for inspecting the contents of NSViewRepresentable")
@@ -135,7 +135,7 @@ public extension Inspectable where Self: NSViewRepresentable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: NSViewControllerRepresentable {
+public extension InspectableProtocol where Self: NSViewControllerRepresentable {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         throw InspectionError.notSupported(
             "Please use `.actualView().viewController()` for inspecting the contents of NSViewControllerRepresentable")
@@ -143,21 +143,21 @@ public extension Inspectable where Self: NSViewControllerRepresentable {
 }
 #elseif os(iOS) || os(tvOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension UIViewRepresentable where Self: Inspectable {
+public extension UIViewRepresentable where Self: InspectableProtocol {
     func uiView() throws -> UIViewType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension UIViewControllerRepresentable where Self: Inspectable {
+public extension UIViewControllerRepresentable where Self: InspectableProtocol {
     func viewController() throws -> UIViewControllerType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: UIViewRepresentable {
+public extension InspectableProtocol where Self: UIViewRepresentable {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         throw InspectionError.notSupported(
             "Please use `.actualView().uiView()` for inspecting the contents of UIViewRepresentable")
@@ -165,7 +165,7 @@ public extension Inspectable where Self: UIViewRepresentable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Inspectable where Self: UIViewControllerRepresentable {
+public extension InspectableProtocol where Self: UIViewControllerRepresentable {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         throw InspectionError.notSupported(
             "Please use `.actualView().viewController()` for inspecting the contents of UIViewControllerRepresentable")
@@ -174,14 +174,14 @@ public extension Inspectable where Self: UIViewControllerRepresentable {
 #elseif os(watchOS)
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
-public extension WKInterfaceObjectRepresentable where Self: Inspectable {
+public extension WKInterfaceObjectRepresentable where Self: InspectableProtocol {
     func interfaceObject() throws -> WKInterfaceObjectType {
         return try ViewHosting.lookup(Self.self)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
-public extension Inspectable where Self: WKInterfaceObjectRepresentable {
+public extension InspectableProtocol where Self: WKInterfaceObjectRepresentable {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
         throw InspectionError.notSupported(
             """

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -105,7 +105,7 @@ public extension InspectableView where View: CustomViewType {
     func actualView() throws -> View.T {
         var view = try Inspector.cast(value: content.view, type: View.T.self)
         content.medium.environmentObjects.forEach {
-            view.inject(environmentObject: $0)
+            view = EnvironmentInjection.inject(environmentObject: $0, into: view)
         }
         return view
     }

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -54,15 +54,15 @@ internal extension Content {
     }
     
     func extractCustomView() throws -> Content {
-        let inspectable = try Inspector.cast(value: view, type: InspectableProtocol.self)
-        let view = try inspectable.extractContent(environmentObjects: medium.environmentObjects)
+        let contentExtractor = try ContentExtractor(source: view)
+        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
         let medium = self.medium.resettingViewModifiers()
         return try Inspector.unwrap(view: view, medium: medium)
     }
     
     func extractCustomViewGroup() throws -> LazyGroup<Content> {
-        let inspectable = try Inspector.cast(value: view, type: InspectableProtocol.self)
-        let view = try inspectable.extractContent(environmentObjects: medium.environmentObjects)
+        let contentExtractor = try ContentExtractor(source: view)
+        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
         return try Inspector.viewsInContainer(view: view, medium: medium)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol CustomViewType {
-    associatedtype T: InspectableProtocol
+    associatedtype T
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -10,7 +10,7 @@ public extension ViewType {
     
     internal static let customViewGenericsPlaceholder = "<EmptyView>"
     
-    struct View<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
+    struct View<T>: KnownViewType, CustomViewType {
         public static var typePrefix: String {
             guard T.self != ViewType.Stub.self
             else { return "" }
@@ -72,7 +72,7 @@ internal extension Content {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     
-    func view<T>(_ type: T.Type) throws -> InspectableView<ViewType.View<T>> where T: InspectableProtocol {
+    func view<T>(_ type: T.Type) throws -> InspectableView<ViewType.View<T>> {
         let child = try View.child(content)
         let prefix = Inspector.typeName(type: type, namespaced: true, generics: .remove)
         let base = ViewType.View<T>.inspectionCall(typeName: Inspector.typeName(type: type))
@@ -87,7 +87,7 @@ public extension InspectableView where View: SingleViewContent {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: MultipleViewContent {
     
-    func view<T>(_ type: T.Type, _ index: Int) throws -> InspectableView<ViewType.View<T>> where T: InspectableProtocol {
+    func view<T>(_ type: T.Type, _ index: Int) throws -> InspectableView<ViewType.View<T>> {
         let content = try child(at: index)
         let prefix = Inspector.typeName(type: type, namespaced: true, generics: .remove)
         let base = ViewType.View<T>.inspectionCall(typeName: Inspector.typeName(type: type))

--- a/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewType {
     
-    struct ViewModifier<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
+    struct ViewModifier<T>: KnownViewType, CustomViewType {
         
         public static var typePrefix: String { "" }
         
@@ -21,7 +21,7 @@ public extension ViewType {
 public extension InspectableView {
     
     func modifier<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.ViewModifier<T>>
-    where T: ViewModifier, T: InspectableProtocol {
+    where T: ViewModifier {
         let name = Inspector.typeName(type: type)
         guard let view = content.medium.viewModifiers.reversed().compactMap({ modifier in
             try? Inspector.attribute(label: "modifier", value: modifier, type: type)

--- a/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewType {
     
-    struct ViewModifier<T>: KnownViewType, CustomViewType where T: Inspectable {
+    struct ViewModifier<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
         
         public static var typePrefix: String { "" }
         
@@ -21,7 +21,7 @@ public extension ViewType {
 public extension InspectableView {
     
     func modifier<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.ViewModifier<T>>
-    where T: ViewModifier, T: Inspectable {
+    where T: ViewModifier, T: InspectableProtocol {
         let name = Inspector.typeName(type: type)
         guard let view = content.medium.viewModifiers.reversed().compactMap({ modifier in
             try? Inspector.attribute(label: "modifier", value: modifier, type: type)
@@ -108,9 +108,9 @@ internal extension Content {
         return try Inspector.unwrap(view: view, medium: medium)
     }
 
-    func customViewModifiers() -> [Inspectable] {
+    func customViewModifiers() -> [InspectableProtocol] {
         return medium.viewModifiers.reversed().compactMap({ modifier in
-            try? Inspector.attribute(label: "modifier", value: modifier, type: Inspectable.self)
+            try? Inspector.attribute(label: "modifier", value: modifier, type: InspectableProtocol.self)
         })
     }
 }

--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -40,11 +40,6 @@ public extension ViewType {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Gesture where Self: InspectableProtocol {
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension AnyGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, *)

--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol GestureViewType {
-    associatedtype T: SwiftUI.Gesture & InspectableProtocol
+    associatedtype T: SwiftUI.Gesture
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewType {
     
     struct Gesture<T>: KnownViewType, GestureViewType
-    where T: SwiftUI.Gesture & InspectableProtocol {
+    where T: SwiftUI.Gesture {
         public static var typePrefix: String {
             return Inspector.typeName(type: T.self, generics: .remove)
         }
@@ -80,21 +80,21 @@ extension TapGesture: InspectableProtocol {}
 public extension InspectableView {
     
     func gesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & InspectableProtocol {
+        where T: Gesture {
         return try gestureModifier(
             modifierName: "AddGestureModifier", path: "modifier",
             type: type, call: "gesture", index: index)
     }
     
     func highPriorityGesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & InspectableProtocol {
+        where T: Gesture {
         return try gestureModifier(
             modifierName: "HighPriorityGestureModifier", path: "modifier",
             type: type, call: "highPriorityGesture", index: index)
     }
     
     func simultaneousGesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & InspectableProtocol {
+        where T: Gesture {
         return try gestureModifier(
             modifierName: "SimultaneousGestureModifier", path: "modifier",
             type: type, call: "simultaneousGesture", index: index)
@@ -169,7 +169,7 @@ public extension InspectableView {
     @available(iOS, unavailable)
     @available(tvOS, unavailable)
     func gestureModifiers<T>() throws -> EventModifiers
-    where T: Gesture & InspectableProtocol, View == ViewType.Gesture<T> {
+    where T: Gesture, View == ViewType.Gesture<T> {
         let typeName = Inspector.typeName(type: T.self)
         let valueName = Inspector.typeName(value: content.view)
         let (_, modifiers) = gestureInfo(typeName, valueName)
@@ -199,7 +199,7 @@ internal extension InspectableView {
         type: T.Type,
         call: String,
         index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture, T: InspectableProtocol {
+        where T: Gesture {
         let typeName = Inspector.typeName(type: type)
         let modifierCall = ViewType.Gesture<T>.inspectionCall(call: call, typeName: typeName, index: nil)
         

--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -41,7 +41,6 @@ public extension ViewType {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Gesture where Self: Inspectable {
-    var entity: Content.InspectableEntity { .gesture }
     func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
 }
 

--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol GestureViewType {
-    associatedtype T: SwiftUI.Gesture & Inspectable
+    associatedtype T: SwiftUI.Gesture & InspectableProtocol
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewType {
     
     struct Gesture<T>: KnownViewType, GestureViewType
-    where T: SwiftUI.Gesture & Inspectable {
+    where T: SwiftUI.Gesture & InspectableProtocol {
         public static var typePrefix: String {
             return Inspector.typeName(type: T.self, generics: .remove)
         }
@@ -40,61 +40,61 @@ public extension ViewType {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension Gesture where Self: Inspectable {
+public extension Gesture where Self: InspectableProtocol {
     func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension AnyGesture: Inspectable {}
+extension AnyGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
-extension DragGesture: Inspectable {}
+extension DragGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension ExclusiveGesture: Inspectable {}
+extension ExclusiveGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 14.0, *)
-extension LongPressGesture: Inspectable {}
+extension LongPressGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension MagnificationGesture: Inspectable {}
+extension MagnificationGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension RotationGesture: Inspectable {}
+extension RotationGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension SequenceGesture: Inspectable {}
+extension SequenceGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension SimultaneousGesture: Inspectable {}
+extension SimultaneousGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 16.0, *)
-extension TapGesture: Inspectable {}
+extension TapGesture: InspectableProtocol {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     
     func gesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & Inspectable {
+        where T: Gesture & InspectableProtocol {
         return try gestureModifier(
             modifierName: "AddGestureModifier", path: "modifier",
             type: type, call: "gesture", index: index)
     }
     
     func highPriorityGesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & Inspectable {
+        where T: Gesture & InspectableProtocol {
         return try gestureModifier(
             modifierName: "HighPriorityGestureModifier", path: "modifier",
             type: type, call: "highPriorityGesture", index: index)
     }
     
     func simultaneousGesture<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture & Inspectable {
+        where T: Gesture & InspectableProtocol {
         return try gestureModifier(
             modifierName: "SimultaneousGestureModifier", path: "modifier",
             type: type, call: "simultaneousGesture", index: index)
@@ -169,7 +169,7 @@ public extension InspectableView {
     @available(iOS, unavailable)
     @available(tvOS, unavailable)
     func gestureModifiers<T>() throws -> EventModifiers
-    where T: Gesture & Inspectable, View == ViewType.Gesture<T> {
+    where T: Gesture & InspectableProtocol, View == ViewType.Gesture<T> {
         let typeName = Inspector.typeName(type: T.self)
         let valueName = Inspector.typeName(value: content.view)
         let (_, modifiers) = gestureInfo(typeName, valueName)
@@ -199,7 +199,7 @@ internal extension InspectableView {
         type: T.Type,
         call: String,
         index: Int? = nil) throws -> InspectableView<ViewType.Gesture<T>>
-        where T: Gesture, T: Inspectable {
+        where T: Gesture, T: InspectableProtocol {
         let typeName = Inspector.typeName(type: type)
         let modifierCall = ViewType.Gesture<T>.inspectionCall(call: call, typeName: typeName, index: nil)
         

--- a/Sources/ViewInspector/SwiftUI/IDView.swift
+++ b/Sources/ViewInspector/SwiftUI/IDView.swift
@@ -23,7 +23,7 @@ extension ViewType.IDView: SingleViewContent {
 private struct IDViewModifier: ModifierNameProvider {
     static var modifierName: String { "IDView" }
     func modifierType(prefixOnly: Bool) -> String { IDViewModifier.modifierName }
-    var customModifier: Inspectable? { nil }
+    var customModifier: InspectableProtocol? { nil }
     let view: Any
 }
 

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -245,7 +245,7 @@ private class RootViewController: NSViewController {
 internal extension ViewHosting {
     #if os(macOS)
     static func lookup<V>(_ view: V.Type) throws -> V.NSViewType
-        where V: Inspectable & NSViewRepresentable {
+        where V: InspectableProtocol & NSViewRepresentable {
             let name = Inspector.typeName(type: view)
             let viewHost = rootViewController.view.descendant(nameTraits: ["ViewHost", name])
             guard let view = viewHost?.subviews.compactMap({ $0 as? V.NSViewType }).first else {
@@ -255,7 +255,7 @@ internal extension ViewHosting {
     }
     
     static func lookup<V>(_ viewController: V.Type) throws -> V.NSViewControllerType
-        where V: Inspectable & NSViewControllerRepresentable {
+        where V: InspectableProtocol & NSViewControllerRepresentable {
             let name = Inspector.typeName(type: viewController)
             let hostVC = rootViewController.descendant(nameTraits: ["NSHostingController", name])
             if let vc = hostVC?.descendants.compactMap({ $0 as? V.NSViewControllerType }).first {
@@ -269,7 +269,7 @@ internal extension ViewHosting {
     }
     #elseif os(iOS) || os(tvOS)
     static func lookup<V>(_ view: V.Type) throws -> V.UIViewType
-        where V: Inspectable & UIViewRepresentable {
+        where V: InspectableProtocol & UIViewRepresentable {
             let name = Inspector.typeName(type: view)
             let viewHost = window.descendant(nameTraits: ["ViewHost", name])
             guard let view = viewHost?.subviews.compactMap({ $0 as? V.UIViewType }).first else {
@@ -279,7 +279,7 @@ internal extension ViewHosting {
     }
     
     static func lookup<V>(_ viewController: V.Type) throws -> V.UIViewControllerType
-        where V: Inspectable & UIViewControllerRepresentable {
+        where V: InspectableProtocol & UIViewControllerRepresentable {
             let name = Inspector.typeName(type: viewController)
             let hostVC = window.rootViewController?.descendant(nameTraits: ["UIHostingController", name])
             guard let vc = hostVC?.descendants.compactMap({ $0 as? V.UIViewControllerType })
@@ -288,7 +288,7 @@ internal extension ViewHosting {
     }
     #elseif os(watchOS)
     static func lookup<V>(_ view: V.Type) throws -> V.WKInterfaceObjectType
-        where V: Inspectable & WKInterfaceObjectRepresentable {
+        where V: InspectableProtocol & WKInterfaceObjectRepresentable {
             let name = Inspector.typeName(type: view)
             guard let rootVC = WKExtension.shared().rootInterfaceController,
                   let viewCache = try? Inspector.attribute(path: """

--- a/Sources/ViewInspector/ViewSearch.swift
+++ b/Sources/ViewInspector/ViewSearch.swift
@@ -378,13 +378,11 @@ private extension UnwrappedView {
             if name.hasPrefix(ViewType.Popover.standardModifierName) {
                 return "popover"
             }
-            if let inspectable = view as? InspectableProtocol {
-                let missingObjects = inspectable.missingEnvironmentObjects
-                if missingObjects.count > 0 {
-                    return InspectionError
-                        .missingEnvironmentObjects(view: name, objects: missingObjects)
-                        .localizedDescription
-                }
+            let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: view)
+            if missingObjects.count > 0 {
+                return InspectionError
+                    .missingEnvironmentObjects(view: name, objects: missingObjects)
+                    .localizedDescription
             }
             return name
         }

--- a/Sources/ViewInspector/ViewSearch.swift
+++ b/Sources/ViewInspector/ViewSearch.swift
@@ -176,7 +176,7 @@ public extension InspectableView {
     func find<V>(_ inspectable: V.Type,
                  relation: ViewSearch.Relation = .child,
                  where condition: (InspectableView<ViewType.View<V>>) throws -> Bool = { _ in true }
-    ) throws -> InspectableView<ViewType.View<V>> where V: Inspectable {
+    ) throws -> InspectableView<ViewType.View<V>> where V: InspectableProtocol {
         return try find(ViewType.View<V>.self, relation: relation, where: condition)
     }
     
@@ -279,7 +279,7 @@ public extension InspectableView {
      */
     func findAll<V>(_ inspectable: V.Type,
                     where condition: (InspectableView<ViewType.View<V>>) throws -> Bool = { _ in true }
-    ) -> [InspectableView<ViewType.View<V>>] where V: Inspectable {
+    ) -> [InspectableView<ViewType.View<V>>] where V: InspectableProtocol {
         return findAll(ViewType.View<V>.self, where: condition)
     }
     
@@ -378,7 +378,7 @@ private extension UnwrappedView {
             if name.hasPrefix(ViewType.Popover.standardModifierName) {
                 return "popover"
             }
-            if let inspectable = view as? Inspectable {
+            if let inspectable = view as? InspectableProtocol {
                 let missingObjects = inspectable.missingEnvironmentObjects
                 if missingObjects.count > 0 {
                     return InspectionError

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -125,7 +125,7 @@ internal extension ViewSearch {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension ViewType {
-    struct Stub: Inspectable {
+    struct Stub: InspectableProtocol {
         func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
     }
 }

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -126,7 +126,6 @@ internal extension ViewSearch {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension ViewType {
     struct Stub: Inspectable {
-        var entity: Content.InspectableEntity
         func extractContent(environmentObjects: [AnyObject]) throws -> Any { () }
     }
 }

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -91,19 +91,19 @@ internal extension ViewSearch {
             .first(where: { $0.viewType.namespacedPrefixes.contains(fullName) }) {
             return identity
         }
-        if (try? content.extractCustomView()) != nil,
-           let inspectable = content.view as? Inspectable {
+        if (try? content.extractCustomView()) != nil {
             let name = Inspector.typeName(
                 value: content.view, generics: .customViewPlaceholder)
-            switch inspectable.entity {
-            case .view:
+            switch content.view {
+            case _ as any View:
                 return .init(ViewType.View<ViewType.Stub>.self, genericTypeName: name)
-            case .viewModifier:
+            case _ as any ViewModifier:
                 return .init(ViewType.ViewModifier<ViewType.Stub>.self, genericTypeName: name)
-            case .gesture:
+            case _ as any Gesture:
+                break
+            default:
                 break
             }
-            
         }
         return nil
     }

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureChangedTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureChangedTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureChangedTests<U: Gesture & InspectableProtocol> {
+final class CommonComposedGestureChangedTests<U: Gesture> {
 
     let testCase: XCTestCase
     let type: U.Type
@@ -63,7 +63,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & InspectableProtocol> 
         (_ChangedGesture<_EndedGesture<MagnificationGesture>>,
          _ChangedGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func callChangedNotFirstTest<T: Gesture & InspectableProtocol>(
+    func callChangedNotFirstTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureChangedNotFirst<T>) throws {
@@ -97,7 +97,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & InspectableProtocol> 
         (_ChangedGesture<_ChangedGesture<MagnificationGesture>>,
          _ChangedGesture<_ChangedGesture<RotationGesture>>) -> T
 
-    func callChangedMultipleTest<T: Gesture & InspectableProtocol>(
+    func callChangedMultipleTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureChangedMultiple<T>) throws {
@@ -134,7 +134,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & InspectableProtocol> 
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callChangedFailureTest<T: Gesture & InspectableProtocol>(
+    func callChangedFailureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureChangedTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureChangedTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureChangedTests<U: Gesture & Inspectable> {
+final class CommonComposedGestureChangedTests<U: Gesture & InspectableProtocol> {
 
     let testCase: XCTestCase
     let type: U.Type
@@ -63,7 +63,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & Inspectable> {
         (_ChangedGesture<_EndedGesture<MagnificationGesture>>,
          _ChangedGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func callChangedNotFirstTest<T: Gesture & Inspectable>(
+    func callChangedNotFirstTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureChangedNotFirst<T>) throws {
@@ -97,7 +97,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & Inspectable> {
         (_ChangedGesture<_ChangedGesture<MagnificationGesture>>,
          _ChangedGesture<_ChangedGesture<RotationGesture>>) -> T
 
-    func callChangedMultipleTest<T: Gesture & Inspectable>(
+    func callChangedMultipleTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureChangedMultiple<T>) throws {
@@ -134,7 +134,7 @@ final class CommonComposedGestureChangedTests<U: Gesture & Inspectable> {
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callChangedFailureTest<T: Gesture & Inspectable>(
+    func callChangedFailureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureEndedTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureEndedTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureEndedTests<U: Gesture & Inspectable> {
+final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
 
     let testCase: XCTestCase
     let type: U.Type
@@ -31,7 +31,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & Inspectable> {
         (_EndedGesture<MagnificationGesture>,
          _EndedGesture<RotationGesture>) -> T
 
-    func callEndedTest<T: Gesture & Inspectable>(
+    func callEndedTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEnded<T>) throws {
@@ -63,7 +63,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & Inspectable> {
         (_EndedGesture<_ChangedGesture<MagnificationGesture>>,
          _EndedGesture<_ChangedGesture<RotationGesture>>) -> T
 
-    func callEndedNotFirstTest<T: Gesture & Inspectable>(
+    func callEndedNotFirstTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEndedNotFirst<T>) throws {
@@ -97,7 +97,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & Inspectable> {
         (_EndedGesture<_EndedGesture<MagnificationGesture>>,
          _EndedGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func callEndedMultipleTest<T: Gesture & Inspectable>(
+    func callEndedMultipleTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEndedMultiple<T>) throws {
@@ -134,7 +134,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & Inspectable> {
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callEndedFailureTest<T: Gesture & Inspectable>(
+    func callEndedFailureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureEndedTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureEndedTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
+final class CommonComposedGestureEndedTests<U: Gesture> {
 
     let testCase: XCTestCase
     let type: U.Type
@@ -31,7 +31,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
         (_EndedGesture<MagnificationGesture>,
          _EndedGesture<RotationGesture>) -> T
 
-    func callEndedTest<T: Gesture & InspectableProtocol>(
+    func callEndedTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEnded<T>) throws {
@@ -63,7 +63,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
         (_EndedGesture<_ChangedGesture<MagnificationGesture>>,
          _EndedGesture<_ChangedGesture<RotationGesture>>) -> T
 
-    func callEndedNotFirstTest<T: Gesture & InspectableProtocol>(
+    func callEndedNotFirstTest<T: Gesture> (
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEndedNotFirst<T>) throws {
@@ -97,7 +97,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
         (_EndedGesture<_EndedGesture<MagnificationGesture>>,
          _EndedGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func callEndedMultipleTest<T: Gesture & InspectableProtocol>(
+    func callEndedMultipleTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureEndedMultiple<T>) throws {
@@ -134,7 +134,7 @@ final class CommonComposedGestureEndedTests<U: Gesture & InspectableProtocol> {
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callEndedFailureTest<T: Gesture & InspectableProtocol>(
+    func callEndedFailureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureTests<U: Gesture & Inspectable> {
+final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
 
     let type: U.Type
 
@@ -25,7 +25,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         self.type = type
     }
 
-    func gestureTest<T: Gesture & Inspectable>(
+    func gestureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -41,7 +41,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         }
     }
 
-    func gesturePathTest<T: Gesture & Inspectable>(
+    func gesturePathTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -57,7 +57,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         }
     }
     
-    func gestureFailureTest<T: Gesture & Inspectable>(
+    func gestureFailureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -83,7 +83,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         (_ModifiersGesture<MagnificationGesture>,
          _ModifiersGesture<RotationGesture>) -> T
 
-    func modifiersTest<T: Gesture & Inspectable>(
+    func modifiersTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiers<T>) throws {
@@ -105,7 +105,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         (_ModifiersGesture<_EndedGesture<MagnificationGesture>>,
          _ModifiersGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func modifiersNotFirstTest<T: Gesture & Inspectable>(
+    func modifiersNotFirstTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiersNotFirst<T>) throws {
@@ -131,7 +131,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         (_ModifiersGesture<_ModifiersGesture<MagnificationGesture>>,
          _ModifiersGesture<_ModifiersGesture<RotationGesture>>) -> T
 
-    func modifiersMultipleTest<T: Gesture & Inspectable>(
+    func modifiersMultipleTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiersMultiple<T>) throws {
@@ -153,7 +153,7 @@ final class CommonComposedGestureTests<U: Gesture & Inspectable> {
         }
     }
 
-    func modifiersFailureTest<T: Gesture & Inspectable>(
+    func modifiersFailureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
+final class CommonComposedGestureTests<U: Gesture> {
 
     let type: U.Type
 
@@ -25,7 +25,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         self.type = type
     }
 
-    func gestureTest<T: Gesture & InspectableProtocol>(
+    func gestureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -41,7 +41,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         }
     }
 
-    func gesturePathTest<T: Gesture & InspectableProtocol>(
+    func gesturePathTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -57,7 +57,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         }
     }
     
-    func gestureFailureTest<T: Gesture & InspectableProtocol>(
+    func gestureFailureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {
@@ -83,7 +83,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         (_ModifiersGesture<MagnificationGesture>,
          _ModifiersGesture<RotationGesture>) -> T
 
-    func modifiersTest<T: Gesture & InspectableProtocol>(
+    func modifiersTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiers<T>) throws {
@@ -105,7 +105,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         (_ModifiersGesture<_EndedGesture<MagnificationGesture>>,
          _ModifiersGesture<_EndedGesture<RotationGesture>>) -> T
 
-    func modifiersNotFirstTest<T: Gesture & InspectableProtocol>(
+    func modifiersNotFirstTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiersNotFirst<T>) throws {
@@ -131,7 +131,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         (_ModifiersGesture<_ModifiersGesture<MagnificationGesture>>,
          _ModifiersGesture<_ModifiersGesture<RotationGesture>>) -> T
 
-    func modifiersMultipleTest<T: Gesture & InspectableProtocol>(
+    func modifiersMultipleTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureModifiersMultiple<T>) throws {
@@ -153,7 +153,7 @@ final class CommonComposedGestureTests<U: Gesture & InspectableProtocol> {
         }
     }
 
-    func modifiersFailureTest<T: Gesture & InspectableProtocol>(
+    func modifiersFailureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureUpdatingTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureUpdatingTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol> {
+final class CommonComposedGestureUpdatingTests<U: Gesture> {
 
     @GestureState var gestureState = CGSize.zero
     
@@ -33,7 +33,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol>
         (GestureStateGesture<MagnificationGesture, CGSize>,
          GestureStateGesture<RotationGesture, CGSize>) -> T
 
-    func callUpdatingTest<T: Gesture & InspectableProtocol>(
+    func callUpdatingTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdating<T>) throws {
@@ -65,7 +65,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol>
         (GestureStateGesture<_EndedGesture<MagnificationGesture>, CGSize>,
          GestureStateGesture<_EndedGesture<RotationGesture>, CGSize>) -> T
 
-    func callUpdatingNotFirstTest<T: Gesture & InspectableProtocol>(
+    func callUpdatingNotFirstTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdatingNotFirst<T>) throws {
@@ -99,7 +99,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol>
         (GestureStateGesture<GestureStateGesture<MagnificationGesture, CGSize>, CGSize>,
          GestureStateGesture<GestureStateGesture<RotationGesture, CGSize>, CGSize>) -> T
 
-    func callUpdatingMultipleTest<T: Gesture & InspectableProtocol>(
+    func callUpdatingMultipleTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdatingMultiple<T>) throws {
@@ -136,7 +136,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol>
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callUpdatingFailureTest<T: Gesture & InspectableProtocol>(
+    func callUpdatingFailureTest<T: Gesture>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonComposedGestureUpdatingTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonComposedGestureUpdatingTests.swift
@@ -8,7 +8,7 @@ import Combine
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-final class CommonComposedGestureUpdatingTests<U: Gesture & Inspectable> {
+final class CommonComposedGestureUpdatingTests<U: Gesture & InspectableProtocol> {
 
     @GestureState var gestureState = CGSize.zero
     
@@ -33,7 +33,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & Inspectable> {
         (GestureStateGesture<MagnificationGesture, CGSize>,
          GestureStateGesture<RotationGesture, CGSize>) -> T
 
-    func callUpdatingTest<T: Gesture & Inspectable>(
+    func callUpdatingTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdating<T>) throws {
@@ -65,7 +65,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & Inspectable> {
         (GestureStateGesture<_EndedGesture<MagnificationGesture>, CGSize>,
          GestureStateGesture<_EndedGesture<RotationGesture>, CGSize>) -> T
 
-    func callUpdatingNotFirstTest<T: Gesture & Inspectable>(
+    func callUpdatingNotFirstTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdatingNotFirst<T>) throws {
@@ -99,7 +99,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & Inspectable> {
         (GestureStateGesture<GestureStateGesture<MagnificationGesture, CGSize>, CGSize>,
          GestureStateGesture<GestureStateGesture<RotationGesture, CGSize>, CGSize>) -> T
 
-    func callUpdatingMultipleTest<T: Gesture & Inspectable>(
+    func callUpdatingMultipleTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: ComposedGestureUpdatingMultiple<T>) throws {
@@ -136,7 +136,7 @@ final class CommonComposedGestureUpdatingTests<U: Gesture & Inspectable> {
         testCase.wait(for: [exp1, exp2], timeout: 0.1)
     }
 
-    func callUpdatingFailureTest<T: Gesture & Inspectable>(
+    func callUpdatingFailureTest<T: Gesture & InspectableProtocol>(
         _ order: InspectableView<ViewType.Gesture<T>>.GestureOrder,
         file: StaticString = #filePath, line: UInt = #line,
         _ factory: (MagnificationGesture, RotationGesture) -> T) throws {

--- a/Tests/ViewInspectorTests/Gestures/CommonGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonGestureTests.swift
@@ -6,7 +6,7 @@ import Combine
 // MARK: - Common Gesture Tests
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-final class CommonGestureTests<T: Gesture & Inspectable> {
+final class CommonGestureTests<T: Gesture & InspectableProtocol> {
     
     @GestureState var gestureState = CGSize.zero
     

--- a/Tests/ViewInspectorTests/Gestures/CommonGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/CommonGestureTests.swift
@@ -6,7 +6,7 @@ import Combine
 // MARK: - Common Gesture Tests
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-final class CommonGestureTests<T: Gesture & InspectableProtocol> {
+final class CommonGestureTests<T: Gesture> {
     
     @GestureState var gestureState = CGSize.zero
     

--- a/Tests/ViewInspectorTests/Gestures/ComposedGestureExampleTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/ComposedGestureExampleTests.swift
@@ -107,7 +107,7 @@ final class ComposedGestureExampleTests: XCTestCase {
 @available(iOS 13.0, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-struct TestGestureView10: View & Inspectable {
+struct TestGestureView10: View & InspectableProtocol {
     @State var scale: CGFloat = 1.0
     @State var angle = Angle(degrees: 0)
     
@@ -140,7 +140,7 @@ struct TestGestureView10: View & Inspectable {
 @available(iOS 13.0, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-struct TestGestureView11: View & Inspectable {
+struct TestGestureView11: View & InspectableProtocol {
     @State var scale: CGFloat = 1.0
     @State var angle = Angle(degrees: 0)
     
@@ -172,7 +172,7 @@ struct TestGestureView11: View & Inspectable {
 @available(iOS 13.0, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-struct TestGestureView12: View & Inspectable {
+struct TestGestureView12: View & InspectableProtocol {
     
     internal let inspection = Inspection<Self>()
     internal let publisher = PassthroughSubject<Void, Never>()

--- a/Tests/ViewInspectorTests/Gestures/GestureExampleTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/GestureExampleTests.swift
@@ -119,7 +119,7 @@ final class GestureExampleTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 16.0, *)
-struct TestGestureView1: View & Inspectable {
+struct TestGestureView1: View & InspectableProtocol {
     @State var tapped = false
         
     var body: some View {
@@ -134,7 +134,7 @@ struct TestGestureView1: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 16.0, *)
-struct TestGestureView2: View & Inspectable {
+struct TestGestureView2: View & InspectableProtocol {
     @State var tapped = false
         
     var body: some View {
@@ -149,7 +149,7 @@ struct TestGestureView2: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 16.0, *)
-struct TestGestureView3: View & Inspectable {
+struct TestGestureView3: View & InspectableProtocol {
     @State var tapped = false
         
     var body: some View {
@@ -165,7 +165,7 @@ struct TestGestureView3: View & Inspectable {
 
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
-struct TestGestureView4: View & Inspectable {
+struct TestGestureView4: View & InspectableProtocol {
     @State var isDragging = false
     
     var body: some View {
@@ -181,7 +181,7 @@ struct TestGestureView4: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 14.0, *)
-struct TestGestureView5: View & Inspectable {
+struct TestGestureView5: View & InspectableProtocol {
     @GestureState var isDetectingLongPress = false
 
     internal let inspection = Inspection<Self>()
@@ -203,7 +203,7 @@ struct TestGestureView5: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 14.0, *)
-struct TestGestureView6: View & Inspectable {
+struct TestGestureView6: View & InspectableProtocol {
     @GestureState var isDetectingLongPress = false
     @State var totalNumberOfTaps = 0
 
@@ -237,7 +237,7 @@ struct TestGestureView6: View & Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 14.0, *)
-struct TestGestureView7: View & Inspectable {
+struct TestGestureView7: View & InspectableProtocol {
     @GestureState var isDetectingLongPress = false
     @State var totalNumberOfTaps = 0
     @State var doneCounting = false
@@ -272,7 +272,7 @@ struct TestGestureView7: View & Inspectable {
 
 #if os(macOS)
 @available(macOS 10.15, *)
-struct TestGestureView8: View & Inspectable {
+struct TestGestureView8: View & InspectableProtocol {
     @State var tapped = false
         
     var body: some View {
@@ -290,7 +290,7 @@ struct TestGestureView8: View & Inspectable {
 #endif
 
 @available(iOS 14.0, macOS 10.15, tvOS 16.0, *)
-struct TestGestureView9: View & Inspectable {
+struct TestGestureView9: View & InspectableProtocol {
     @State var tapped = false
         
     var body: some View {

--- a/Tests/ViewInspectorTests/InspectableViewTests.swift
+++ b/Tests/ViewInspectorTests/InspectableViewTests.swift
@@ -75,7 +75,7 @@ final class InspectableViewTestsAccessTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ViewWithAbsentChildren: View, Inspectable {
+private struct ViewWithAbsentChildren: View, InspectableProtocol {
     let present: Bool
     
     @ViewBuilder

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -127,7 +127,7 @@ final class Inspection<V>: InspectionEmissary {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestView: View, Inspectable {
+private struct TestView: View, InspectableProtocol {
     
     @State private(set) var flag: Bool
     let publisher = PassthroughSubject<Bool, Never>()
@@ -150,7 +150,7 @@ private class ExternalState: ObservableObject {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestViewModifier: ViewModifier, Inspectable {
+private struct TestViewModifier: ViewModifier, InspectableProtocol {
     
     @Binding var flag: Bool
     @EnvironmentObject var envState: ExternalState

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -292,7 +292,7 @@ private struct Struct1 {
 private struct Struct3<T> { }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestPrintView: View, Inspectable {
+private struct TestPrintView: View, InspectableProtocol {
     
     let str = ["abc", "def"]
     

--- a/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
@@ -257,7 +257,7 @@ private struct InspectableActionSheetWithItem<Item: Identifiable>: ViewModifier,
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ActionSheetFindTestView: View, Inspectable {
+private struct ActionSheetFindTestView: View, InspectableProtocol {
     
     @Binding var isSheet1Presented = false
     @Binding var isSheet2Presented = false
@@ -289,7 +289,7 @@ private struct ActionSheetFindTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct PopupMixTestView: View, Inspectable {
+private struct PopupMixTestView: View, InspectableProtocol {
     
     @Binding var isAlertPresented = true
     @Binding var isActionSheetPresented = true

--- a/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
@@ -333,7 +333,7 @@ private struct InspectableAlertWithItem<Item: Identifiable>: ViewModifier, ItemP
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct AlertFindTestView: View, Inspectable {
+private struct AlertFindTestView: View, InspectableProtocol {
     
     @Binding var isAlert1Presented = false
     @Binding var isAlert2Presented = false

--- a/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ButtonTests.swift
@@ -206,4 +206,4 @@ private struct TestPrimitiveButtonStyle: PrimitiveButtonStyle {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension TestPrimitiveButtonStyle.TestButton: Inspectable { }
+extension TestPrimitiveButtonStyle.TestButton: InspectableProtocol { }

--- a/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
@@ -31,7 +31,7 @@ final class ConditionalContentTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ConditionalView: View, Inspectable {
+private struct ConditionalView: View, InspectableProtocol {
     
     @ObservedObject var viewModel = ViewModel()
     var body: some View {
@@ -47,7 +47,7 @@ private struct ConditionalView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ConditionalViewWithModifier: View, Inspectable {
+private struct ConditionalViewWithModifier: View, InspectableProtocol {
     
     let value: Bool
     

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewBuilderTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewBuilderTests.swift
@@ -107,4 +107,4 @@ private struct TestViewBuilderView<Content: View>: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension TestViewBuilderView: Inspectable { }
+extension TestViewBuilderView: InspectableProtocol { }

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
@@ -160,7 +160,7 @@ private struct NonInspectableModifier: ViewModifier {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestModifier: ViewModifier, Inspectable {
+private struct TestModifier: ViewModifier, InspectableProtocol {
     var tag: Int = 0
     func body(content: Self.Content) -> some View {
         content.onAppear(perform: { })
@@ -168,7 +168,7 @@ private struct TestModifier: ViewModifier, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestModifier2: ViewModifier, Inspectable {
+private struct TestModifier2: ViewModifier, InspectableProtocol {
     
     @Binding var value: Bool
     var didAppear: ((Self) -> Void)?
@@ -184,7 +184,7 @@ private struct TestModifier2: ViewModifier, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestModifier3: ViewModifier, Inspectable {
+private struct TestModifier3: ViewModifier, InspectableProtocol {
     
     @EnvironmentObject var viewModel: ExternalState
     
@@ -202,7 +202,7 @@ private class ExternalState: ObservableObject {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestModifier4: ViewModifier, Inspectable {
+private struct TestModifier4: ViewModifier, InspectableProtocol {
     
     let injection: ExternalState
     
@@ -226,7 +226,7 @@ private struct TestModifier4: ViewModifier, Inspectable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension TestModifier4 {
-    struct ViewWithEnvObject: View, Inspectable {
+    struct ViewWithEnvObject: View, InspectableProtocol {
         
         @EnvironmentObject var envObj: ExternalState
         

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
@@ -384,7 +384,7 @@ extension EnvironmentValues {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension ViewType {
-    struct Test<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
+    struct Test<T>: KnownViewType, CustomViewType {
         public static var typePrefix: String { "String" }
         static var namespacedPrefixes: [String] { ["Swift.String"] }
     }

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
@@ -245,14 +245,14 @@ private struct NonInspectableTestView: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct SimpleTestView: View, Inspectable {
+private struct SimpleTestView: View, InspectableProtocol {
     var body: some View {
         EmptyView()
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct LocalStateTestView: View, Inspectable {
+private struct LocalStateTestView: View, InspectableProtocol {
     
     @State private(set) var flag: Bool
     let inspection = Inspection<Self>()
@@ -266,7 +266,7 @@ private struct LocalStateTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ObservedStateTestView: View, Inspectable {
+private struct ObservedStateTestView: View, InspectableProtocol {
     
     @ObservedObject var viewModel: ExternalState
     
@@ -276,7 +276,7 @@ private struct ObservedStateTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvironmentStateTestView: View, Inspectable {
+private struct EnvironmentStateTestView: View, InspectableProtocol {
     
     @EnvironmentObject var viewModel: ExternalState
     let inspection = Inspection<Self>()
@@ -288,7 +288,7 @@ private struct EnvironmentStateTestView: View, Inspectable {
 }
 
 #if os(macOS)
-private struct TestViewRepresentable: NSViewRepresentable, Inspectable {
+private struct TestViewRepresentable: NSViewRepresentable, InspectableProtocol {
     
     func makeNSView(context: NSViewRepresentableContext<Self>) -> NSView {
         let view = NSView()
@@ -301,7 +301,7 @@ private struct TestViewRepresentable: NSViewRepresentable, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestViewControllerRepresentable: NSViewControllerRepresentable, Inspectable {
+private struct TestViewControllerRepresentable: NSViewControllerRepresentable, InspectableProtocol {
     
     func makeNSViewController(context: Context) -> NSViewController {
         let vc = NSViewController()
@@ -314,7 +314,7 @@ private struct TestViewControllerRepresentable: NSViewControllerRepresentable, I
 }
 #elseif os(iOS) || os(tvOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestViewRepresentable: UIViewRepresentable, Inspectable {
+private struct TestViewRepresentable: UIViewRepresentable, InspectableProtocol {
     
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
@@ -327,7 +327,7 @@ private struct TestViewRepresentable: UIViewRepresentable, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestViewControllerRepresentable: UIViewControllerRepresentable, Inspectable {
+private struct TestViewControllerRepresentable: UIViewControllerRepresentable, InspectableProtocol {
     
     func makeUIViewController(context: Context) -> UIViewController {
         let vc = UIViewController()
@@ -341,7 +341,7 @@ private struct TestViewControllerRepresentable: UIViewControllerRepresentable, I
 #elseif os(watchOS)
 
 @available(watchOS, deprecated: 7.0)
-private struct TestViewRepresentable: WKInterfaceObjectRepresentable, Inspectable {
+private struct TestViewRepresentable: WKInterfaceObjectRepresentable, InspectableProtocol {
     
     typealias Context = WKInterfaceObjectRepresentableContext<TestViewRepresentable>
     func makeWKInterfaceObject(context: Context) -> some WKInterfaceObject {
@@ -384,28 +384,28 @@ extension EnvironmentValues {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension ViewType {
-    struct Test<T>: KnownViewType, CustomViewType where T: Inspectable {
+    struct Test<T>: KnownViewType, CustomViewType where T: InspectableProtocol {
         public static var typePrefix: String { "String" }
         static var namespacedPrefixes: [String] { ["Swift.String"] }
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct NameMatchView: View, Inspectable {
+private struct NameMatchView: View, InspectableProtocol {
     var body: some View {
         Text("")
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct NameMatchViewList: View, Inspectable {
+private struct NameMatchViewList: View, InspectableProtocol {
     var body: some View {
         ForEach(0..<5) { _ in NameMatchView() }
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct GenericContainer<T>: View, Inspectable {
+private struct GenericContainer<T>: View, InspectableProtocol {
     var body: some View {
         TestView()
     }
@@ -413,7 +413,7 @@ private struct GenericContainer<T>: View, Inspectable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension GenericContainer {
-    struct TestView: View, Inspectable {
+    struct TestView: View, InspectableProtocol {
         var body: some View {
             Text("")
         }

--- a/Tests/ViewInspectorTests/SwiftUI/DisclosureGroupTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/DisclosureGroupTests.swift
@@ -102,7 +102,7 @@ final class DisclosureGroupTests: XCTestCase {
 @available(iOS 14.0, macOS 11.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-private struct TestViewState: View, Inspectable {
+private struct TestViewState: View, InspectableProtocol {
     @ObservedObject var state = ExpansionState()
     
     var body: some View {
@@ -120,7 +120,7 @@ private struct TestViewState: View, Inspectable {
 @available(iOS 14.0, macOS 11.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-private struct TestViewBinding: View, Inspectable {
+private struct TestViewBinding: View, InspectableProtocol {
 
     @Binding var expanded: Bool = false
     

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
@@ -32,8 +32,8 @@ class EnvironmentObjectInjectionTests: XCTestCase {
         let obj1 = TestEnvObject1()
         let obj2 = TestEnvObject2()
         var sut = EnvironmentObjectInnerView()
-        sut.inject(environmentObject: obj1)
-        sut.inject(environmentObject: obj2)
+        sut = EnvironmentInjection.inject(environmentObject: obj1, into: sut)
+        sut = EnvironmentInjection.inject(environmentObject: obj2, into: sut)
         XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "env_true")
     }
     
@@ -87,7 +87,7 @@ class EnvironmentObjectInjectionTests: XCTestCase {
             Search did not find a match. Possible blockers: EnvironmentObjectInnerView is \
             missing EnvironmentObjects: [\"obj2: TestEnvObject2\", \"obj1: TestEnvObject1\"]
             """)
-        sut.inject(environmentObject: TestEnvObject1())
+        sut = EnvironmentInjection.inject(environmentObject: TestEnvObject1(), into: sut)
         XCTAssertThrows(try sut.inspect().find(ViewType.Text.self),
             """
             Search did not find a match. Possible blockers: EnvironmentObjectInnerView is \

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
@@ -109,7 +109,7 @@ private class TestEnvObject2: ObservableObject {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvironmentObjectInnerView: View, Inspectable {
+private struct EnvironmentObjectInnerView: View, InspectableProtocol {
     
     private var iVar1: Int8 = 0
     private var iVar2: Int16 = 0
@@ -128,7 +128,7 @@ private struct EnvironmentObjectInnerView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvironmentObjectOuterView: View, Inspectable {
+private struct EnvironmentObjectOuterView: View, InspectableProtocol {
     
     private var iVar1: Bool = false
     @EnvironmentObject var obj1: TestEnvObject1
@@ -146,7 +146,7 @@ private struct EnvironmentObjectOuterView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvironmentObjectViewModifier: ViewModifier, Inspectable {
+private struct EnvironmentObjectViewModifier: ViewModifier, InspectableProtocol {
     private var iVar1: Bool = false
     @EnvironmentObject var obj2: TestEnvObject2
     @EnvironmentObject var obj1: TestEnvObject1

--- a/Tests/ViewInspectorTests/SwiftUI/EquatableViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EquatableViewTests.swift
@@ -45,7 +45,7 @@ final class GlobalModifiersForEquatableView: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestView: View, Equatable, Inspectable {
+private struct TestView: View, Equatable, InspectableProtocol {
     
     var body: some View { EmptyView() }
     static func == (lhs: Self, rhs: Self) -> Bool { true }

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -213,7 +213,7 @@ where Item: Identifiable, FullScreenCover: View {
 
 @available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @available(macOS, unavailable)
-private struct FullScreenCoverFindTestView: View, Inspectable {
+private struct FullScreenCoverFindTestView: View, InspectableProtocol {
 
     @Binding var isFullScreenCover1Presented = false
     @Binding var isFullScreenCover2Presented = false

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
@@ -176,7 +176,7 @@ final class NavigationLinkTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestView: View, Inspectable {
+private struct TestView: View, InspectableProtocol {
     let parameter: String
     
     var body: some View {
@@ -185,7 +185,7 @@ private struct TestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
-private struct TestViewState: View, Inspectable {
+private struct TestViewState: View, InspectableProtocol {
     @ObservedObject var state = NavigationState()
     
     var tag1: String { "tag1" }
@@ -202,7 +202,7 @@ private struct TestViewState: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
-private struct TestViewBinding: View, Inspectable {
+private struct TestViewBinding: View, InspectableProtocol {
 
     @Binding var selection: String?
     

--- a/Tests/ViewInspectorTests/SwiftUI/OpaqueViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/OpaqueViewTests.swift
@@ -35,14 +35,14 @@ final class OpaqueViewTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct InspectableTestView: View, Inspectable {
+private struct InspectableTestView: View, InspectableProtocol {
     var body: some View {
         Text("Test")
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvInspectableTestView: View, Inspectable {
+private struct EnvInspectableTestView: View, InspectableProtocol {
     
     var body: some View {
         body(State())

--- a/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
@@ -57,7 +57,7 @@ final class OptionalViewTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct OptionalView: View, Inspectable {
+private struct OptionalView: View, InspectableProtocol {
     
     let flag: Bool
     var body: some View {
@@ -68,7 +68,7 @@ private struct OptionalView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct MixedOptionalView: View, Inspectable {
+private struct MixedOptionalView: View, InspectableProtocol {
     
     let flag: Bool
     var body: some View {

--- a/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
@@ -253,7 +253,7 @@ where Item: Identifiable, Popover: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct PopoverFindTestView: View, Inspectable {
+private struct PopoverFindTestView: View, InspectableProtocol {
     
     @Binding var isPopover1Presented = false
     @Binding var isPopover2Presented = false

--- a/Tests/ViewInspectorTests/SwiftUI/PreferenceTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PreferenceTests.swift
@@ -109,7 +109,7 @@ final class PreferenceTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ManyOverlaysView: View, Inspectable {
+private struct ManyOverlaysView: View, InspectableProtocol {
     var body: some View {
         EmptyView()
             .overlay(AnyView(Text("Test")))
@@ -122,7 +122,7 @@ private struct ManyOverlaysView: View, Inspectable {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct ManyOverlaysViewIOS15: View, Inspectable {
+private struct ManyOverlaysViewIOS15: View, InspectableProtocol {
     var body: some View {
         EmptyView()
             .overlay(Spacer())
@@ -135,7 +135,7 @@ private struct ManyOverlaysViewIOS15: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct ManyBGOverlaysView: View, Inspectable {
+private struct ManyBGOverlaysView: View, InspectableProtocol {
     var body: some View {
         EmptyView()
             .background(AnyView(Text("Test")))

--- a/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
@@ -176,7 +176,7 @@ where Item: Identifiable, Sheet: View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct SheetFindTestView: View, Inspectable {
+private struct SheetFindTestView: View, InspectableProtocol {
     
     @Binding var isSheet1Presented = false
     @Binding var isSheet2Presented = false

--- a/Tests/ViewInspectorTests/SwiftUI/SubscriptionViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SubscriptionViewTests.swift
@@ -25,7 +25,7 @@ final class SubscriptionViewTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct SubscriptionTestView: View, Inspectable {
+private struct SubscriptionTestView: View, InspectableProtocol {
     
     let publisher: AnyPublisher<Void, Never>
     

--- a/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
@@ -49,7 +49,7 @@ final class TupleViewTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct SimpleTupleView: View, Inspectable {
+private struct SimpleTupleView: View, InspectableProtocol {
     var body: some View {
         EmptyView()
         Text("abc")
@@ -57,7 +57,7 @@ private struct SimpleTupleView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TupleInsideTupleView: View, Inspectable {
+private struct TupleInsideTupleView: View, InspectableProtocol {
     
     let flag: Bool
     var body: some View {

--- a/Tests/ViewInspectorTests/ViewHostingTests.swift
+++ b/Tests/ViewInspectorTests/ViewHostingTests.swift
@@ -194,7 +194,7 @@ private class NSViewWithTag: NSView {
     static let onTag: Int = 43
 }
 
-private struct NSTestView: NSViewRepresentable, Inspectable {
+private struct NSTestView: NSViewRepresentable, InspectableProtocol {
     
     typealias UpdateContext = NSViewRepresentableContext<Self>
     
@@ -212,7 +212,7 @@ private struct NSTestView: NSViewRepresentable, Inspectable {
 }
 
 extension NSTestView {
-    struct WrapperView: View, Inspectable {
+    struct WrapperView: View, InspectableProtocol {
         
         @State var flag: Bool
         var didAppear: ((Self) -> Void)?
@@ -227,7 +227,7 @@ extension NSTestView {
 #elseif os(iOS) || os(tvOS)
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct UITestView: UIViewRepresentable, Inspectable {
+private struct UITestView: UIViewRepresentable, InspectableProtocol {
     
     typealias UpdateContext = UIViewRepresentableContext<Self>
     
@@ -249,7 +249,7 @@ private struct UITestView: UIViewRepresentable, Inspectable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension UITestView {
-    struct WrapperView: View, Inspectable {
+    struct WrapperView: View, InspectableProtocol {
         
         @State var flag: Bool
         var didAppear: ((Self) -> Void)?
@@ -265,7 +265,7 @@ extension UITestView {
     
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
 @available(watchOS, deprecated: 7.0)
-private struct WKTestView: WKInterfaceObjectRepresentable, Inspectable {
+private struct WKTestView: WKInterfaceObjectRepresentable, InspectableProtocol {
     
     var didUpdate: () -> Void
     
@@ -282,7 +282,7 @@ private struct WKTestView: WKInterfaceObjectRepresentable, Inspectable {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 7.0, *)
 @available(watchOS, deprecated: 7.0)
 extension WKTestView {
-    struct WrapperView: View, Inspectable {
+    struct WrapperView: View, InspectableProtocol {
         
         var didAppear: ((Self) -> Void)?
         var didUpdate: () -> Void
@@ -296,7 +296,7 @@ extension WKTestView {
 #endif
 
 #if os(macOS)
-private struct NSTestVC: NSViewControllerRepresentable, Inspectable {
+private struct NSTestVC: NSViewControllerRepresentable, InspectableProtocol {
     
     class TestVC: NSViewController {
         override func loadView() {
@@ -325,7 +325,7 @@ private struct NSTestVC: NSViewControllerRepresentable, Inspectable {
 }
 #elseif os(iOS) || os(tvOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct UITestVC: UIViewControllerRepresentable, Inspectable {
+private struct UITestVC: UIViewControllerRepresentable, InspectableProtocol {
     
     class TestVC: UIViewController { }
     

--- a/Tests/ViewInspectorTests/ViewModifiers/CustomStyleModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/CustomStyleModifiersTests.swift
@@ -147,4 +147,4 @@ extension RedOutlineHelloWorldStyle {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension RedOutlineHelloWorldStyle.StyleBody: Inspectable {}
+extension RedOutlineHelloWorldStyle.StyleBody: InspectableProtocol {}

--- a/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
@@ -158,7 +158,7 @@ final class NavigationBarItemsTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestView: View, Inspectable {
+private struct TestView: View, InspectableProtocol {
     
     let inspection = Inspection<Self>()
         

--- a/Tests/ViewInspectorTests/ViewModifiers/TransitiveModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/TransitiveModifiersTests.swift
@@ -79,7 +79,7 @@ final class TransitiveModifiersTests: XCTestCase {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct HittenTestView: View, Inspectable {
+private struct HittenTestView: View, InspectableProtocol {
     var body: some View {
         VStack {
             Button("abc", action: { })
@@ -91,7 +91,7 @@ private struct HittenTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct TestDisabledView: View, Inspectable {
+private struct TestDisabledView: View, InspectableProtocol {
     var body: some View {
         VStack {
             Button(action: { }, label: {
@@ -114,7 +114,7 @@ private struct TestDisabledView: View, Inspectable {
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-private struct FlipsRightToLeftTestView: View, Inspectable {
+private struct FlipsRightToLeftTestView: View, InspectableProtocol {
     var body: some View {
         VStack {
             Stepper("1", onIncrement: nil, onDecrement: nil)
@@ -127,7 +127,7 @@ private struct FlipsRightToLeftTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 11.0, tvOS 13.0, *)
-private struct ColorSchemeTestView: View, Inspectable {
+private struct ColorSchemeTestView: View, InspectableProtocol {
     var body: some View {
         VStack {
             Text("1")
@@ -145,7 +145,7 @@ private struct ColorSchemeTestView: View, Inspectable {
 }
 
 @available(iOS 13.0, macOS 11.0, tvOS 13.0, *)
-private struct AllowsHitTestingTestView: View, Inspectable {
+private struct AllowsHitTestingTestView: View, InspectableProtocol {
     
     var body: some View {
         VStack {
@@ -164,7 +164,7 @@ private struct AllowsHitTestingTestView: View, Inspectable {
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-private struct TestLabelsHiddenView: View, Inspectable {
+private struct TestLabelsHiddenView: View, InspectableProtocol {
     var body: some View {
         VStack {
             Stepper(onIncrement: nil, onDecrement: nil, label: {

--- a/Tests/ViewInspectorTests/ViewSearchTests.swift
+++ b/Tests/ViewInspectorTests/ViewSearchTests.swift
@@ -218,10 +218,10 @@ final class ViewSearchTests: XCTestCase {
         let view = AnyView(Test.NonInspectableView().id(5))
         XCTAssertNoThrow(try view.inspect().find(viewWithId: 5))
         let err = "Search did not find a match. Possible blockers: NonInspectableView"
-        XCTAssertThrows(try view.inspect().find(ViewType.EmptyView.self,
-                                                traversal: .breadthFirst), err)
-        XCTAssertThrows(try view.inspect().find(ViewType.EmptyView.self,
-                                                traversal: .depthFirst), err)
+        XCTAssertNoThrow(try view.inspect().find(ViewType.EmptyView.self,
+                                                traversal: .breadthFirst))
+        XCTAssertNoThrow(try view.inspect().find(ViewType.EmptyView.self,
+                                                traversal: .depthFirst))
     }
     
     func testConflictingViewTypeNames() throws {

--- a/Tests/ViewInspectorTests/ViewSearchTests.swift
+++ b/Tests/ViewInspectorTests/ViewSearchTests.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct Test {
-    struct InnerView: View, Inspectable {
+    struct InnerView: View, InspectableProtocol {
         var body: some View {
             Button(action: { }, label: {
                 HStack { Text("Btn") }
@@ -15,7 +15,7 @@ private struct Test {
             })
         }
     }
-    struct MainView: View, Inspectable {
+    struct MainView: View, InspectableProtocol {
         var body: some View {
             AnyView(Group {
                 SwiftUI.EmptyView()
@@ -39,7 +39,7 @@ private struct Test {
             })
         }
     }
-    struct ConditionalView: View, Inspectable {
+    struct ConditionalView: View, InspectableProtocol {
         let falseCondition = false
         let trueCondition = true
         
@@ -55,7 +55,7 @@ private struct Test {
             }
         }
     }
-    struct Modifier: ViewModifier, Inspectable {
+    struct Modifier: ViewModifier, InspectableProtocol {
         let text: String
         func body(content: Modifier.Content) -> some View {
             AnyView(content.overlay(Text(text)))
@@ -66,7 +66,7 @@ private struct Test {
             SwiftUI.EmptyView()
         }
     }
-    struct EmptyView: View, Inspectable {
+    struct EmptyView: View, InspectableProtocol {
         var body: some View {
             Text("empty")
         }
@@ -256,7 +256,7 @@ final class ViewSearchTests: XCTestCase {
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 private extension Test {
-    struct AccessibleView: View, Inspectable {
+    struct AccessibleView: View, InspectableProtocol {
         var body: some View {
             Button(action: { }, label: {
                 HStack {


### PR DESCRIPTION
_This PR is easy to review commit by commit, if you want to follow the progress._

In this PR I prototype how we might remove the requirement that all views conform to `Inspectable` in order to be inspected. My hope for this PR is to continue the discussion in https://github.com/nalexn/ViewInspector/issues/203 and align on a path for removing the requirement that all views need to conform to `Inspectable` in order to be inspected.

-----

### Status: ⚠️WIP⚠️
In the first commit I updated an existing test to fail, with the goal of fixing this test with future commits. I'm midway through the refactor, focused on removing the `entity` property and `extractContent(…)` method from the `Inspectable` protocol.

I was able to remove `entity` easily. I'm having trouble removing `extractContent(…)` due to the way it requires refactoring the environment injection code. See https://github.com/nalexn/ViewInspector/pull/213#discussion_r1034169681 for where I'm stuck.

I've renamed `Inspectable` to `InspectableProtocol`. My eventual goal is to remove `InspectableProtocol` entirely in favor of the new `Inspectable` struct.