### PR TITLE
[WIP] Closures in environment block view inspection

### DIFF
--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -7,7 +7,7 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewEnvironmentTests: XCTestCase {
     
-    func testEnvironment() throws {
+    func testEnvironmentValue() throws {
         let key = TestEnvKey()
         let sut = EmptyView().environment(\.testKey, key)
         XCTAssertNoThrow(try sut.inspect().emptyView())
@@ -16,6 +16,15 @@ final class ViewEnvironmentTests: XCTestCase {
                         "EmptyView does not have 'environment(TestEnvKey)' modifier")
         let sut2 = EmptyView().environment(\.colorScheme, .light)
         XCTAssertEqual(try sut2.inspect().emptyView().environment(\.colorScheme), .light)
+    }
+
+    func testClosureEnvironmentValue() {
+        let value: (_ value: String) -> Bool = { value in value == "hello world" }
+        let sut = EmptyView().environment(\.testHandlerClosure, value)
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+        XCTAssertNoThrow(try sut.inspect().emptyView().environment(\.testHandlerClosure))
+        XCTAssertThrows(try EmptyView().inspect().emptyView().environment(\.testHandlerClosure),
+                        "EmptyView does not have 'environment((_ value: String) -> Bool)' modifier")
     }
     
     func testEnvironmentObject() throws {
@@ -42,4 +51,17 @@ private extension EnvironmentValues {
         get { self[TestEnvKey.self] }
         set { self[TestEnvKey.self] = newValue }
     }
+}
+
+private struct TestHandlerClosureKey: EnvironmentKey {
+    static var defaultValue: (_ value: String) -> Bool { { _ in true } }
+}
+
+extension EnvironmentValues {
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public var testHandlerClosure: (_ value: String) -> Bool {
+    get { self[TestHandlerClosureKey.self] }
+    set { self[TestHandlerClosureKey.self] = newValue }
+  }
 }

--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -26,6 +26,15 @@ final class ViewEnvironmentTests: XCTestCase {
         XCTAssertThrows(try EmptyView().inspect().emptyView().environment(\.testHandlerClosure),
                         "EmptyView does not have 'environment((_ value: String) -> Bool)' modifier")
     }
+
+    func testBoxedClosureEnvironmentValue() {
+        let value: HandlerBox = HandlerBox(handle: { value in value == "hello world" })
+        let sut = EmptyView().environment(\.testHandlerBoxedClosure, value)
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+        XCTAssertNoThrow(try sut.inspect().emptyView().environment(\.testHandlerBoxedClosure))
+        XCTAssertThrows(try EmptyView().inspect().emptyView().environment(\.testHandlerBoxedClosure),
+                        "EmptyView does not have 'environment(HandlerBox)' modifier")
+    }
     
     func testEnvironmentObject() throws {
         let sut = EmptyView().environmentObject(TestEnvObject())
@@ -63,5 +72,27 @@ extension EnvironmentValues {
   public var testHandlerClosure: (_ value: String) -> Bool {
     get { self[TestHandlerClosureKey.self] }
     set { self[TestHandlerClosureKey.self] = newValue }
+  }
+}
+
+public struct HandlerBox {
+
+  let handle: (_ value: String) -> Bool
+
+  public func callAsFunction(_ value: String) -> Bool {
+      handle(value)
+  }
+}
+
+private struct TestBoxedHandlerClosureKey: EnvironmentKey {
+    static var defaultValue: HandlerBox { .init(handle: { _ in false }) }
+}
+
+extension EnvironmentValues {
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public var testHandlerBoxedClosure: HandlerBox {
+    get { self[TestBoxedHandlerClosureKey.self] }
+    set { self[TestBoxedHandlerClosureKey.self] = newValue }
   }
 }


### PR DESCRIPTION
This PR is not ready to be merged. I'm finding that we can't inspect views when there is an environment value that is a closure. Boxing the closure in a struct avoids the issue. So far I do not have a fix. I've written tests to demonstrated what I described.