### PR TITLE
Add support for `navigationDestination(isPresented:destination:)`

### DIFF
--- a/Sources/ViewInspector/SwiftUI/NavigationDestination.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationDestination.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension ViewType {
+
+    struct NavigationDestination: KnownViewType {
+        public static var typePrefix: String = "ViewDestinationNavigationDestinationModifier"
+        public static func inspectionCall(typeName: String) -> String {
+            return "navigationDestination(\(ViewType.indexPlaceholder))"
+        }
+    }
+}
+
+// MARK: - Extraction
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+public extension InspectableView {
+
+    func navigationDestination(_ index: Int? = nil) throws -> InspectableView<ViewType.NavigationDestination> {
+        return try contentForModifierLookup.navigationDestination(parent: self, index: index)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension Content {
+
+    func navigationDestination(parent: UnwrappedView, index: Int?) throws
+    -> InspectableView<ViewType.NavigationDestination> {
+        let modifier = try self.modifierAttribute(
+            modifierLookup: isNavigationDestination(modifier:), path: "modifier",
+            type: Any.self, call: "navigationDestination", index: index ?? 0)
+        let medium = self.medium.resettingViewModifiers()
+        let content = Content(modifier, medium: medium)
+        let call = ViewType.inspectionCall(
+            base: ViewType.NavigationDestination.inspectionCall(typeName: ""), index: index)
+        let view = try InspectableView<ViewType.NavigationDestination>(
+            content, parent: parent, call: call, index: index)
+        guard try view.content.isDestinationPresented() else {
+            throw InspectionError.viewNotFound(parent: "NavigationDestination")
+        }
+        return view
+    }
+
+    private func isNavigationDestination(modifier: Any) -> Bool {
+        guard let modifier = modifier as? ModifierNameProvider
+        else { return false }
+        return modifier.modifierType.contains(ViewType.NavigationDestination.typePrefix)
+    }
+}
+
+// MARK: - Non Standard Children
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.NavigationDestination: SingleViewContent {
+
+    public static func child(_ content: Content) throws -> Content {
+        return try children(content).element(at: 0)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.NavigationDestination: MultipleViewContent {
+
+    public static func children(_ content: Content) throws -> LazyGroup<Content> {
+        if let isPresented = try? content.isDestinationPresented(), !isPresented {
+            throw InspectionError.viewNotFound(parent: "NavigationDestination's destination")
+        }
+        let view = try Inspector.attribute(label: "destination", value: content.view)
+        return try Inspector.viewsInContainer(view: view, medium: content.medium)
+    }
+}
+
+// MARK: - Custom Attributes
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectableView where View == ViewType.NavigationDestination {
+
+    func isPresented() throws -> Bool {
+        try content.isPresentedBinding().wrappedValue
+    }
+
+    func set(isPresented: Bool) throws {
+        try content.isPresentedBinding().wrappedValue = isPresented
+    }
+}
+
+// MARK: - Private
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private extension Content {
+
+    func isDestinationPresented() throws -> Bool {
+        try isPresentedBinding().wrappedValue
+    }
+
+    func isPresentedBinding() throws -> Binding<Bool> {
+        try Inspector
+            .attribute(label: "_isPresented", value: view, type: Binding<Bool>.self)
+    }
+}

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -50,6 +50,7 @@ internal extension ViewSearch {
             ViewType.Menu.self,
             ViewType.MenuButton.self,
             ViewType.MultiDatePicker.self,
+            ViewType.NavigationDestination.self,
             ViewType.NavigationLink.self,
             ViewType.NavigationView.self,
             ViewType.NavigationSplitView.self,
@@ -341,6 +342,9 @@ internal extension ViewSearch {
         }),
         .init(name: ViewType.ConfirmationDialog.typePrefix, builder: { parent, index in
             try parent.content.confirmationDialog(parent: parent, index: index)
+        }),
+        .init(name: ViewType.NavigationDestination.typePrefix, builder: { parent, index in
+            try parent.content.navigationDestination(parent: parent, index: index)
         }),
         .init(name: ViewType.SafeAreaInset.typePrefix, builder: { parent, index in
             try parent.content.safeAreaInset(parent: parent, index: index)

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationDestinationTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationDestinationTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class NavigationDestinationTests: XCTestCase {
+
+    func testInspectionNotBlocked() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().navigationDestination(isPresented: binding, destination: { EmptyView() })
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+    
+    func testInspectionErrorNoModifier() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let sut = EmptyView().offset()
+        XCTAssertThrows(try sut.inspect().emptyView().navigationDestination(),
+                        "EmptyView does not have 'navigationDestination' modifier")
+    }
+    
+    func testInspectionErrorWhenNotPresented() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: false)
+        let sut = EmptyView().navigationDestination(isPresented: binding, destination: { EmptyView() })
+        XCTAssertThrows(try sut.inspect().emptyView().navigationDestination(),
+                        "View for NavigationDestination is absent")
+    }
+    
+    func testSimpleUnwrap() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().navigationDestination(isPresented: binding, destination: { EmptyView() })
+        XCTAssertEqual(try sut.inspect().emptyView().navigationDestination().pathToRoot,
+                       "emptyView().navigationDestination()")
+    }
+
+    func testDestinationInspection() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().navigationDestination(isPresented: binding, destination: { EmptyView() })
+        let destination = try sut.inspect().emptyView().navigationDestination().emptyView()
+        XCTAssertEqual(destination.pathToRoot,
+                       "emptyView().navigationDestination().emptyView()")
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationDestinationTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationDestinationTests.swift
@@ -48,4 +48,12 @@ final class NavigationDestinationTests: XCTestCase {
         XCTAssertEqual(destination.pathToRoot,
                        "emptyView().navigationDestination().emptyView()")
     }
+
+    func testDestinationSearch() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = Color.blue.navigationDestination(isPresented: binding, destination: { Text("abc") })
+        XCTAssertNoThrow(try sut.inspect().find(text: "abc"))
+    }
 }

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1FA29F102AF0503000CCE6FA /* NavigationDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */; };
+		1FA29F132AF051AD00CCE6FA /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */; };
 		355B2D57BFF536BCD0B555B8 /* ViewPaddingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B2B0F773087003E9F5A49 /* ViewPaddingTests.swift */; };
 		520E915C26E64F210090BD1F /* EnvironmentInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520E915B26E64F210090BD1F /* EnvironmentInjection.swift */; };
 		520E916226E69E540090BD1F /* PopupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520E916126E69E540090BD1F /* PopupPresenter.swift */; };
