### PR TITLE
Add support for `ignoresSafeArea()`

### DIFF
--- a/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
@@ -30,6 +30,20 @@ public extension InspectableView {
     }
 }
 
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+public extension InspectableView {
+
+    func ignoresSafeArea() throws -> (regions: SafeAreaRegions, edges: Edge.Set) {
+        let regions = try modifierAttribute(
+            modifierName: "_SafeAreaRegionsIgnoringLayout", path: "modifier|regions",
+            type: SafeAreaRegions.self, call: "ignoresSafeArea(_:edges:)")
+        let edges = try modifierAttribute(
+            modifierName: "_SafeAreaRegionsIgnoringLayout", path: "modifier|edges",
+            type: Edge.Set.self, call: "ignoresSafeArea(_:edges:)")
+        return (regions, edges)
+    }
+}
+
 // MARK: - ViewLayering
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
@@ -76,6 +76,29 @@ final class ViewPositioningTests: XCTestCase {
             .inspect().emptyView().coordinateSpaceName()
         XCTAssertEqual(sut, name)
     }
+
+    func testIgnoresSafeArea() throws {
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        else { throw XCTSkip() }
+        let sut = EmptyView().ignoresSafeArea()
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testIgnoresSafeAreaInspection() throws {
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        else { throw XCTSkip() }
+        let sut = try EmptyView().ignoresSafeArea(.container, edges: .bottom).inspect().emptyView().ignoresSafeArea()
+        XCTAssertEqual(sut.regions, .container)
+        XCTAssertEqual(sut.edges, .bottom)
+    }
+
+    func testIgnoresSafeAreaDefaultsInspection() throws {
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        else { throw XCTSkip() }
+        let sut = try EmptyView().ignoresSafeArea().inspect().emptyView().ignoresSafeArea()
+        XCTAssertEqual(sut.regions, .all)
+        XCTAssertEqual(sut.edges, .all)
+    }
 }
 
 // MARK: - ViewAligningTests


### PR DESCRIPTION
This PR adds support for the `ignoresSafeArea(_:edges:)` view modifier.