### PR TITLE
Increase support for SpatialTapGesture

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -260,7 +260,7 @@ internal extension InspectableView {
                 return (modifier, [])
             case .composed:
                 return traverseComposedGesture(modifier, name, &modifiers)
-            case .state :
+            case .state:
                 return traverseStateGesture(modifier, name, &modifiers)
             }
         } else if modifier == name {
@@ -314,6 +314,7 @@ internal extension InspectableView {
             "RotationGesture": .simple,
             "SequenceGesture": .composed,
             "SimultaneousGesture": .composed,
+            "SpatialTapGesture": .simple,
             "TapGesture": .simple,
         ]
         return knownGestures[name]
@@ -427,4 +428,20 @@ public extension SimultaneousGesture.Value {
             Allocator(first: first, second: second),
             to: SimultaneousGesture.Value.self)
     }
+}
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(tvOS, unavailable)
+public extension SpatialTapGesture.Value {
+
+    private struct Allocator {
+        var location: CGPoint
+    }
+
+    init(location: CGPoint) {
+        self = unsafeBitCast(
+            Allocator(location: location),
+            to: SpatialTapGesture.Value.self
+        )
+   }
 }

--- a/Tests/ViewInspectorTests/Gestures/SpatialTapGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/SpatialTapGestureTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+import SwiftUI
+import Combine
+@testable import ViewInspector
+
+// MARK: - Spatial Tap Gesture Tests
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(tvOS, unavailable)
+final class SpatialTapGestureTests: XCTestCase {
+
+    var spatialTapLocation: CGPoint?
+    var spatialTapValue: SpatialTapGesture.Value?
+
+    var gestureTests: CommonGestureTests<SpatialTapGesture>?
+
+    override func setUpWithError() throws {
+        spatialTapLocation = CGPoint(x: 100, y: 100)
+        spatialTapValue = SpatialTapGesture.Value(location: spatialTapLocation!)
+
+        gestureTests = CommonGestureTests<SpatialTapGesture>(testCase: self,
+                                                             gesture: SpatialTapGesture(),
+                                                             value: spatialTapValue!,
+                                                             assert: assertSpatialTapValue)
+    }
+
+    override func tearDownWithError() throws {
+        spatialTapLocation = nil
+        spatialTapValue = nil
+        gestureTests = nil
+    }
+
+    func testCreateSpatialTapGestureValue() throws {
+        XCTAssertNotNil(spatialTapLocation)
+        let value = try XCTUnwrap(spatialTapValue)
+        assertSpatialTapValue(value)
+    }
+
+    func testSpatialTapGestureMask() throws {
+        try gestureTests!.maskTest()
+    }
+
+    func testSpatialTapGesture() throws {
+        let sut = EmptyView().gesture(SpatialTapGesture(count: 2, coordinateSpace: .global))
+        let spatialTapGesture = try sut.inspect().emptyView().gesture(SpatialTapGesture.self).actualGesture()
+        XCTAssertEqual(spatialTapGesture.count, 2)
+        XCTAssertEqual(spatialTapGesture.coordinateSpace, .global)
+    }
+
+    func testSpatialTapGestureWithUpdatingModifier() throws {
+        try gestureTests!.propertiesWithUpdatingModifierTest()
+    }
+
+    func testSpatialTapGestureWithOnChangedModifier() throws {
+        try gestureTests!.propertiesWithOnChangedModifierTest()
+    }
+
+    func testSpatialTapGestureWithOnEndedModifier() throws {
+        try gestureTests!.propertiesWithOnEndedModifierTest()
+    }
+
+    #if os(macOS)
+    func testSpatialTapGestureWithModifiers() throws {
+        try gestureTests!.propertiesWithModifiersTest()
+    }
+    #endif
+
+    func testSpatialTapGestureFailure() throws {
+        try gestureTests!.propertiesFailureTest("SpatialTapGesture")
+    }
+
+    func testSpatialTapGestureCallUpdating() throws {
+        try gestureTests!.callUpdatingTest()
+    }
+
+    func testSpatialTapGestureCallUpdatingNotFirst() throws {
+        try gestureTests!.callUpdatingNotFirstTest()
+    }
+
+    func testSpatialTapGestureCallUpdatingMultiple() throws {
+        try gestureTests!.callUpdatingMultipleTest()
+    }
+
+    func testSpatialTapGestureCallUpdatingFailure() throws {
+        try gestureTests!.callUpdatingFailureTest()
+    }
+
+    func testSpatialTapGestureCallOnChanged() throws {
+        try gestureTests!.callOnChangedTest()
+    }
+
+    func testSpatialTapGestureCallOnChangedNotFirst() throws {
+        try gestureTests!.callOnChangedNotFirstTest()
+    }
+
+    func testSpatialTapGestureCallOnChangedMultiple() throws {
+        try gestureTests!.callOnChangedMultipleTest()
+    }
+
+    func testSpatialTapGestureCallOnChangedFailure() throws {
+        try gestureTests!.callOnChangedFailureTest()
+    }
+
+    func testSpatialTapGestureCallOnEnded() throws {
+        try gestureTests!.callOnEndedTest()
+    }
+
+    func testSpatialTapGestureCallOnEndedNotFirst() throws {
+        try gestureTests!.callOnEndedNotFirstTest()
+    }
+
+    func testSpatialTapGestureCallOnEndedMultiple() throws {
+        try gestureTests!.callOnEndedMultipleTest()
+    }
+
+    func testSpatialTapGestureCallOnEndedFailure() throws {
+        try gestureTests!.callOnEndedFailureTest()
+    }
+
+    #if os(macOS)
+    func testSpatialTapGestureModifiers() throws {
+        try gestureTests!.modifiersTest()
+    }
+
+    func testSpatialTapGestureModifiersNotFirst() throws {
+        try gestureTests!.modifiersNotFirstTest()
+    }
+
+    func testSpatialTapGestureModifiersMultiple() throws {
+        try gestureTests!.modifiersMultipleTest()
+    }
+
+    func testSpatialTapGestureModifiersNone() throws {
+        try gestureTests!.modifiersNoneTest()
+    }
+    #endif
+
+    func assertSpatialTapValue(
+        _ value: SpatialTapGesture.Value,
+        file: StaticString = #filePath,
+        line: UInt = #line) {
+        XCTAssertEqual(value, SpatialTapGesture.Value(location: spatialTapLocation!))
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/GridTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/GridTests.swift
@@ -78,7 +78,7 @@ final class GridTests: XCTestCase {
     func testGridRowAlignmentInspection() throws {
         guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
         else { throw XCTSkip() }
-        let view = Grid() { GridRow(alignment: .bottom) { EmptyView() } }
+        let view = Grid { GridRow(alignment: .bottom) { EmptyView() } }
         let sut = try view.inspect().grid().gridRow(0).alignment()
         XCTAssertEqual(sut, .bottom)
     }

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		1FA29F102AF0503000CCE6FA /* NavigationDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */; };
 		1FA29F132AF051AD00CCE6FA /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */; };
+		1FFB701D2B0C21DC004975B3 /* SpatialTapGestureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */; };
 		355B2D57BFF536BCD0B555B8 /* ViewPaddingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B2B0F773087003E9F5A49 /* ViewPaddingTests.swift */; };
 		520E915C26E64F210090BD1F /* EnvironmentInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520E915B26E64F210090BD1F /* EnvironmentInjection.swift */; };
 		520E916226E69E540090BD1F /* PopupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520E916126E69E540090BD1F /* PopupPresenter.swift */; };
