### PR TITLE
add onReceive after inspection function

### DIFF
--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -89,6 +89,26 @@ final class InspectionEmissaryTests: XCTestCase {
         wait(for: [exp1, exp2, exp3], timeout: 0.2)
     }
     
+    func testViewInspectOnReceiveAfter() throws {
+        let sut = TestView(flag: false)
+        let exp1 = sut.inspection.inspect { view in
+            let text = try view.button().labelView().text().string()
+            XCTAssertEqual(text, "false")
+            sut.publisher.send(true)
+        }
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
+            let text = try view.button().labelView().text().string()
+            XCTAssertEqual(text, "true")
+            sut.publisher.send(false)
+        }
+        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+            let text = try view.button().labelView().text().string()
+            XCTAssertEqual(text, "false")
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+    }
+    
     func testViewModifierInspectOnReceive() throws {
         let binding = Binding(wrappedValue: false)
         let sut = TestViewModifier(flag: binding)
@@ -98,6 +118,30 @@ final class InspectionEmissaryTests: XCTestCase {
             sut.publisher.send(true)
         }
         let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
+            let text = try view.hStack().button(1).labelView().text().string()
+            XCTAssertEqual(text, "true")
+            sut.publisher.send(false)
+        }
+        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+            let text = try view.hStack().button(1).labelView().text().string()
+            XCTAssertEqual(text, "false")
+        }
+        let view = EmptyView()
+            .modifier(sut)
+            .environmentObject(ExternalState())
+        ViewHosting.host(view: view)
+        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+    }
+    
+    func testViewModifierInspectOnReceiveAfter() throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = TestViewModifier(flag: binding)
+        let exp1 = sut.inspection.inspect { view in
+            let text = try view.hStack().button(1).labelView().text().string()
+            XCTAssertEqual(text, "false")
+            sut.publisher.send(true)
+        }
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
             let text = try view.hStack().button(1).labelView().text().string()
             XCTAssertEqual(text, "true")
             sut.publisher.send(false)


### PR DESCRIPTION
Currently there is no way to do inspection after some action + delay which for example might be needed when you click some button and there is some processing and we want to assert something after processing is done