### PR TITLE
Modified the return to a wildcard pattern.

### DIFF
--- a/Sources/ViewInspector/SwiftUI/PopoverContent.swift
+++ b/Sources/ViewInspector/SwiftUI/PopoverContent.swift
@@ -21,7 +21,7 @@ extension ViewType.PopoverContent: SingleViewContent {
 extension ViewType.WrappedContent: SingleViewContent {
 
     static func child(_ content: Content) throws -> Content {
-        let closure = try Inspector.attribute(label: "popoverContent", value: content.view)
+        let _ = try Inspector.attribute(label: "popoverContent", value: content.view)
         // Closure's type is () -> 'consumer view type', which we cannot
         // cast to without asking for the type from the caller side.
         // Discontinuing support for now


### PR DESCRIPTION
Hello. 👋
I receive a warning during each build due to unused constants.
So I propose a fix.

<img width="748" alt="스크린샷 2024-01-24 오전 10 13 12" src="https://github.com/nalexn/ViewInspector/assets/13725729/4b2082d6-b631-467c-aa3c-dbae7d1ba4b1">
