### PR TITLE
Fix inspecting when there is a closure environment value

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -116,19 +116,10 @@ private extension String {
     func replacingGenericParameters(_ replacement: String) -> String {
         guard let start = self.firstIndex(of: "<")
         else { return self }
-        var balance = 1
-        var current = self.index(after: start)
-        while balance > 0 && current < endIndex {
-            let char = self[current]
-            if char == "<" { balance += 1 }
-            if char == ">" { balance -= 1 }
-            current = self.index(after: current)
-        }
-        if balance == 0 {
-            return String(self[..<start]) + replacement +
-                String(self[current...]).replacingGenericParameters(replacement)
-        }
-        return self
+        guard let end = self.lastIndex(of: ">")
+        else { return self}
+
+        return String(self[..<start]) + replacement + String(self[index(after: end)...])
     }
 }
 

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -55,6 +55,8 @@ final class InspectorTests: XCTestCase {
         XCTAssertEqual(name2, "Struct1")
         let name3 = Inspector.typeName(value: Struct3<Int>(), generics: .remove)
         XCTAssertEqual(name3, "Struct3")
+        let name4 = Inspector.typeName(value: Struct3<(String) -> Void>(), generics: .remove)
+        XCTAssertEqual(name4, "Struct3")
     }
     
     func testTypeNameType() {
@@ -62,6 +64,10 @@ final class InspectorTests: XCTestCase {
         XCTAssertEqual(name1, "Struct3<Int>")
         let name2 = Inspector.typeName(type: Struct1.self)
         XCTAssertEqual(name2, "Struct1")
+        let name3 = Inspector.typeName(
+            type: ModifiedContent<EmptyView, _EnvironmentKeyWritingModifier<(String) -> Void>>.self,
+            generics: .remove)
+        XCTAssertEqual(name3, "ModifiedContent")
     }
     
     func testPrintValue() {

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -57,6 +57,8 @@ final class InspectorTests: XCTestCase {
         XCTAssertEqual(name3, "Struct3")
         let name4 = Inspector.typeName(value: Struct3<(String) -> Void>(), generics: .remove)
         XCTAssertEqual(name4, "Struct3")
+        let name5 = Inspector.typeName(value: (Struct3<Int>(), Struct3<String>()), generics: .remove)
+        XCTAssertEqual(name5, "(Struct3, Struct3)")
     }
     
     func testTypeNameType() {

--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -57,9 +57,9 @@ private struct TestHandlerClosureKey: EnvironmentKey {
     static var defaultValue: (_ value: String) -> Bool { { _ in true } }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension EnvironmentValues {
 
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   fileprivate var testHandlerClosure: (_ value: String) -> Bool {
     get { self[TestHandlerClosureKey.self] }
     set { self[TestHandlerClosureKey.self] = newValue }

--- a/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EnvironmentModifiersTests.swift
@@ -7,7 +7,7 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ViewEnvironmentTests: XCTestCase {
     
-    func testEnvironment() throws {
+    func testEnvironmentValue() throws {
         let key = TestEnvKey()
         let sut = EmptyView().environment(\.testKey, key)
         XCTAssertNoThrow(try sut.inspect().emptyView())
@@ -16,6 +16,15 @@ final class ViewEnvironmentTests: XCTestCase {
                         "EmptyView does not have 'environment(TestEnvKey)' modifier")
         let sut2 = EmptyView().environment(\.colorScheme, .light)
         XCTAssertEqual(try sut2.inspect().emptyView().environment(\.colorScheme), .light)
+    }
+
+    func testClosureEnvironmentValue() {
+        let value: (_ value: String) -> Bool = { value in value == "hello world" }
+        let sut = EmptyView().environment(\.testHandlerClosure, value)
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+        XCTAssertNoThrow(try sut.inspect().emptyView().environment(\.testHandlerClosure))
+        XCTAssertThrows(try EmptyView().inspect().emptyView().environment(\.testHandlerClosure),
+                        "EmptyView does not have 'environment((String) -> Bool)' modifier")
     }
     
     func testEnvironmentObject() throws {
@@ -42,4 +51,17 @@ private extension EnvironmentValues {
         get { self[TestEnvKey.self] }
         set { self[TestEnvKey.self] = newValue }
     }
+}
+
+private struct TestHandlerClosureKey: EnvironmentKey {
+    static var defaultValue: (_ value: String) -> Bool { { _ in true } }
+}
+
+extension EnvironmentValues {
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  fileprivate var testHandlerClosure: (_ value: String) -> Bool {
+    get { self[TestHandlerClosureKey.self] }
+    set { self[TestHandlerClosureKey.self] = newValue }
+  }
 }


### PR DESCRIPTION
## Change summary

We have noticed that applying an environment value that has a closure type to a view causes the view to become uninspectable. I've added a failing test to this PR to demonstrate this (see the test added to EnvironmentModifiersTests.swift).

After digging in, I think the cause of this is the implementation of `replacingGenericParameters(…)` in Inspector.swift. The current implementation will scan a type name string for `<` and `>` characters. When there is a generic parameter with a closure type (e.g. `SomeType<(String) -> Void>`) the scanning code gets tripped up on the `>` in the closure.

I revised the implementation of `replacingGenericParameters(…)` to only consider the first `<` and last `>`. With this change, the test that was originally failing began to pass.

## Reviewers

@nalexn when you have a chance I would love if you can take a look at this PR and see what you think!
@rafael-assis with whom I am working on using ViewInspector at our company