### PR TITLE
Add inspection support for Layout protocol based views

### DIFF
--- a/Sources/ViewInspector/SwiftUI/TreeView.swift
+++ b/Sources/ViewInspector/SwiftUI/TreeView.swift
@@ -9,7 +9,15 @@ internal extension ViewType {
 extension ViewType.TreeView: SingleViewContent {
 
     static func child(_ content: Content) throws -> Content {
-        let view = try Inspector.attribute(path: "content", value: content.view)
+        let view: Any = try {
+            guard let rootContent = try? Inspector.attribute(path: "root|content", value: content.view) else {
+                // Try to return the `contents` property directly if the tree root does not contain a View.
+                // (e.g. Layout, _VariadicView_MultiViewRoot, _VariadicView_UnaryViewRoot)
+                return try Inspector.attribute(path: "content", value: content.view)
+            }
+
+            return rootContent
+        }()
         return try Inspector.unwrap(view: view, medium: content.medium)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/TreeView.swift
+++ b/Sources/ViewInspector/SwiftUI/TreeView.swift
@@ -9,7 +9,7 @@ internal extension ViewType {
 extension ViewType.TreeView: SingleViewContent {
 
     static func child(_ content: Content) throws -> Content {
-        let view = try Inspector.attribute(path: "root|content", value: content.view)
+        let view = try Inspector.attribute(path: "content", value: content.view)
         return try Inspector.unwrap(view: view, medium: content.medium)
     }
 }

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -70,9 +70,9 @@ private struct SampleVariadicViewScreen: View {
         } else {
           opacity = 0.5
         }
-      }) {
+      }, label: {
         Text("Execute")
-      }
+      })
     })
   }
 }
@@ -114,7 +114,7 @@ private struct SimpleHStackLayout: Layout {
     var spaces: [CGFloat]
   }
 
