### PR TITLE
CustomInspectable view support

### DIFF
--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -99,7 +99,7 @@ internal extension Array where Element == String {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public struct ViewType { }
+public enum ViewType { }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension ViewType {

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -5,7 +5,7 @@ import UIKit
 #endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-public struct ViewHosting { }
+public enum ViewHosting { }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension ViewHosting {

--- a/Tests/ViewInspectorTests/CustomInspectableTests.swift
+++ b/Tests/ViewInspectorTests/CustomInspectableTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class CustomInspectableTests: XCTestCase {
+
+    func testCustomInspectableViewRepresentable() throws {
+        let sut = CustomViewRepresentable(labels: ["1", "abc"])
+        XCTAssertNoThrow(try sut.inspect().find(text: "abc"))
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct CustomViewRepresentable: UIViewRepresentable, CustomInspectable {
+
+    let labels: [String]
+
+    @ViewBuilder
+    var customInspectableContent: some View {
+        let indexedLabels = Array(labels.enumerated())
+        ForEach(indexedLabels, id: \.0) { _, label in
+            Text(label)
+        }
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        // This could be a UICollectionView, a UIStackView, or a custom view with some hosted
+        // SwiftUI views (via `UIHostingController`)
+        UIView()
+    }
+
+    func updateUIView(_ view: UIView, context: Context) { }
+}

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		F6F08E7123A3BD0C001F04DF /* AccessibilityModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F08E7023A3BD0C001F04DF /* AccessibilityModifiersTests.swift */; };
 		F6FB7F5825476431006658EF /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FB7F5725476431006658EF /* ColorPicker.swift */; };
 		F6FB7F6225476480006658EF /* ColorPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FB7F6125476480006658EF /* ColorPickerTests.swift */; };
+		FD69836E2B48D86C003CB125 /* CustomInspectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69836D2B48D86C003CB125 /* CustomInspectableTests.swift */; };
 		OBJ_51 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_69 /* ViewInspector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ViewInspector::ViewInspector::Product" /* ViewInspector.framework */; };
 /* End PBXBuildFile section */
@@ -582,6 +583,7 @@
 		F6FEBEF5256AE732006C28F5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Test.strings; sourceTree = "<group>"; };
 		F6FEBEFA256AEE09006C28F5 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Test.strings; sourceTree = "<group>"; };
 		F6FEBEFF256B0A3D006C28F5 /* en-AU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU"; path = "en-AU.lproj/Test.strings"; sourceTree = "<group>"; };
+		FD69836D2B48D86C003CB125 /* CustomInspectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInspectableTests.swift; sourceTree = "<group>"; };
 		OBJ_30 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		OBJ_31 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -793,6 +795,7 @@
 			isa = PBXGroup;
 			children = (
 				F60EEBE42382F004007DB53A /* BaseTypesTests.swift */,
+				FD69836D2B48D86C003CB125 /* CustomInspectableTests.swift */,
 				F6A35A4925B35F710068B8B2 /* LazyGroupTests.swift */,
 				F614E66525B36ACC000C4F66 /* InspectableViewTests.swift */,
 				F60EEBE52382F004007DB53A /* InspectorTests.swift */,
@@ -1379,6 +1382,7 @@
 				F6D933CD2385FFA300358E0E /* SliderTests.swift in Sources */,
 				F6C15A07254A0592000240F1 /* LazyVGridTests.swift in Sources */,
 				F6ECF6CC23A6702B000FC591 /* AnimationModifiersTests.swift in Sources */,
+				FD69836E2B48D86C003CB125 /* CustomInspectableTests.swift in Sources */,
 				CDA844B6262B7E6900C56C98 /* LongPressGestureTests.swift in Sources */,
 				CDA844E0262B84DC00C56C98 /* ExclusiveGestureChildrenTests.swift in Sources */,
 				F6A35A4A25B35F710068B8B2 /* LazyGroupTests.swift in Sources */,


### PR DESCRIPTION
Hey @nalexn ,

At Airbnb, we've recently discovered that `ViewInspector` doesn't work with some of our new SwiftUI infrastructure. We're having trouble getting a custom `UIViewRepresentable` that contains SwiftUI subviews to properly work. Internally, we've wrapped `UICollectionView` in a `UIViewRepresentable`, and under the hood, it uses `UIHostingConfiguration`s to show SwiftUI views in cells.

The API for this `UIViewRepresentable` is pretty declarative - we pass it some data, and under the hood, it diffs the data and updates the collection view.

The issue is that `ViewInspector` doesn't really know how to handle a `UIViewRepresentable` that contains SwiftUI views. After some discussion internally, we realized that one way around this limitation is to simply expose an alternative SwiftUI-native representation of the `UIViewRepresentable` to `ViewInspector`, based on the current set of data. For example, if we have a `UIViewRepresentable` wrapping a collection view, and its current cell data looks like this:

```
0: "First row"
1: "Second row"
2: "Third row"
``` 

We could expose this to `ViewInspector` using a custom view-building property:
```swift
@ViewBuilder
var inspectableRepresentation: some View {
    CustomCellView("First row")
    CustomCellView("Second row")
    CustomCellView("Third row")
}
```

Internally, `ViewInspector` would use this custom representation, rather than the `UIViewRepresentable`. The `inspectableRepresentation` view would likely be a `ForEach`, rather than a hard-coded `VStack` like in my simple example above.

-----

The full approach taken is to introduce a protocol called `CustomInspectable`. Any SwiftUI view can conform to this, and if it does, `ViewInspector` will use the custom view it provides for inspection, rather than treating it as a `UIViewRepresentable` or whatever type it originally was.

Other use cases might be:
- [HorizonCalendar](https://github.com/airbnb/HorizonCalendar), a UIKit calendar library with full support for being used in SwiftUI view hierarchies (and using SwiftUI views as its actual content)
- Wrapping Google Maps in a view representable and using SwiftUI views as the annotation views

This approach is a purely additive change, and requires very little additional code in the library. I'd love to get your thoughts on it :)