### PR TITLE
unwrap PopoverContent on macOS

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -277,6 +277,8 @@ internal extension Inspector {
             return try ViewType.DelayedPreferenceView.child(content)
         case "_PreferenceReadingView":
             return try ViewType.PreferenceReadingView.child(content)
+        case "PopoverContent":
+            return try ViewType.PopoverContent.child(content)
         default:
             return content
         }

--- a/Sources/ViewInspector/SwiftUI/PopoverContent.swift
+++ b/Sources/ViewInspector/SwiftUI/PopoverContent.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@available(macOS 10.15, *)
+internal extension ViewType {
+    struct PopoverContent { }
+}
+
+// MARK: - Content Extraction
+
+@available(macOS 10.15, *)
+extension ViewType.PopoverContent: SingleViewContent {
+
+    static func child(_ content: Content) throws -> Content {
+        let view = try Inspector.attribute(label: "content", value: content.view)
+        return try Inspector.unwrap(view: view, medium: content.medium)
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/PopoverContentTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PopoverContentTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+import SwiftUI
+import ViewInspector
+import XCTest
+
+#if os(macOS)
+
+fileprivate protocol AnyHostingView {
+    var anyRootView: AnyView { get }
+}
+
+extension NSHostingView: AnyHostingView {
+    fileprivate var anyRootView: AnyView { AnyView(rootView) }
+}
+
+fileprivate class TestModel: ObservableObject {
+    @Published var showPopover = false
+}
+
+fileprivate struct WindowRootView: View {
+    @ObservedObject var model: TestModel
+
+    var body: some View {
+        Rectangle()
+            .foregroundColor(.red)
+            .popover(isPresented: $model.showPopover) {
+                Text("popover content")
+                    .padding()
+            }
+    }
+}
+
+class PopoverContentTests: XCTestCase {
+
+    private var window: NSWindow! = NSWindow(
+        contentRect: .init(x: 0, y: 0, width: 200, height: 200),
+        styleMask: [.titled, .resizable, .miniaturizable, .closable],
+        backing: .buffered,
+        defer: false
+    )
+
+    private let model = TestModel()
+
+    override func tearDown() {
+        window.orderOut(nil)
+    }
+
+    func testPopoverContent() throws {
+        window.contentView = NSHostingView(rootView: WindowRootView(model: model))
+        window.orderBack(nil)
+        model.showPopover = true
+        CATransaction.commit()
+
+        let maybePopoverContentView = window
+            .childWindows?
+            .first { $0.accessibilityParent() as? NSView === window.contentView }?
+            .contentView
+
+        let popoverContentView = try XCTUnwrap(maybePopoverContentView as? AnyHostingView)
+        let popoverRootView = try popoverContentView.anyRootView.inspect()
+        XCTAssertNoThrow(try popoverRootView.find(text: "popover content"))
+    }
+}
+
+#endif


### PR DESCRIPTION
On macOS, a popover is displayed in its own `NSWindow`, and the `contentView` of that window is an `NSHostingView`. The hosted SwiftUI `View` structure looks like this:

```
ModifiedContent<AnyView, PopoverRootModifier>
  AnyView
    PopoverContent<ModifiedContent<ModifiedContent<ModifiedContent<YourPopoverContent, ClearNavigationContextModifier>, _EnvironmentKeyWritingModifier<NavigationEnabled>>, _EnvironmentKeyWritingModifier<Optional<NavigationState>>>>
      ModifiedContent<ModifiedContent<ModifiedContent<YourPopoverContent, ClearNavigationContextModifier>, _EnvironmentKeyWritingModifier<NavigationEnabled>>, _EnvironmentKeyWritingModifier<Optional<NavigationState>>>
        ModifiedContent<ModifiedContent<YourPopoverContent, ClearNavigationContextModifier>, _EnvironmentKeyWritingModifier<NavigationEnabled>>
          ModifiedContent<YourPopoverContent, ClearNavigationContextModifier>
            YourPopoverContent
```

This commit allows ViewInspector to unwrap PopoverContent so that it can inspect the user-provided views of the popover.