### PR TITLE
Fix Objective-C class EnviromentObject injection

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -110,6 +110,10 @@ private extension String {
             let end = str.index(range.upperBound, offsetBy: .init(11))
             str.replaceSubrange(range.lowerBound..<end, with: "")
         }
+
+        // For Objective-C classes String(reflecting:) sometimes adds the namespace __C, drop it too
+        str = str.replacingOccurrences(of: "__C.", with: "")
+
         return str
     }
     

--- a/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
@@ -70,7 +70,7 @@ internal extension Content {
            modifier.qualifiesAsEnvironmentModifier() {
             if let value = try? modifier.value(),
                let object = try? Inspector.attribute(label: "some", value: value, type: AnyObject.self),
-               !(object is NSObject) {
+               object is any ObservableObject {
                 medium = self.medium.appending(environmentObject: object)
             } else {
                 medium = self.medium.appending(environmentModifier: modifier)

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
@@ -163,6 +163,27 @@ final class ModifiedContentTests: XCTestCase {
         XCTAssertFalse(view2.isHidden())
         XCTAssertEqual(try view2.text().string(), "other")
     }
+
+    func testEnvironmentModifierWithNSObject() throws {
+        let view = Text("str").environment(\.font, .headline)
+        let sut = try view.inspect().text()
+        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 1)
+        XCTAssertEqual(sut.content.medium.environmentObjects.count, 0)
+    }
+
+    func testEnvironmentModifierWithNonNSObject() throws {
+        let view = Text("str").environment(\.accessibilityEnabled, true)
+        let sut = try view.inspect().text()
+        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 1)
+        XCTAssertEqual(sut.content.medium.environmentObjects.count, 0)
+    }
+
+    func testEnvironmentObjectWithNSObject() throws {
+        let view = Text("str").environmentObject(ObjcTestClass())
+        let sut = try view.inspect().text()
+        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 0)
+        XCTAssertEqual(sut.content.medium.environmentObjects.count, 1)
+    }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
@@ -94,6 +94,18 @@ class EnvironmentObjectInjectionTests: XCTestCase {
             missing EnvironmentObjects: [\"obj2: TestEnvObject2\"]
             """)
     }
+
+    func testObjcClassAsEnvironmentObject() throws {
+        var sut = EnvironmentObjectObjcClass()
+        XCTAssertThrows(try sut.inspect().find(ViewType.Text.self),
+            """
+            Search did not find a match. Possible blockers: EnvironmentObjectObjcClass is \
+            missing EnvironmentObjects: [\"obj: ObjcTestClass\"]
+            """)
+
+        sut = EnvironmentInjection.inject(environmentObject: ObjcTestClass(), into: sut)
+        XCTAssertNoThrow(try sut.inspect().find(ViewType.Text.self))
+    }
 }
 
 // MARK: -
@@ -156,6 +168,20 @@ private struct EnvironmentObjectViewModifier: ViewModifier {
         VStack {
             Text(obj1.value1 + "+\(obj2.value2)")
             content
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ObjcTestClass: ObservableObject {}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct EnvironmentObjectObjcClass: ViewModifier {
+    @EnvironmentObject var obj: ObjcTestClass
+
+    func body(content: Self.Content) -> some View {
+        VStack {
+            Text(obj.value ?? "null")
         }
     }
 }

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObjectInjectionTests.swift
@@ -105,6 +105,9 @@ class EnvironmentObjectInjectionTests: XCTestCase {
 
         sut = EnvironmentInjection.inject(environmentObject: ObjcTestClass(), into: sut)
         XCTAssertNoThrow(try sut.inspect().find(ViewType.Text.self))
+
+        let sut2 = EnvironmentObjectObjcClass().environmentObject(ObjcTestClass())
+        XCTAssertNoThrow(try sut2.inspect().find(ViewType.Text.self))
     }
 }
 
@@ -176,10 +179,10 @@ private struct EnvironmentObjectViewModifier: ViewModifier {
 extension ObjcTestClass: ObservableObject {}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-private struct EnvironmentObjectObjcClass: ViewModifier {
+private struct EnvironmentObjectObjcClass: View {
     @EnvironmentObject var obj: ObjcTestClass
 
-    func body(content: Self.Content) -> some View {
+    var body: some View {
         VStack {
             Text(obj.value ?? "null")
         }

--- a/Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.h
+++ b/Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.h
@@ -1,0 +1,15 @@
+//
+//  ObjcTestClass.h
+//  ViewInspectorTests
+//
+//  Created by Gleb Tarasov on 28/06/2023.
+//
+
+@import Foundation;
+
+@interface ObjcTestClass: NSObject
+
+@property(strong, nullable) NSString *value;
+
+@end
+

--- a/Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.m
+++ b/Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.m
@@ -1,0 +1,13 @@
+//
+//  ObjcTestClass.m
+//  ViewInspectorTests
+//
+//  Created by Gleb Tarasov on 28/06/2023.
+//
+
+#import "ObjcTestClass.h"
+
+
+@implementation ObjcTestClass
+
+@end

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		D766E67026E17F01004AAA80 /* FullScreenCoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D766E66F26E17F01004AAA80 /* FullScreenCoverTests.swift */; };
 		DD421B5F26FA6648008EFE05 /* EllipticalGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD421B5E26FA6648008EFE05 /* EllipticalGradientTests.swift */; };
 		DDCA44AD26FA64F500138898 /* EllipticalGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCA44AC26FA64F500138898 /* EllipticalGradient.swift */; };
+		E30CF98C2A4C81F500E2F1CA /* ObjcTestClass.m in Sources */ = {isa = PBXBuildFile; fileRef = E30CF98B2A4C81F500E2F1CA /* ObjcTestClass.m */; };
 		F6026A27256A7D1900CA31E5 /* TextAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A26256A7D1900CA31E5 /* TextAttributes.swift */; };
 		F6026A31256A7E3D00CA31E5 /* TextAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */; };
 		F60385D523D3C74B008F31BD /* InspectionEmissary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60385D423D3C74B008F31BD /* InspectionEmissary.swift */; };
@@ -378,6 +379,8 @@
 		D766E66F26E17F01004AAA80 /* FullScreenCoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCoverTests.swift; sourceTree = "<group>"; };
 		DD421B5E26FA6648008EFE05 /* EllipticalGradientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EllipticalGradientTests.swift; sourceTree = "<group>"; };
 		DDCA44AC26FA64F500138898 /* EllipticalGradient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EllipticalGradient.swift; sourceTree = "<group>"; };
+		E30CF98B2A4C81F500E2F1CA /* ObjcTestClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcTestClass.m; sourceTree = "<group>"; };
+		E30CF98D2A4C820E00E2F1CA /* ObjcTestClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcTestClass.h; sourceTree = "<group>"; };
 		F6026A26256A7D1900CA31E5 /* TextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributes.swift; sourceTree = "<group>"; };
 		F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributesTests.swift; sourceTree = "<group>"; };
 		F60385D423D3C74B008F31BD /* InspectionEmissary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectionEmissary.swift; sourceTree = "<group>"; };
@@ -859,6 +862,8 @@
 				F6D933B42385ED2700358E0E /* VSplitViewTests.swift */,
 				F60EEBF02382F004007DB53A /* VStackTests.swift */,
 				F60EEBE72382F004007DB53A /* ZStackTests.swift */,
+				E30CF98D2A4C820E00E2F1CA /* ObjcTestClass.h */,
+				E30CF98B2A4C81F500E2F1CA /* ObjcTestClass.m */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -1280,6 +1285,7 @@
 				F6DFD88623830EB80028E84D /* ListTests.swift in Sources */,
 				F682A00C254772C3005F1B70 /* DisclosureGroupTests.swift in Sources */,
 				CDA844BC262B7EA800C56C98 /* MagnificationGestureTests.swift in Sources */,
+				E30CF98C2A4C81F500E2F1CA /* ObjcTestClass.m in Sources */,
 				F6C15A3F254B4835000240F1 /* LinkTests.swift in Sources */,
 				5296338C29697EB400EC6C81 /* NavigationSplitViewTests.swift in Sources */,
 				F6ECF6D823A69CB5000FC591 /* VisualEffectModifiersTests.swift in Sources */,
@@ -1619,6 +1625,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = ViewInspectorTests;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_OBJC_BRIDGING_HEADER = Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.h;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ViewInspectorTests;
 			};
@@ -1647,6 +1654,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = ViewInspectorTests;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_OBJC_BRIDGING_HEADER = Tests/ViewInspectorTests/SwiftUI/ObjcTestClass.h;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ViewInspectorTests;
 			};


### PR DESCRIPTION
Inspection of SwiftUI views with Objective-C classes injected as EnvrionmentObjects doesn't work.

When we take `String(reflecting:)` for `EnvironmentObject<SomeObjcClass>` it returns `EnvironmentObject<SomeObjcClass>` in some cases, and `EnvironmentObject<__C.SomeObjcClass>` in other cases.

That is the reason `EnvironmentInjection.inject` cannot inject the value because of the mismatch in type names.

The second problem is the check for `NSObject` when we determine if this is `environment()` modifier or `enviromentObject()`. Changed it to the check for `ObservableObject`, because any `enviromentObject` should be observable.
