### PR TITLE
Add NavigationLink value() attribute

### DIFF
--- a/Sources/ViewInspector/SwiftUI/NavigationLink.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationLink.swift
@@ -76,6 +76,11 @@ public extension InspectableView where View == ViewType.NavigationLink {
     func deactivate() throws {
         try content.set(isActive: false)
     }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func value<Value>(_ type: Value.Type = Value.self) throws -> Value {
+        try content.value(type)
+    }
 }
 
 // MARK: - Private
@@ -113,5 +118,10 @@ private extension Content {
         }
         return try Inspector
             .attribute(label: "_externalIsActive", value: view, type: Binding<Bool>.self)
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func value<Value>(_ type: Value.Type) throws -> Value {
+        try Inspector.attribute(path: "presentedValue|some|v4|storage|data", value: view, type: Value.self)
     }
 }

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
@@ -226,6 +226,48 @@ final class NavigationLinkTests: XCTestCase {
             0).vStack().forEach(1).view(TestTreeView.self, 1).vStack().text(0)
             """)
     }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func testNavigationValue() throws {
+        let viewInt = NavigationLink("Go to value", value: 42)
+        XCTAssertEqual(try viewInt.inspect().navigationLink().value(Int.self), 42)
+        XCTAssertThrows(
+            try viewInt.inspect().navigationLink().value(String.self),
+            "Type mismatch: Int is not String"
+        )
+        let viewString = NavigationLink("Go to value", value: "Test string value")
+        XCTAssertEqual(try viewString.inspect().navigationLink().value(), "Test string value")
+        XCTAssertThrows(
+            try viewString.inspect().navigationLink().value(Int.self),
+            "Type mismatch: String is not Int"
+        )
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func testNavigationValueHashable() throws {
+        let sut = NavigationLink("Go to hashable", value: TestValueHashable())
+        XCTAssertEqual(try sut.inspect().navigationLink().value(), TestValueHashable())
+        XCTAssertThrows(
+            try sut.inspect().navigationLink().value(Int.self),
+            "Type mismatch: TestValueHashable is not Int"
+        )
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func testNavigationValueCodable() throws {
+        let sut = NavigationLink("Go to codable", value: TestValueCodable(val: 3))
+        XCTAssertEqual(try sut.inspect().navigationLink().value(), TestValueCodable(val: 3))
+        XCTAssertNotEqual(try sut.inspect().navigationLink().value(), TestValueCodable(val: 4))
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func testNavigationValueMissing() throws {
+        let sut = NavigationLink("Go to codable", destination: EmptyView.init)
+        XCTAssertThrows(
+            try sut.inspect().navigationLink().value(TestValueCodable.self),
+            "Optional<NavigationLinkPresentedValue> does not have 'some' attribute"
+        )
+    }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -331,3 +373,11 @@ private struct TestTreeView: View {
         }
     }
 }
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private struct TestValueCodable: Codable, Hashable {
+    let val: Int
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private struct TestValueHashable: Hashable {}


### PR DESCRIPTION
Adds a func to get the value of `NavigationLink(value:label:)`. This allows testing to assert a particular link navigates to the correct destination value.