### PR TITLE
Added get selected value from SwiftUI.Picker component

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Picker.swift
+++ b/Sources/ViewInspector/SwiftUI/Picker.swift
@@ -75,6 +75,27 @@ public extension InspectableView where View == ViewType.Picker {
         }
         casted.forEach { $0.wrappedValue = value }
     }
+    
+    func selectedValue<SelectionValue>() throws -> SelectionValue {
+        var bindings = try Inspector.attribute(path: "selection", value: content.view)
+        if let single = bindings as? Binding<SelectionValue> {
+            bindings = [single]
+        }
+        let typeName = Inspector.typeName(value: bindings)
+        guard let casted = bindings as? [Binding<SelectionValue>] else {
+            var endIndex = typeName.index(before: typeName.endIndex)
+            if typeName.hasPrefix("Array") {
+                endIndex = typeName.index(before: endIndex)
+            }
+            let expected = typeName[..<endIndex]
+                .replacingOccurrences(of: "Array<Binding<", with: "")
+                .replacingOccurrences(of: "Binding<", with: "")
+            let factual = Inspector.typeName(type: SelectionValue.self)
+            throw InspectionError
+                .notSupported("selectedValue() expected a value of type \(expected) but received \(factual)")
+        }
+        return casted.first!.wrappedValue
+    }
 }
 
 // MARK: - Global View Modifiers

--- a/Tests/ViewInspectorTests/SwiftUI/PickerTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PickerTests.swift
@@ -95,6 +95,19 @@ final class PickerTests: XCTestCase {
         XCTAssertEqual(try view.inspect().find(text: "xyz").pathToRoot,
                        "anyView().picker().text(1)")
     }
+    
+    func testGetSelectedValue() throws {
+        let binding = Binding<String>(wrappedValue: "First Option")
+        let view = Picker(selection: binding, label: Text("Title")) {
+            Text("First Option").tag(0)
+            Text("Second Option").tag(1)
+        }
+        try view.inspect().picker().select(value: "Second Option")
+        
+        XCTAssertThrows(try view.inspect().picker().selectedValue() as Int,
+                        "selectedValue() expected a value of type String but received Int")
+        XCTAssertEqual("Second Option", try view.inspect().picker().selectedValue())
+    }
 }
 
 // MARK: - View Modifiers


### PR DESCRIPTION
With TextField ViewType I am able to get the current input value with .input()

I wanted to be able get the currently selected value from a Picker ViewType without the need to inject the binding attribute or have public getters on the view.

This commit allows the `selectedValue()` method of `InpsectableView<ViewType.Picker>` to get the current value that is a binding.

```
let binding = Binding<String>(wrappedValue: "First Option")
let view = Picker(selection: binding, label: Text("Title")) {
        Text("First Option").tag(0)
        Text("Second Option").tag(1)
}
try view.inspect().picker().select(value: "Second Option")
        
XCTAssertEqual("Second Option", try view.inspect().picker().selectedValue())
```