-  var spacing: CGFloat? = nil
+  var spacing: CGFloat?
 
   func makeCache(subviews: Subviews) -> CacheData {
     CacheData(

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -30,7 +30,7 @@ final class TreeViewTests: XCTestCase {
     }
 
   func testVariadicViewTree() throws {
-    let button = try VariadicViewScreen().inspect().find(button: "Execute")
+    let button = try VariadicViewScreen().inspect().find(button: "Change opacity")
     XCTAssertNotNil(button)
   }
 
@@ -62,7 +62,7 @@ private struct VariadicViewScreen: View {
   var body: some View {
     _VariadicView.Tree(VariadicViewScreenOpacityRoot(opacity: opacity),
                        content: {
-      Text("Click the button to execute the action.")
+      Text("Click the button to change the opacity.")
       Button(action: {
         if opacity < 1.0 {
           opacity = 1.0
@@ -70,7 +70,7 @@ private struct VariadicViewScreen: View {
           opacity = 0.5
         }
       }, label: {
-        Text("Execute")
+        Text("Change opacity")
       })
     })
   }

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -28,6 +28,17 @@ final class TreeViewTests: XCTestCase {
         }
         XCTAssertEqual(sut.content.medium.viewModifiers.count, count)
     }
+
+  @available(iOS 16.0, *)
+  func testVariadicViewTree() throws {
+    let button = try SampleVariadicViewScreen().inspect().find(button: "Execute")
+    XCTAssertNotNil(button)
+  }
+
+  @available(iOS 16.0, *)
+  func testLayoutViewTree() throws {
+    XCTAssertNoThrow(try SampleLayoutScreen().inspect().find(text: "SampleLayoutScreen text 2"))
+  }
 }
 
 // MARK: - View Modifiers
@@ -41,4 +52,116 @@ final class GlobalModifiersForTreeView: XCTestCase {
         let sut = EmptyView().contextMenu(ContextMenu(menuItems: { Text("") }))
         XCTAssertNoThrow(try sut.inspect().emptyView())
     }
+}
+
+// MARK: - SampleVariadicViewScreen
+
+@available(iOS 13.0, macOS 10.15, *)
+private struct SampleVariadicViewScreen: View {
+  @State var opacity: Double = 1.0
+
+  var body: some View {
+    _VariadicView.Tree(SampleVariadicViewScreenOpacityRoot(opacity: opacity),
+                       content: {
+      Text("Click the button to execute the action.")
+      Button(action: {
+        if opacity < 1.0 {
+          opacity = 1.0
+        } else {
+          opacity = 0.5
+        }
+      }) {
+        Text("Execute")
+      }
+    })
+  }
+}
+
+// MARK: - SampleVariadicViewScreenRoot
+
+@available(iOS 13.0, macOS 10.15, *)
+private struct SampleVariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
+  let opacity: Double
+
+  func body(children: _VariadicView.Children) -> some View {
+    ForEach(children) { child in
+      child
+        .opacity(opacity)
+    }
+  }
+}
+
+// MARK: - SampleLayoutScreen
+
+@available(iOS 16.0, *)
+private struct SampleLayoutScreen: View {
+  var body: some View {
+    SimpleHStackLayout {
+      Text("SampleLayoutScreen text 1")
+      Text("SampleLayoutScreen text 2")
+      Text("SampleLayoutScreen text 3")
+    }
+  }
+}
+
+// MARK: - SimpleHStack
+
+@available(iOS 16.0, *)
+// copied from https://swiftui-lab.com/layout-protocol-part-1/#layout-cache
+private struct SimpleHStackLayout: Layout {
+  struct CacheData {
+    var maxHeight: CGFloat
+    var spaces: [CGFloat]
+  }
+
+  var spacing: CGFloat? = nil
+
+  func makeCache(subviews: Subviews) -> CacheData {
+    CacheData(
+      maxHeight: computeMaxHeight(subviews: subviews),
+      spaces: computeSpaces(subviews: subviews))
+  }
+
+  func updateCache(_ cache: inout CacheData, subviews: Subviews) {
+    cache.maxHeight = computeMaxHeight(subviews: subviews)
+    cache.spaces = computeSpaces(subviews: subviews)
+  }
+
+  func sizeThatFits(proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) -> CGSize {
+    let idealViewSizes = subviews.map { $0.sizeThatFits(.unspecified) }
+    let accumulatedWidths = idealViewSizes.reduce(0) { $0 + $1.width }
+    let accumulatedSpaces = cache.spaces.reduce(0) { $0 + $1 }
+
+    return CGSize(
+      width: accumulatedSpaces + accumulatedWidths,
+      height: cache.maxHeight)
+  }
+
+  func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
+    var pt = CGPoint(x: bounds.minX, y: bounds.minY)
+
+    for idx in subviews.indices {
+      subviews[idx].place(at: pt, anchor: .topLeading, proposal: .unspecified)
+
+      if idx < subviews.count - 1 {
+        pt.x += subviews[idx].sizeThatFits(.unspecified).width + cache.spaces[idx]
+      }
+    }
+  }
+
+  func computeSpaces(subviews: LayoutSubviews) -> [CGFloat] {
+    if let spacing {
+      return [CGFloat](repeating: spacing, count: subviews.count - 1)
+    } else {
+      return subviews.indices.map { idx in
+        guard idx < subviews.count - 1 else { return CGFloat(0) }
+
+        return subviews[idx].spacing.distance(to: subviews[idx + 1].spacing, along: .horizontal)
+      }
+    }
+  }
+
+  func computeMaxHeight(subviews: LayoutSubviews) -> CGFloat {
+    subviews.map { $0.sizeThatFits(.unspecified) }.reduce(0) { max($0, $1.height) }
+  }
 }

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -8,7 +8,7 @@ final class TreeViewTests: XCTestCase {
     
     @available(watchOS, deprecated: 7.0)
     func testEnclosedView() throws {
-        let sut = Text("Test").contextMenu(ContextMenu(menuItems: { Text("Menu") }))
+        let sut = Text("Test").contextMenu(menuItems: { Text("Menu") })
         let text = try sut.inspect().text().string()
         XCTAssertEqual(text, "Test")
     }
@@ -17,7 +17,7 @@ final class TreeViewTests: XCTestCase {
     func testRetainsModifiers() throws {
         let view = Text("Test")
             .padding()
-            .contextMenu(ContextMenu(menuItems: { Text("Menu") }))
+            .contextMenu(menuItems: { Text("Menu") })
             .padding().padding()
         let sut = try view.inspect().text()
         let count: Int
@@ -51,7 +51,7 @@ final class GlobalModifiersForTreeView: XCTestCase {
     
     @available(watchOS, deprecated: 7.0)
     func testContextMenu() throws {
-        let sut = EmptyView().contextMenu(ContextMenu(menuItems: { Text("") }))
+        let sut = EmptyView().contextMenu(menuItems: { Text("") })
         XCTAssertNoThrow(try sut.inspect().emptyView())
     }
 }

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -29,7 +29,7 @@ final class TreeViewTests: XCTestCase {
         XCTAssertEqual(sut.content.medium.viewModifiers.count, count)
     }
 
-  @available(iOS 16.0, *)
+  @available(watchOS, deprecated: 7.0)
   func testVariadicViewTree() throws {
     let button = try SampleVariadicViewScreen().inspect().find(button: "Execute")
     XCTAssertNotNil(button)

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -29,15 +29,14 @@ final class TreeViewTests: XCTestCase {
         XCTAssertEqual(sut.content.medium.viewModifiers.count, count)
     }
 
-  @available(watchOS, deprecated: 7.0)
   func testVariadicViewTree() throws {
-    let button = try SampleVariadicViewScreen().inspect().find(button: "Execute")
+    let button = try VariadicViewScreen().inspect().find(button: "Execute")
     XCTAssertNotNil(button)
   }
 
   @available(iOS 16.0, *)
-  func testLayoutViewTree() throws {
-    XCTAssertNoThrow(try SampleLayoutScreen().inspect().find(text: "SampleLayoutScreen text 2"))
+  func testLayoutBasedViewTree() throws {
+    XCTAssertNoThrow(try LayoutScreen().inspect().find(text: "LayoutScreen text 2"))
   }
 }
 
@@ -54,14 +53,14 @@ final class GlobalModifiersForTreeView: XCTestCase {
     }
 }
 
-// MARK: - SampleVariadicViewScreen
+// MARK: - VariadicViewScreen
 
 @available(iOS 13.0, macOS 10.15, *)
-private struct SampleVariadicViewScreen: View {
+private struct VariadicViewScreen: View {
   @State var opacity: Double = 1.0
 
   var body: some View {
-    _VariadicView.Tree(SampleVariadicViewScreenOpacityRoot(opacity: opacity),
+    _VariadicView.Tree(VariadicViewScreenOpacityRoot(opacity: opacity),
                        content: {
       Text("Click the button to execute the action.")
       Button(action: {
@@ -77,10 +76,10 @@ private struct SampleVariadicViewScreen: View {
   }
 }
 
-// MARK: - SampleVariadicViewScreenRoot
+// MARK: - VariadicViewScreenOpacityRoot
 
 @available(iOS 13.0, macOS 10.15, *)
-private struct SampleVariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
+private struct VariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
   let opacity: Double
 
   func body(children: _VariadicView.Children) -> some View {
@@ -91,23 +90,23 @@ private struct SampleVariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot 
   }
 }
 
-// MARK: - SampleLayoutScreen
+// MARK: - LayoutScreen
 
 @available(iOS 16.0, *)
-private struct SampleLayoutScreen: View {
+private struct LayoutScreen: View {
   var body: some View {
     SimpleHStackLayout {
-      Text("SampleLayoutScreen text 1")
-      Text("SampleLayoutScreen text 2")
-      Text("SampleLayoutScreen text 3")
+      Text("LayoutScreen text 1")
+      Text("LayoutScreen text 2")
+      Text("LayoutScreen text 3")
     }
   }
 }
 
-// MARK: - SimpleHStack
+// MARK: - SimpleHStackLayout
 
+/// Sample code copied from https://swiftui-lab.com/layout-protocol-part-1/#layout-cache
 @available(iOS 16.0, *)
-// copied from https://swiftui-lab.com/layout-protocol-part-1/#layout-cache
 private struct SimpleHStackLayout: Layout {
   struct CacheData {
     var maxHeight: CGFloat

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -29,11 +29,6 @@ final class TreeViewTests: XCTestCase {
         XCTAssertEqual(sut.content.medium.viewModifiers.count, count)
     }
 
-    func testVariadicViewTree() throws {
-        let button = try VariadicViewScreen().inspect().find(button: "Change opacity")
-        XCTAssertNotNil(button)
-    }
-
     func testLayoutBasedViewTree() throws {
         guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) else {
             throw XCTSkip("Layouts are not available in this version.")
@@ -53,43 +48,6 @@ final class GlobalModifiersForTreeView: XCTestCase {
     func testContextMenu() throws {
         let sut = EmptyView().contextMenu(menuItems: { Text("") })
         XCTAssertNoThrow(try sut.inspect().emptyView())
-    }
-}
-
-// MARK: - VariadicViewScreen
-
-@available(iOS 13.0, macOS 10.15, *)
-private struct VariadicViewScreen: View {
-    @State var opacity: Double = 1.0
-
-    var body: some View {
-        _VariadicView.Tree(VariadicViewScreenOpacityRoot(opacity: opacity),
-                           content: {
-            Text("Click the button to change the opacity.")
-            Button(action: {
-                if opacity < 1.0 {
-                    opacity = 1.0
-                } else {
-                    opacity = 0.5
-                }
-            }, label: {
-                Text("Change opacity")
-            })
-        })
-    }
-}
-
-// MARK: - VariadicViewScreenOpacityRoot
-
-@available(iOS 13.0, macOS 10.15, *)
-private struct VariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
-    let opacity: Double
-
-    func body(children: _VariadicView.Children) -> some View {
-        ForEach(children) { child in
-            child
-                .opacity(opacity)
-        }
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -34,8 +34,11 @@ final class TreeViewTests: XCTestCase {
         XCTAssertNotNil(button)
     }
 
-    @available(iOS 16.0, *)
     func testLayoutBasedViewTree() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) else {
+            throw XCTSkip("Layouts are not available in this version.")
+        }
+
         XCTAssertNoThrow(try LayoutScreen().inspect().find(text: "LayoutScreen text 2"))
     }
 }
@@ -92,7 +95,7 @@ private struct VariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
 
 // MARK: - LayoutScreen
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private struct LayoutScreen: View {
     var body: some View {
         SimpleHStackLayout {
@@ -106,7 +109,7 @@ private struct LayoutScreen: View {
 // MARK: - SimpleHStackLayout
 
 /// Sample code copied from https://swiftui-lab.com/layout-protocol-part-1/#layout-cache
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private struct SimpleHStackLayout: Layout {
     struct CacheData {
         var maxHeight: CGFloat

--- a/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TreeViewTests.swift
@@ -29,15 +29,15 @@ final class TreeViewTests: XCTestCase {
         XCTAssertEqual(sut.content.medium.viewModifiers.count, count)
     }
 
-  func testVariadicViewTree() throws {
-    let button = try VariadicViewScreen().inspect().find(button: "Change opacity")
-    XCTAssertNotNil(button)
-  }
+    func testVariadicViewTree() throws {
+        let button = try VariadicViewScreen().inspect().find(button: "Change opacity")
+        XCTAssertNotNil(button)
+    }
 
-  @available(iOS 16.0, *)
-  func testLayoutBasedViewTree() throws {
-    XCTAssertNoThrow(try LayoutScreen().inspect().find(text: "LayoutScreen text 2"))
-  }
+    @available(iOS 16.0, *)
+    func testLayoutBasedViewTree() throws {
+        XCTAssertNoThrow(try LayoutScreen().inspect().find(text: "LayoutScreen text 2"))
+    }
 }
 
 // MARK: - View Modifiers
@@ -57,50 +57,50 @@ final class GlobalModifiersForTreeView: XCTestCase {
 
 @available(iOS 13.0, macOS 10.15, *)
 private struct VariadicViewScreen: View {
-  @State var opacity: Double = 1.0
+    @State var opacity: Double = 1.0
 
-  var body: some View {
-    _VariadicView.Tree(VariadicViewScreenOpacityRoot(opacity: opacity),
-                       content: {
-      Text("Click the button to change the opacity.")
-      Button(action: {
-        if opacity < 1.0 {
-          opacity = 1.0
-        } else {
-          opacity = 0.5
-        }
-      }, label: {
-        Text("Change opacity")
-      })
-    })
-  }
+    var body: some View {
+        _VariadicView.Tree(VariadicViewScreenOpacityRoot(opacity: opacity),
+                           content: {
+            Text("Click the button to change the opacity.")
+            Button(action: {
+                if opacity < 1.0 {
+                    opacity = 1.0
+                } else {
+                    opacity = 0.5
+                }
+            }, label: {
+                Text("Change opacity")
+            })
+        })
+    }
 }
 
 // MARK: - VariadicViewScreenOpacityRoot
 
 @available(iOS 13.0, macOS 10.15, *)
 private struct VariadicViewScreenOpacityRoot: _VariadicView_MultiViewRoot {
-  let opacity: Double
+    let opacity: Double
 
-  func body(children: _VariadicView.Children) -> some View {
-    ForEach(children) { child in
-      child
-        .opacity(opacity)
+    func body(children: _VariadicView.Children) -> some View {
+        ForEach(children) { child in
+            child
+                .opacity(opacity)
+        }
     }
-  }
 }
 
 // MARK: - LayoutScreen
 
 @available(iOS 16.0, *)
 private struct LayoutScreen: View {
-  var body: some View {
-    SimpleHStackLayout {
-      Text("LayoutScreen text 1")
-      Text("LayoutScreen text 2")
-      Text("LayoutScreen text 3")
+    var body: some View {
+        SimpleHStackLayout {
+            Text("LayoutScreen text 1")
+            Text("LayoutScreen text 2")
+            Text("LayoutScreen text 3")
+        }
     }
-  }
 }
 
 // MARK: - SimpleHStackLayout
@@ -108,59 +108,59 @@ private struct LayoutScreen: View {
 /// Sample code copied from https://swiftui-lab.com/layout-protocol-part-1/#layout-cache
 @available(iOS 16.0, *)
 private struct SimpleHStackLayout: Layout {
-  struct CacheData {
-    var maxHeight: CGFloat
-    var spaces: [CGFloat]
-  }
-
-  var spacing: CGFloat?
-
-  func makeCache(subviews: Subviews) -> CacheData {
-    CacheData(
-      maxHeight: computeMaxHeight(subviews: subviews),
-      spaces: computeSpaces(subviews: subviews))
-  }
-
-  func updateCache(_ cache: inout CacheData, subviews: Subviews) {
-    cache.maxHeight = computeMaxHeight(subviews: subviews)
-    cache.spaces = computeSpaces(subviews: subviews)
-  }
-
-  func sizeThatFits(proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) -> CGSize {
-    let idealViewSizes = subviews.map { $0.sizeThatFits(.unspecified) }
-    let accumulatedWidths = idealViewSizes.reduce(0) { $0 + $1.width }
-    let accumulatedSpaces = cache.spaces.reduce(0) { $0 + $1 }
-
-    return CGSize(
-      width: accumulatedSpaces + accumulatedWidths,
-      height: cache.maxHeight)
-  }
-
-  func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
-    var pt = CGPoint(x: bounds.minX, y: bounds.minY)
-
-    for idx in subviews.indices {
-      subviews[idx].place(at: pt, anchor: .topLeading, proposal: .unspecified)
-
-      if idx < subviews.count - 1 {
-        pt.x += subviews[idx].sizeThatFits(.unspecified).width + cache.spaces[idx]
-      }
+    struct CacheData {
+        var maxHeight: CGFloat
+        var spaces: [CGFloat]
     }
-  }
 
-  func computeSpaces(subviews: LayoutSubviews) -> [CGFloat] {
-    if let spacing {
-      return [CGFloat](repeating: spacing, count: subviews.count - 1)
-    } else {
-      return subviews.indices.map { idx in
-        guard idx < subviews.count - 1 else { return CGFloat(0) }
+    var spacing: CGFloat?
 
-        return subviews[idx].spacing.distance(to: subviews[idx + 1].spacing, along: .horizontal)
-      }
+    func makeCache(subviews: Subviews) -> CacheData {
+        CacheData(
+            maxHeight: computeMaxHeight(subviews: subviews),
+            spaces: computeSpaces(subviews: subviews))
     }
-  }
 
-  func computeMaxHeight(subviews: LayoutSubviews) -> CGFloat {
-    subviews.map { $0.sizeThatFits(.unspecified) }.reduce(0) { max($0, $1.height) }
-  }
+    func updateCache(_ cache: inout CacheData, subviews: Subviews) {
+        cache.maxHeight = computeMaxHeight(subviews: subviews)
+        cache.spaces = computeSpaces(subviews: subviews)
+    }
+
+    func sizeThatFits(proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) -> CGSize {
+        let idealViewSizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let accumulatedWidths = idealViewSizes.reduce(0) { $0 + $1.width }
+        let accumulatedSpaces = cache.spaces.reduce(0) { $0 + $1 }
+
+        return CGSize(
+            width: accumulatedSpaces + accumulatedWidths,
+            height: cache.maxHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
+        var pt = CGPoint(x: bounds.minX, y: bounds.minY)
+
+        for idx in subviews.indices {
+            subviews[idx].place(at: pt, anchor: .topLeading, proposal: .unspecified)
+
+            if idx < subviews.count - 1 {
+                pt.x += subviews[idx].sizeThatFits(.unspecified).width + cache.spaces[idx]
+            }
+        }
+    }
+
+    func computeSpaces(subviews: LayoutSubviews) -> [CGFloat] {
+        if let spacing {
+            return [CGFloat](repeating: spacing, count: subviews.count - 1)
+        } else {
+            return subviews.indices.map { idx in
+                guard idx < subviews.count - 1 else { return CGFloat(0) }
+
+                return subviews[idx].spacing.distance(to: subviews[idx + 1].spacing, along: .horizontal)
+            }
+        }
+    }
+
+    func computeMaxHeight(subviews: LayoutSubviews) -> CGFloat {
+        subviews.map { $0.sizeThatFits(.unspecified) }.reduce(0) { max($0, $1.height) }
+    }
 }


### PR DESCRIPTION
## Changes

While trying to inspect SwiftUI Views use the `Layout` [protocol](https://developer.apple.com/documentation/swiftui/layout), it was found out that the content views were not able to be retrieved.

Views that use that protocol internally use that `_VariadicView.Tree` where the `root` property of the tree is the layout struct and the `content` property contains the items that will be laid out.

The bottom line of the issue is that ViewInspector's code passes a path to be navigated in order to find the `content` property **assuming that it's a child property** of the `root` property. 

```swift
    static func child(_ content: Content) throws -> Content {
        let view = try Inspector.attribute(path: "root|content", value: content.view)
        return try Inspector.unwrap(view: view, medium: content.medium)
    }
```
That assumption in the current code covers scenarios such as context menu on older versions of iOS.

The `content` property that contains the Views is **actually a sibling** of `root` property as the type structure dump below shows:

```
▿ Content
  ▿ view : Tree<_LayoutRoot<SimpleHStackLayout>, TupleView<(Text, Text, Text)>>
    ▿ root : _LayoutRoot<SimpleHStackLayout>
      ▿ layout : SimpleHStackLayout
        - spacing : nil
    ▿ content : TupleView<(Text, Text, Text)>
      ▿ value : 3 elements
        ▿ .0 : Text
          ▿ storage : Storage
            ▿ anyTextStorage : <LocalizedTextStorage: 0x000060000358b750>: "LayoutScreen text 1"
          - modifiers : 0 elements
        ▿ .1 : Text
          ▿ storage : Storage
            ▿ anyTextStorage : <LocalizedTextStorage: 0x00006000035ec000>: "LayoutScreen text 2"
          - modifiers : 0 elements
        ▿ .2 : Text
          ▿ storage : Storage
            ▿ anyTextStorage : <LocalizedTextStorage: 0x00006000035ec050>: "LayoutScreen text 3"
          - modifiers : 0 elements
  ▿ medium : Medium
    - viewModifiers : 0 elements
    - transitiveViewModifiers : 0 elements
    - environmentModifiers : 0 elements
    - environmentObjects : 0 elements
```

This change adds a second route in case the `root|content` is not available, it attempts the sibling `content` property which will cover the new scenario.

As the `Layout` based views also `_VariadicView.Tree` under the hood, this fixes #226 created by @bachand.

@nalexn as an FYI: @bachand and I work together at Airbnb and we're using the ViewInspector library in SwiftUI tests.

## Testing

Added tests to exercise the `Layout` based Views on iOS 16 and above.

## Code Coverage results for TreeView.swift file on iOS 16.2:

**Before:**

<img width="1264" alt="test_coverage_before" src="https://user-images.githubusercontent.com/2278022/217402297-8bd46f9c-4c86-45a5-a5f3-c5664d165c9a.png">


**After:**

<img width="1313" alt="coverage_after" src="https://user-images.githubusercontent.com/2278022/217941080-e72759c9-7bfe-4326-b4e9-63fc96616167.png">


## Review
@bachand 
@nalexn 