### PR TITLE
[iOS17] Added concrete iOS version check for button style

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Button.swift
+++ b/Sources/ViewInspector/SwiftUI/Button.swift
@@ -85,10 +85,12 @@ public extension InspectableView {
                 "ButtonStyleModifier",
             ].contains(where: { modifier.modifierType.hasPrefix($0) })
         }, call: "buttonStyle")
-        if let style = try? Inspector.attribute(path: "modifier|style|style", value: modifier) {
-            return style
+        
+        if #available(iOS 17, *) {
+            return try Inspector.attribute(path: "modifier|style", value: modifier)
+        } else {
+            return try Inspector.attribute(path: "modifier|style|style", value: modifier)
         }
-        return try Inspector.attribute(path: "modifier|style", value: modifier)
     }
 }
 


### PR DESCRIPTION
Issues described here – https://github.com/nalexn/ViewInspector/issues/277, I believe it can help other developers 

<img width="276" alt="CleanShot 2023-11-20 at 14 35 22@2x" src="https://github.com/nalexn/ViewInspector/assets/19555744/94722904-f1dc-4a96-afbf-8bc84791b460">
