### PR TITLE
Add inspection support for ViewThatFits.

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -298,6 +298,12 @@ internal extension Inspector {
             return try ViewType.PreferenceReadingView.child(content)
         case "PopoverContent":
             return try ViewType.PopoverContent.child(content)
+        case "ViewThatFits":
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+                return try ViewType.ViewThatFits.child(content)
+            } else {
+                return content
+            }
         default:
             return content
         }

--- a/Sources/ViewInspector/SwiftUI/ViewThatFits.swift
+++ b/Sources/ViewInspector/SwiftUI/ViewThatFits.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+internal extension ViewType {
+    struct ViewThatFits {}
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+extension ViewType.ViewThatFits: SingleViewContent {
+
+    static func child(_ content: Content) throws -> Content {
+        let view: Any = try {
+            guard let rootContent = try? Inspector.attribute(path: "_tree|content", value: content.view) else {
+                // A ViewThatFits View renders only one of its child Views based on the available horizontal space.
+                // This inspection returns all children that can potentially be picked by `ViewThatFits`.
+                // https://developer.apple.com/documentation/swiftui/viewthatfits
+                return try Inspector.attribute(path: "content", value: content.view)
+            }
+
+            return rootContent
+        }()
+        return try Inspector.unwrap(view: view, medium: content.medium)
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/ViewThatFitsTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ViewThatFitsTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import SwiftUI
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+final class ViewThatFitsTests: XCTestCase {
+    func testAllEnclosedChildTextViews() throws {
+        let sut = TestViewThatFits()
+        let longText = try sut.inspect().find(text: "Very long text that will only get picked if there is available space.")
+        let shortText = try sut.inspect().find(text: "Short text")
+
+        XCTAssertEqual(try longText.string(), "Very long text that will only get picked if there is available space.")
+        XCTAssertEqual(try shortText.string(), "Short text")
+    }
+}
+
+// MARK: - TestViewThatFits
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+struct TestViewThatFits: View {
+    var body: some View {
+        ViewThatFits {
+            Text("Very long text that will only get picked if there is available space.")
+            Text("Short text")
+        }
+    }
+}

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		DD421B5F26FA6648008EFE05 /* EllipticalGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD421B5E26FA6648008EFE05 /* EllipticalGradientTests.swift */; };
 		DDCA44AD26FA64F500138898 /* EllipticalGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCA44AC26FA64F500138898 /* EllipticalGradient.swift */; };
 		E30CF98C2A4C81F500E2F1CA /* ObjcTestClass.m in Sources */ = {isa = PBXBuildFile; fileRef = E30CF98B2A4C81F500E2F1CA /* ObjcTestClass.m */; };
+		EDC6031B2A95256C0072E420 /* ViewThatFits.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC603162A951BE00072E420 /* ViewThatFits.swift */; };
+		EDC6031C2A95260E0072E420 /* ViewThatFitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC603182A9521DF0072E420 /* ViewThatFitsTests.swift */; };
 		F6026A27256A7D1900CA31E5 /* TextAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A26256A7D1900CA31E5 /* TextAttributes.swift */; };
 		F6026A31256A7E3D00CA31E5 /* TextAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */; };
 		F60385D523D3C74B008F31BD /* InspectionEmissary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60385D423D3C74B008F31BD /* InspectionEmissary.swift */; };
@@ -381,6 +383,8 @@
 		DDCA44AC26FA64F500138898 /* EllipticalGradient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EllipticalGradient.swift; sourceTree = "<group>"; };
 		E30CF98B2A4C81F500E2F1CA /* ObjcTestClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcTestClass.m; sourceTree = "<group>"; };
 		E30CF98D2A4C820E00E2F1CA /* ObjcTestClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcTestClass.h; sourceTree = "<group>"; };
+		EDC603162A951BE00072E420 /* ViewThatFits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewThatFits.swift; sourceTree = "<group>"; };
+		EDC603182A9521DF0072E420 /* ViewThatFitsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewThatFitsTests.swift; sourceTree = "<group>"; };
 		F6026A26256A7D1900CA31E5 /* TextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributes.swift; sourceTree = "<group>"; };
 		F6026A30256A7E3D00CA31E5 /* TextAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributesTests.swift; sourceTree = "<group>"; };
 		F60385D423D3C74B008F31BD /* InspectionEmissary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectionEmissary.swift; sourceTree = "<group>"; };
@@ -739,6 +743,7 @@
 				F653BDE2255698A6001FA688 /* TupleView.swift */,
 				5236C34226CDC2F4007432E1 /* UnaryViewAdaptor.swift */,
 				523CD47F277C98FC00D4FD3A /* VideoPlayer.swift */,
