### PR TITLE
[Perf improvement] Implementing memoization for sanitizeNamespace and replaceGenericParameters funcs.

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -5,8 +5,8 @@ public struct Inspector {
 
     /// Removes the "(unknown context at <memory_address>)" portion of a type name.
     /// Calls to this method are memoized and retained for the lifetime of the program.
-    /// - Parameter typeName: The raw type name. (e.g. ``SomeTypeName.(unknown context at $138b3290c).SomePropertyName``)
-    /// - Returns: The sanitized type name. (e.g. ``SomeTypeName.SomePropertyName``)
+    /// - Parameter typeName: The raw type name. (e.g. `SomeTypeName.(unknown context at $138b3290c).SomePropertyName`)
+    /// - Returns: The sanitized type name. (e.g. `SomeTypeName.SomePropertyName`)
     static func sanitizeNamespace(ofTypeName typeName: String) -> String {
         var str = typeName
 
@@ -32,9 +32,9 @@ public struct Inspector {
     /// Replaces the generic types of a given type name with a string.
     /// Calls to this method are memoized and retained for the lifetime of the program.
     /// - Parameters:
-    ///   - typeName: The original type name. (e.g. ``SomeTypeName<SomeGenericTypeParameter>``)
+    ///   - typeName: The original type name. (e.g. `SomeTypeName<SomeGenericTypeParameter>`)
     ///   - replacement: The string to replace the generic parameters with. (e.g. "<EmptyView>")
-    /// - Returns: The type name with its generic parameters replaced. (e.g. ``SomeTypeName<EmptyView>``)
+    /// - Returns: The type name with its generic parameters replaced. (e.g. `SomeTypeName<EmptyView>`)
     static func replaceGenericParameters(inTypeName typeName: String,
                                          withReplacement replacement: String) -> String {
         // Check memoized value
@@ -96,11 +96,11 @@ public struct Inspector {
     private static var sanitizedNamespacesCache: [String: String] = [:]
 
     private static let sanitizeNamespacePatterns = [
-        "\\.\\(unknown context at ..........\\)",
+        "(\\.\\(unknown context at ..........\\))",
         // This pattern may be helpful to solve issue #268.
         // It will remain disabled until it is confirmed.
         // https://github.com/nalexn/ViewInspector/issues/268
-        //"\\(extension in [a-zA-Z0-9]*\\)\\:",
+        //"(\\(extension in [a-zA-Z0-9]*\\)\\:)",
     ]
 
     private static let sanitizeNamespaceRegex = {

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -1,18 +1,115 @@
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public struct Inspector { }
+public struct Inspector {
+
+    /// Removes the "(unknown context at <memory_address>)" portion of a type name.
+    /// Calls to this method are memoized and retained for the lifetime of the program.
+    /// - Parameter typeName: The raw type name. (e.g. ``SomeTypeName.(unknown context at $138b3290c).SomePropertyName``)
+    /// - Returns: The sanitized type name. (e.g. ``SomeTypeName.SomePropertyName``)
+    static func sanitizeNamespace(ofTypeName typeName: String) -> String {
+        var str = typeName
+
+        if let sanitized = sanitizedNamespacesCache[typeName] {
+            return sanitized
+        }
+
+        let range = NSRange(location: 0, length: str.utf16.count)
+        str = sanitizeNamespaceRegex.stringByReplacingMatches(in: str,
+                                                              options: [],
+                                                              range: range,
+                                                              withTemplate: "")
+
+        // For Objective-C classes String(reflecting:) sometimes adds the namespace __C, drop it too
+        str = str.replacingOccurrences(of: "<__C.", with: "<")
+
+        Inspector.sanitizedNamespacesCache[typeName] = str
+
+        return str
+
+    }
+
+    /// Replaces the generic types of a given type name with a string.
+    /// Calls to this method are memoized and retained for the lifetime of the program.
+    /// - Parameters:
+    ///   - typeName: The original type name. (e.g. ``SomeTypeName<SomeGenericTypeParameter>``)
+    ///   - replacement: The string to replace the generic parameters with. (e.g. "<EmptyView>")
+    /// - Returns: The type name with its generic parameters replaced. (e.g. ``SomeTypeName<EmptyView>``)
+    static func replaceGenericParameters(inTypeName typeName: String,
+                                         withReplacement replacement: String) -> String {
+        // Check memoized value
+        if let typeNameDict = Inspector.replacedGenericParametersCache[typeName],
+           let cachedResult = typeNameDict[replacement] {
+            return cachedResult
+        }
+
+        // Compute value
+        let result = computeReplacementOfGenericParameters(inTypeName: typeName,
+                                                           withReplacement: replacement)
+
+        // Store memoized value
+        var typeNameDict = Inspector.replacedGenericParametersCache[typeName] ?? [:]
+        typeNameDict[replacement] = result
+        Inspector.replacedGenericParametersCache[typeName] = typeNameDict
+
+        return result
+    }
+
+    private static func computeReplacementOfGenericParameters(inTypeName typeName: String,
+                                                              withReplacement replacement: String) -> String {
+        guard let start = typeName.firstIndex(of: "<") else {
+            return typeName
+        }
+
+        var balance = 1
+        var current = typeName.index(after: start)
+        while balance > 0 && current < typeName.endIndex {
+            let char = typeName[current]
+            if char == "<" { balance += 1 }
+            if char == ">" {
+                guard let indexOfPreviousChar = typeName.index(current,
+                                                               offsetBy: -1,
+                                                               limitedBy: typeName.startIndex) else {
+                    return typeName
+                }
+                let previousChar = typeName[indexOfPreviousChar]
+                if previousChar == "-" {
+                    // We've found the "->" arrow for a closure type. Ignore this ">".
+                } else {
+                    balance -= 1
+                }
+            }
+            current = typeName.index(after: current)
+        }
+
+        if balance == 0 {
+            return String(typeName[..<start]) +
+            replacement +
+            replaceGenericParameters(inTypeName: String(typeName[current...]),
+                                     withReplacement: replacement)
+        }
+
+        return typeName
+    }
+
+    private static var replacedGenericParametersCache: [String : [String : String]] = [:]
+    private static var sanitizedNamespacesCache: [String: String] = [:]
+
+    // swiftlint:disable force_try
+    private static let sanitizeNamespaceRegex = try! NSRegularExpression(pattern: "\\.\\(unknown context at ..........\\)")
+    // swiftlint:enable force_try
+}
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension Inspector {
-    
+
     static func attribute(label: String, value: Any) throws -> Any {
         if label == "super", let superclass = Mirror(reflecting: value).superclassMirror {
             return superclass
         }
         return try attribute(label: label, value: value, type: Any.self)
     }
-    
+
     static func attribute<T>(label: String, value: Any, type: T.Type) throws -> T {
         let mirror = (value as? Mirror) ?? Mirror(reflecting: value)
         guard let child = mirror.descendant(label) else {
@@ -21,11 +118,11 @@ internal extension Inspector {
         }
         return try cast(value: child, type: T.self)
     }
-    
+
     static func attribute(path: String, value: Any) throws -> Any {
         return try attribute(path: path, value: value, type: Any.self)
     }
-    
+
     static func attribute<T>(path: String, value: Any, type: T.Type) throws -> T {
         let labels = path.components(separatedBy: "|")
         let child = try labels.reduce(value, { (value, label) -> Any in
@@ -33,14 +130,14 @@ internal extension Inspector {
         })
         return try cast(value: child, type: T.self)
     }
-    
+
     static func cast<T>(value: Any, type: T.Type) throws -> T {
         guard let casted = value as? T else {
             throw InspectionError.typeMismatch(value, T.self)
         }
         return casted
     }
-    
+
     static func unsafeMemoryRebind<V, T>(value: V, type: T.Type) throws -> T {
         guard MemoryLayout<V>.size == MemoryLayout<T>.size else {
             throw InspectionError.notSupported(
@@ -55,13 +152,13 @@ internal extension Inspector {
                 .assumingMemoryBound(to: T.self).pointee
         }
     }
-    
+
     enum GenericParameters {
         case keep
         case remove
         case customViewPlaceholder
     }
-    
+
     static func typeName(value: Any,
                          namespaced: Bool = false,
                          generics: GenericParameters = .keep) -> String {
@@ -72,17 +169,17 @@ internal extension Inspector {
         return typeName(type: type(of: value), namespaced: namespaced,
                         generics: generics)
     }
-    
+
     static func isSystemType(value: Any) -> Bool {
         let name = typeName(value: value, namespaced: true)
         return isSystemType(name: name)
     }
-    
+
     static func isSystemType(type: Any.Type) -> Bool {
         let name = typeName(type: type, namespaced: true)
         return isSystemType(name: name)
     }
-    
+
     private static func isSystemType(name: String) -> Bool {
         return [
             String.swiftUINamespaceRegex, "Swift\\.",
@@ -90,68 +187,22 @@ internal extension Inspector {
             "_AuthenticationServices_SwiftUI\\.", "_AVKit_SwiftUI\\.",
         ].containsPrefixRegex(matching: name, wholeMatch: false)
     }
-    
+
     static func typeName(type: Any.Type,
                          namespaced: Bool = false,
                          generics: GenericParameters = .keep) -> String {
-        let typeName = namespaced ? String(reflecting: type).sanitizingNamespace() : String(describing: type)
+        let typeName = namespaced ? sanitizeNamespace(ofTypeName: String(reflecting: type)) : String(describing: type)
         switch generics {
         case .keep:
             return typeName
         case .remove:
-            return typeName.replacingGenericParameters("")
+            return replaceGenericParameters(inTypeName: typeName,
+                                            withReplacement: "")
         case .customViewPlaceholder:
             let parameters = ViewType.customViewGenericsPlaceholder
-            return typeName.replacingGenericParameters(parameters)
+            return replaceGenericParameters(inTypeName: typeName,
+                                            withReplacement: parameters)
         }
-    }
-}
-
-private extension String {
-    func sanitizingNamespace() -> String {
-        var str = self
-
-        let pattern = "\\.\\(unknown context at ..........\\)"
-        // swiftlint:disable force_try
-        let regex = try! NSRegularExpression(pattern: pattern)
-        // swiftlint:enable force_try
-        let range = NSRange(location: 0, length: str.utf16.count)
-        str = regex.stringByReplacingMatches(
-          in: str,
-          options: [],
-          range: range,
-          withTemplate: "")
-
-        // For Objective-C classes String(reflecting:) sometimes adds the namespace __C, drop it too
-        str = str.replacingOccurrences(of: "<__C.", with: "<")
-
-        return str
-    }
-    
-    func replacingGenericParameters(_ replacement: String) -> String {
-        guard let start = self.firstIndex(of: "<")
-        else { return self }
-        var balance = 1
-        var current = self.index(after: start)
-        while balance > 0 && current < endIndex {
-            let char = self[current]
-            if char == "<" { balance += 1 }
-            if char == ">" {
-                guard let indexOfPreviousChar = index(
-                    current, offsetBy: -1, limitedBy: startIndex)
-                else { return self }
-                let previousChar = self[indexOfPreviousChar]
-                if previousChar == "-" {
-                    // We've found the "->" arrow for a closure type. Ignore this ">".
-                } else { balance -= 1 }
-            }
-            current = self.index(after: current)
-        }
-        if balance == 0 {
-            return String(self[..<start]) + replacement +
-                String(self[current...]).replacingGenericParameters(replacement)
-        }
-        return self
     }
 }
 
@@ -159,18 +210,18 @@ private extension String {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension Inspector {
-    
+
     /**
-        Use this function to lookup the struct content:
-        ```
-        (lldb) po Inspector.print(view) as AnyObject
-        ```
+     Use this function to lookup the struct content:
+     ```
+     (lldb) po Inspector.print(view) as AnyObject
+     ```
      */
     static func print(_ value: Any) -> String {
         let tree = attributesTree(value: value, medium: .empty, visited: [])
         return typeName(value: value) + print(tree, level: 1)
     }
-    
+
     fileprivate static func print(_ value: Any, level: Int) -> String {
         let prefix = Inspector.newline(value: value)
         if let array = value as? [Any] {
@@ -180,11 +231,11 @@ public extension Inspector {
         }
         return prefix + String(describing: value) + "\n"
     }
-    
+
     fileprivate static func indent(level: Int) -> String {
         return Array(repeating: "  ", count: level).joined()
     }
-    
+
     private static func newline(value: Any) -> String {
         let needsNewLine: Bool = {
             if let array = value as? [Any] {
@@ -194,7 +245,7 @@ public extension Inspector {
         }()
         return needsNewLine ? "\n" : ""
     }
-    
+
     private static func attributesTree(value: Any, medium: Content.Medium, visited: [AnyObject]) -> Any {
         var visited = visited
         if type(of: value) is AnyClass {
@@ -261,7 +312,7 @@ fileprivate extension Array {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension Inspector {
-    
+
     static func viewsInContainer(view: Any, medium: Content.Medium) throws -> LazyGroup<Content> {
         let unwrappedContainer = try Inspector.unwrap(content: Content(view, medium: medium.resettingViewModifiers()))
         guard Inspector.isTupleView(unwrappedContainer.view) else {
@@ -269,15 +320,15 @@ internal extension Inspector {
         }
         return try ViewType.TupleView.children(unwrappedContainer)
     }
-    
+
     static func isTupleView(_ view: Any) -> Bool {
         return Inspector.typeName(value: view, generics: .remove) == ViewType.TupleView.typePrefix
     }
-    
+
     static func unwrap(view: Any, medium: Content.Medium) throws -> Content {
         return try unwrap(content: Content(view, medium: medium))
     }
-    
+
     // swiftlint:disable cyclomatic_complexity
     static func unwrap(content: Content) throws -> Content {
         switch Inspector.typeName(value: content.view, generics: .remove) {
@@ -310,9 +361,9 @@ internal extension Inspector {
         }
     }
     // swiftlint:enable cyclomatic_complexity
-    
+
     static func guardType(value: Any, namespacedPrefixes: [String], inspectionCall: String) throws {
-        
+
         var typePrefix = typeName(type: type(of: value), namespaced: true, generics: .remove)
         if typePrefix == ViewType.popupContainerTypePrefix {
             typePrefix = typeName(type: type(of: value), namespaced: true)

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -95,9 +95,19 @@ public struct Inspector {
     private static var replacedGenericParametersCache: [String : [String : String]] = [:]
     private static var sanitizedNamespacesCache: [String: String] = [:]
 
-    // swiftlint:disable force_try
-    private static let sanitizeNamespaceRegex = try! NSRegularExpression(pattern: "\\.\\(unknown context at ..........\\)")
-    // swiftlint:enable force_try
+    private static let sanitizeNamespacePatterns = [
+        "\\.\\(unknown context at ..........\\)",
+        // This pattern may be helpful to solve issue #268.
+        // It will remain disabled until it is confirmed.
+        // https://github.com/nalexn/ViewInspector/issues/268
+        //"\\(extension in [a-zA-Z0-9]*\\)\\:",
+    ]
+
+    private static let sanitizeNamespaceRegex = {
+        // swiftlint:disable force_try
+        try! NSRegularExpression(pattern: sanitizeNamespacePatterns.joined(separator: "|"))
+        // swiftlint:enable force_try
+    }()
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)


### PR DESCRIPTION
Hi @nalexn. Picking up were we left off on #263, we have identified another opportunity for performance improvements in ViewInspector. @bachand and I discussed it and we'd love to get your thoughts on it.
Thank you so much for your time! 🙏 

## Context: performance improvements under larger SwiftUI View hierarchies

We have profiled and traced some of our slowest tests in Instruments showed that the 2 funcs defined in the `String` extension were the top offenders in terms of running time.

- `String.replacingGenericParameters(_:)`
- `String.sanitizingNamespace()`

The combined time of all calls to both of these functions accounted for almost 50% of the entire test running time:
| Weight(s) | Weight(%) | Self Weight | Symbol Name
| --- | --- | --- | --- |
|28.26 s | 100.0%  |	0 s | UnitTestHost (16171)
8.08 s |28.5% | 8.08 s | String.replacingGenericParameters(_:)
5.80 s | 20.5%	 | 5.80 s | String.sanitizingNamespace()

![Instruments_trace](https://github.com/nalexn/ViewInspector/assets/2278022/85f30dc5-f341-4f75-83f0-b73732ad2ec7)

It was already known that these 2 functions are called thousands of times for a single test case in our codebase.
This fact motivated an investigation on how many times these 2 funcs are called for the exact same input in order to inform a potential decision to memoize the calls. 

A histogram of the calls to `sanitizingNamespace` for each input was built from a single feature integration test run.
We found that for some types, the func `sanitizingNamespace` thousands of times for them. For example:

```
    - key : "SwiftUI.Environment<Swift.Optional<Swift.AnyHashable>>"
    - value : 3640

    - key : "SwiftUICoreUI.ScrollEventDispatch"
    - value : 144817

    - key : "Swift.Bool"
    - value : 3906

    - key : "SwiftUI.Environment<PrimitiveTypesCoreUI.AdaptiveTraitCollection>"
    - value : 19052
 
    - key : "(PrimitiveTypesCoreUI.InteractivityState) -> SwiftUI.ModifiedContent<SwiftUI._ViewModifier_Content<PrimitiveTypesCoreUI.Interactive<PrimitiveTypesCoreUI.TextStyleViewModifier>>, PrimitiveTypesCoreUI.TextStyleViewModifier>"
    - value : 17912
```

## Changes

It was then clear that caching the output of these expensive string manipulation operations would be worth it.
This is exactly what theses changes do.
It's a simple memoization which stores the computed value to be returned directly instead of recalculating them repeatedly.

## Testing

-  Ran tests at Airbnb that use ViewInspector

Local runs of the the test used to profile ViewInspector's execution time showed a **substantial improvement of running time. During the 2 Unit Tests CI runs of the changes in this PR, we noticed an **improvement of about 86% (19 seconds)**. That particular test took ~22 seconds to run before the optimizations and  ~3 seconds** after the optimizations:

Although the unit tests in ViewInspector are more lightweight compared to the tests we run at Airbnb, we could also see a good improvement of the overall running time of all tests of the library:

| Before | After |
| --- | --- |
| <img width="1072" alt="ViewInspector_perf_before" src="https://github.com/nalexn/ViewInspector/assets/2278022/179c57ed-8529-4643-9059-3794448d85cc"> | <img width="1072" alt="ViewInspector_perf_after" src="https://github.com/nalexn/ViewInspector/assets/2278022/3b50b7b6-5a12-4a01-89d5-5b7a8e450a17"> |

## Please review:

@nalexn 
@michael-bachand 