@@ -311,6 +312,7 @@
 /* Begin PBXFileReference section */
 		1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestinationTests.swift; sourceTree = "<group>"; };
 		1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
+		1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatialTapGestureTests.swift; sourceTree = "<group>"; };
 		355B2B0F773087003E9F5A49 /* ViewPaddingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPaddingTests.swift; sourceTree = "<group>"; };
 		520E915B26E64F210090BD1F /* EnvironmentInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentInjection.swift; sourceTree = "<group>"; };
 		520E916126E69E540090BD1F /* PopupPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPresenter.swift; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 				CDA844B5262B7E6900C56C98 /* LongPressGestureTests.swift */,
 				CDA844BB262B7EA800C56C98 /* MagnificationGestureTests.swift */,
 				CDA844C1262B7EEE00C56C98 /* RotationGestureTests.swift */,
+				1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */,
 				CDA844C7262B7F3100C56C98 /* TapGestureTests.swift */,
 				CDA844CD262B817800C56C98 /* ExclusiveGestureTests.swift */,
 				CDA844D3262B81AB00C56C98 /* SequenceGestureTests.swift */,
@@ -1279,6 +1282,7 @@
 				CDA844A1262B747000C56C98 /* CommonGestureTests.swift in Sources */,
 				F64105CE257C3E1F0033D82D /* ViewSearchTests.swift in Sources */,
 				CDA844D4262B81AB00C56C98 /* SequenceGestureTests.swift in Sources */,
+				1FFB701D2B0C21DC004975B3 /* SpatialTapGestureTests.swift in Sources */,
 				F6D9339D2385ADA500358E0E /* GeometryReaderTests.swift in Sources */,
 				F6C15AAD254DB0AB000240F1 /* ScrollViewReaderTests.swift in Sources */,
 				CDA844E6262B84ED00C56C98 /* SequenceGestureChildrenTests.swift in Sources */,


### PR DESCRIPTION
To write tests using `SpatialTapGesture`, we needed a way to initialize the `Value`. This adds the appropriate `init` & adds tests for `SpatialTapGesture`.