+				EDC603162A951BE00072E420 /* ViewThatFits.swift */,
 				F6D933B22385ED1400358E0E /* VSplitView.swift */,
 				F60EEBC92382EED0007DB53A /* VStack.swift */,
 				F60EEBC12382EED0007DB53A /* ZStack.swift */,
@@ -860,6 +865,7 @@
 				F653BDEC25569D2E001FA688 /* TupleViewTests.swift */,
 				523CD47D277C882E00D4FD3A /* VideoPlayerTests.swift */,
 				F6D933B42385ED2700358E0E /* VSplitViewTests.swift */,
+				EDC603182A9521DF0072E420 /* ViewThatFitsTests.swift */,
 				F60EEBF02382F004007DB53A /* VStackTests.swift */,
 				F60EEBE72382F004007DB53A /* ZStackTests.swift */,
 				E30CF98D2A4C820E00E2F1CA /* ObjcTestClass.h */,
@@ -1194,6 +1200,7 @@
 				F66EDB5B23EDC19000A01B9F /* Spacer.swift in Sources */,
 				F639DBBF23A6CF03003A6FED /* AccessibilityModifiers.swift in Sources */,
 				F6D933AB2385EAD400358E0E /* GroupBox.swift in Sources */,
+				EDC6031B2A95256C0072E420 /* ViewThatFits.swift in Sources */,
 				F6D933CB2385FF8F00358E0E /* Slider.swift in Sources */,
 				F6A35A5425B366E90068B8B2 /* InspectableView+RandomAccessCollection.swift in Sources */,
 				522090522776401C001A899A /* LocationButton.swift in Sources */,
@@ -1292,6 +1299,7 @@
 				F6DB5A0B253510CC0056FC83 /* TextInputModifiersTests.swift in Sources */,
 				F609EFC323A4342400B9256A /* PreferenceTests.swift in Sources */,
 				F6F08E6423A29FA1001F04DF /* SubscriptionViewTests.swift in Sources */,
+				EDC6031C2A95260E0072E420 /* ViewThatFitsTests.swift in Sources */,
 				F6D933AD2385EB0100358E0E /* GroupBoxTests.swift in Sources */,
 				F6ECF6D223A680DA000FC591 /* TransformingModifiersTests.swift in Sources */,
 				CDA84502262B885600C56C98 /* CommonComposedGestureTests.swift in Sources */,


### PR DESCRIPTION
## Changes

Similar to the issue fixed by #228, this change aims to fix blocking inspection for Views that are nested inside a [ViewThatFits](https://developer.apple.com/documentation/swiftui/viewthatfits) View.

`ViewThatFits` has a structure similar to a `TreeView` and needs to be inspected for its `content` property for ViewInspector to find its children.

<img width="580" alt="ViewThatFits_debugger" src="https://github.com/nalexn/ViewInspector/assets/2278022/c31cf972-9630-4103-bd14-75ff587f8bd1">

## Discussion

This is a first step that unblocks the inspection of children Views of `ViewThatFits`.

However, the [documented](https://developer.apple.com/documentation/swiftui/viewthatfits) behavior of this View states that only one of its children will be provided (rendered) based on horizontal space. Implementing inspection in a way that all children Views are returned may be problematic as all children are likely going to be similar in content, labels and accessibility traits.

This can potentially cause multiple Views returned in an inspection done with a `findAll(where:)` call.

I will investigate the possibility of hosting the `ViewThatFits` View inside a `ViewHosting` View and validate whether only one of the children view is available. That will be the scenario that is the closest to SwiftUI running on a real simulator/device.

Another suggestion we're considering is the addition of a capability that enables the test code to pick an index of the child view wanted. Alternatively we can just always default to the first child in the `ViewThatFits`.

@nalexn we'd love to have your thoughts and recommendations on this.

## Testing

I added a test to explicitly find 2 children Views inside a `ViewThatFits`, which enforces the behavior being proposed in this PR.

## Review
@bachand 
@nalexn 