### PR TITLE
[Perf improvement] Fixing Content.Medium creation for the unwrapping of custom modifiers.

### DIFF
--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
@@ -177,6 +177,144 @@ final class ModifiedContentTests: XCTestCase {
         XCTAssertEqual(sut.content.medium.environmentModifiers.count, 1)
         XCTAssertEqual(sut.content.medium.environmentObjects.count, 0)
     }
+
+    func testMultipleTransitiveModifiers() throws {
+        let view = Text("str")
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+            .allowsHitTesting(true)
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.transitiveViewModifiers.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 0)
+    }
+
+    func testMultipleCustomTransitiveModifiers() throws {
+        let view = Text("str")
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+            .modifier(AllowHitTestingTransitiveModifier())
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.transitiveViewModifiers.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 15)
+    }
+
+    func testMultipleEnvironmentModifiers() throws {
+        let view = Text("str")
+            .environment(\.font, .headline)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+            .environment(\.accessibilityEnabled, true)
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 0)
+    }
+
+    func testMultipleCustomEnvironmentModifiers() throws {
+        let view = Text("str")
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+            .modifier(AccessibilityEnabledEnvironmentModifier())
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 15)
+    }
+
+    func testMultipleEnvironmentObjects() throws {
+        let view = Text("str")
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+            .environmentObject(ExternalState())
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.environmentObjects.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 0)
+    }
+
+    func testMultipleCustomEnvironmentObjectModifiers() throws {
+        let view = Text("str")
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+            .modifier(ExternalStateEnvironmentObjectModifier())
+
+        let sut = try view.inspect()
+        XCTAssertEqual(sut.content.medium.environmentObjects.count, 15)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 15)
+    }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -261,5 +399,32 @@ private struct TestEnvironmentalModifier: EnvironmentalModifier {
     
     func resolve(in environment: EnvironmentValues) -> some ViewModifier {
         return TestModifier()
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct AllowHitTestingTransitiveModifier: ViewModifier {
+
+    func body(content: Self.Content) -> some View {
+        content
+            .allowsHitTesting(true)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct AccessibilityEnabledEnvironmentModifier: ViewModifier {
+
+    func body(content: Self.Content) -> some View {
+        content
+            .environment(\.accessibilityEnabled, true)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct ExternalStateEnvironmentObjectModifier: ViewModifier {
+
+    func body(content: Self.Content) -> some View {
+        content
+            .environmentObject(ExternalState())
     }
 }


### PR DESCRIPTION
Hi @nalexn. 
We found the issue described below as we continued working on profiling performance bottlenecks in `ViewInspector`and their effects in our test codebase at Airbnb.

It's a simple fix and we'd love to get your thoughts on it.
Thank you so much again for collaborating with us! 🙏 

## The problem: `Content.Medium.appending()` funcs are called an excessive number of times

After #273 was merged, we noticed that we had a few tests that were still taking a long time to run.
We profiled and traced those tests in Instruments again and noticed that the methods that add `environmentModifiers` and `environmentObjects` to the medium (and their callers) were responsible for most of the running time of those tests.

- `Content.Medium.appending(environmentModifier:)`
- `Content.Medium.appending(environmentObject:)`

<img width="622" alt="profiling_ViewInspector_calls" src="https://github.com/rafael-assis/ViewInspector/assets/2278022/f63d133c-bbed-407f-ba63-5e82b7bdf302">

We then tracked the number of `environmentModifiers` and `environmentObjects` contained in the `medium` property of the InspectableView's [content](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/InspectableView.swift#L7), and noticed a disproportional number of items in those arrays compared to the number of custom modifiers applied to our test view.

As an example, consider the following test:

``` swift
struct AccessibilityEnabledEnvironmentModifier: ViewModifier {

    func body(content: Self.Content) -> some View {
        content
            .environment(\.accessibilityEnabled, true)
    }
}

final class ModifiedContentTests: XCTestCase {
    func testMultipleCustomEnvironmentModifiers() throws {
        let view = Text("str")
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())
            .modifier(AccessibilityEnabledEnvironmentModifier())

        let sut = try view.inspect().text()
        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 15)
    }
}
```

❌  The assertion on the test failed as the `environmentModifiers.count` that should be **15** turns out to be **32767**. 


In further experiments, we concluded that the **[Big O notation](https://en.wikipedia.org/wiki/Big_O_notation)** that represents the complexity of the test increased from the expected linear time **O(n)** to **O(2<sup>n</sup>)**. (where n is the number of custom environment modifiers applied to the `Text("str")` View.

We noticed that the issue does not happen when the `.environment()` modifier call is applied directly to the view:

```swift
func testMultipleEnvironmentModifiers() throws {
        let view = Text("str")
            .environment(\.font, .headline)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)
            .environment(\.accessibilityEnabled, true)

        let sut = try view.inspect().text()
        XCTAssertEqual(sut.content.medium.environmentModifiers.count, 15)
    }
```
✅  The test above passes.

## The fix: Making custom modifier logic linear as the unwrapping traversal

The cause of the issue is that the code that [handles](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L83-L106) the unwrapping of custom modifiers in `func unwrappedModifiedContent()` duplicates all the properties that were previously passed by the unwrapping of its container View.

The duplication happens because the items in the medium that were originally used to [extract](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L84) the current modifier content view are also returned in the `InspectableView`'s Content.Medium by the find [call](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L86).

The same items will then be [appended again](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L100-L102) to the original medium that will be [passed as a parameter](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L108) to the recursive call that unwraps the modifier's child content.

The fix consists of simply recreating the medium with the 3 properties (`transitiveModifiers`,`environmentModifiers` and `environmentObject`) reset to the values of the `Content.Medium` in the `InspectableView` (`viewModifierContent` variable) returned by the find [call](https://github.com/nalexn/ViewInspector/blob/a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift#L86).

## Results in tests for our production code

We could see dramatic improvements in running time of the tests that flagged this issue in our CI environment:

Test ID | Before fix (seconds) | After fix (seconds)
-- | -- | -- 
Test 1 | 1.9 | 1.142 
Test 2 | 6.622 | 5.653 
Test 3 | 115.327 | 0.929
Test 4 | 78.488 | 2.29
Test 5 | 83.076| 3.538
Test 6 | 107.458 | 0.885 
Test 7 | 46.893 | 0.638

## Testing

We are adding 6 test cases to validate the application of custom modifiers and SwiftUI built-in modifiers in scenarios where the 3 properties of the `Content.Medium` struct are affected by this issue.

`Content.Medium` property | SwiftUI built-in modifier | custom modifier
-- | -- | --
`transitiveModifiers` | `testMultipleTransitiveModifiers` | `testMultipleCustomTransitiveModifiers`
`environmentModifiers` | `testMultipleEnvironmentModifiers`  | `testMultipleCustomEnvironmentModifiers`
`environmentObjects` | `testMultipleEnvironmentObjects` | `testMultipleCustomEnvironmentObjectModifiers`

The tests to validate the direct application of the built-in SwiftUI modifiers were added only for comparison purposes. They show the correct behavior and are used as a reference for the correct results of the custom modifier application scenarios that were fixed.

## Please review:

@nalexn 
@bachand

