### PR TITLE
Fix for iOS 16.4 issues with accessibility identifiers and labels

### DIFF
--- a/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
@@ -336,9 +336,13 @@ extension Dictionary: AccessibilityKeyValues {
     func accessibilityKeyValues() throws -> [(key: UInt64, value: Any)] {
         return try self.keys.compactMap { key -> (key: UInt64, value: Any)? in
             guard let value = self[key] else { return nil }
-            let keyPointerValue = try Inspector.attribute(
-                path: "rawValue|pointerValue", value: key, type: UInt64.self)
-            return (key: keyPointerValue, value: value as Any)
+            if let key = key as? ObjectIdentifier {
+                return (key: UInt64(abs(key.hashValue)), value: value as Any)
+            } else {
+                let keyPointerValue = try Inspector.attribute(
+                    path: "rawValue|pointerValue", value: key, type: UInt64.self)
+                return (key: keyPointerValue, value: value as Any)
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #235 

Do note that there's also an issue with TImeLineView with the latest. I chose not to address it because getting out a fix for this seems far more urgent.

I didn't have to modify tests because the existing tests exposed the problem (and verified the solution)