### PR TITLE
[iOS 17 perf degradation fix] Changing sanitizingNamespace implementation to use regular expression pattern matching.

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -110,10 +110,15 @@ internal extension Inspector {
 private extension String {
     func sanitizingNamespace() -> String {
         var str = self
-        while let range = str.range(of: ".(unknown context at ") {
-            let end = str.index(range.upperBound, offsetBy: .init(11))
-            str.replaceSubrange(range.lowerBound..<end, with: "")
-        }
+
+        let pattern = "\\.\\(unknown context at ..........\\)"
+        let regex = try! NSRegularExpression(pattern: pattern)
+        let range = NSRange(location: 0, length: str.utf16.count)
+        str = regex.stringByReplacingMatches(
+          in: str,
+          options: [],
+          range: range,
+          withTemplate: "")
 
         // For Objective-C classes String(reflecting:) sometimes adds the namespace __C, drop it too
         str = str.replacingOccurrences(of: "<__C.", with: "<")


### PR DESCRIPTION
Hi @nalexn. we have identified this iOS 17.0 issue here at Airbnb and we'd love to get your input.
I believe we have a good solution (described below). Let myself and @bachand know your thoughts on it.
Thank you! 🙏 

## Context: performance degradation on iOS 17.0

On our validation exercises to adopt Xcode 15 in the Airbnb development environment, we noticed a **significant degradation in performance** when running tests that used ViewInspector.

We identified that that degradation only happened when running against an **iOS 17.0 simulator**.
We measured the multiple sets of tests running from Xcode 15 and comparing results between 2 iPhone 14 simulators, one running iOS 16.4 the other running iOS 17.0.
Overall we could see same sets of **tests running against iOS 17.0 would take around 3x longer** compared to the runs against iOS 16.4.

Measuring execution times of the full call stack we noticed that the logic of replacing strings like ".(unknown context at $1541f4030)" from the type name in `sanitizingNamespace()` was one of the top offenders.
In large hierarchies and tests that heavily relied on `find()` and `findAll()` calls, `sanitizingNamespace()` could get called more than 30,000 times for a single run. 

In those particular scenarios, the aggregated time spent on the all executions of `sanitizingNamespace()`got close to 8x slower when running on iOS 17.0 compared to the same runs on iOS 16.4.

## Changes

We have experimented a different approach for the logic that replaces those ".(unknown context at " strings from the namespaces that uses pattern matching with the `NSRegularExpression` type.

The results on our test runs with against larger view hierarchies showed that this new implementation has similar run times on iOS 16.4 as the previous implementations. On iOS 17.0 it improved dramatically by matching the times of iOS 16.4 and some times even showing slightly better performance on these measured run times. 

## Testing

The full set of ViewInspector tests was executed before and after the fix in both iOS 16.4 and iOS 17.0.
The scenario for those tests is pretty lightweight, which made the tests run times vary a little, but no degradation was detected in either iOS versions:

| | Before | After |
| --- | --- | ----- |
| iOS 16.4 | 4.486 seconds <img width="1105" alt="ViewInspector_iOS16_4_before" src="https://github.com/nalexn/ViewInspector/assets/2278022/dc271d58-079a-4f12-baad-a7a7c73da958"> | 4.608 seconds <img width="1149" alt="ViewInspector_iOS16_4_after" src="https://github.com/nalexn/ViewInspector/assets/2278022/9d1a1569-a3d0-4cdb-be8a-01cf4e255a62"> |
| iOS 17.0 | 5.336 seconds <img width="1149" alt="ViewInspector_iOS17_0_before" src="https://github.com/nalexn/ViewInspector/assets/2278022/3152a394-bcea-4563-9a29-c91ea9021e0f"> | 4.929 seconds <img width="1105" alt="ViewInspector_iOS17_0_after" src="https://github.com/nalexn/ViewInspector/assets/2278022/68607e74-40ec-4c59-bbd8-c2bb0c1fe5c1"> |

## Review
@bachand 
@nalexn 