@@ -307,6 +309,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestinationTests.swift; sourceTree = "<group>"; };
+		1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
 		355B2B0F773087003E9F5A49 /* ViewPaddingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPaddingTests.swift; sourceTree = "<group>"; };
 		520E915B26E64F210090BD1F /* EnvironmentInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentInjection.swift; sourceTree = "<group>"; };
 		520E916126E69E540090BD1F /* PopupPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPresenter.swift; sourceTree = "<group>"; };
@@ -720,6 +724,7 @@
 				F6C15A70254B68C0000240F1 /* Menu.swift */,
 				F6684BEF23AA504500DECCB3 /* MenuButton.swift */,
 				523E973C2A9B25FD002E8EB5 /* MultiDatePicker.swift */,
+				1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */,
 				F6D9339E2385B46A00358E0E /* NavigationLink.swift */,
 				5296338929697C7D00EC6C81 /* NavigationSplitView.swift */,
 				529633852969672A00EC6C81 /* NavigationStack.swift */,
@@ -846,6 +851,7 @@
 				F6C15A6A254B669F000240F1 /* MenuTests.swift */,
 				F6684BED23AA4CF400DECCB3 /* MenuButtonTests.swift */,
 				523E973E2A9B2616002E8EB5 /* MultiDatePickerTests.swift */,
+				1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */,
 				F6D933A02385B48100358E0E /* NavigationLinkTests.swift */,
 				5296338B29697EB400EC6C81 /* NavigationSplitViewTests.swift */,
 				52963387296967ED00EC6C81 /* NavigationStackTests.swift */,
@@ -1179,6 +1185,7 @@
 				F653BDE3255698A6001FA688 /* TupleView.swift in Sources */,
 				F60EEBDE2382EED0007DB53A /* ForEach.swift in Sources */,
 				F6C15A0D254A05A4000240F1 /* LazyVGrid.swift in Sources */,
+				1FA29F132AF051AD00CCE6FA /* NavigationDestination.swift in Sources */,
 				5250764B2651800800ADE4E7 /* ActionSheet.swift in Sources */,
 				F60EEBCD2382EED0007DB53A /* Inspector.swift in Sources */,
 				F64105C4257BF9A70033D82D /* ViewSearch.swift in Sources */,
@@ -1295,6 +1302,7 @@
 				F6ECF6D023A67D11000FC591 /* SizingModifiersTests.swift in Sources */,
 				F60EEBFF2382F004007DB53A /* DividerTests.swift in Sources */,
 				F639DBC523A7DFA6003A6FED /* TouchBarTests.swift in Sources */,
+				1FA29F102AF0503000CCE6FA /* NavigationDestinationTests.swift in Sources */,
 				F67540EF23A3D8B30022AC33 /* PositioningModifiersTests.swift in Sources */,
 				F6D933B52385ED2700358E0E /* VSplitViewTests.swift in Sources */,
 				52B71AA626EB5BED00B719D4 /* SafeAreaInsetTests.swift in Sources */,


### PR DESCRIPTION
As `NavigationLink(isPresented:destination:label:)` & similar are deprecated, add support for `.navigationDestination(isPresented:destination:)`