### PR TITLE
Add structured concurrency support

### DIFF
--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -19,11 +19,15 @@ public protocol CustomInspectable {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@preconcurrency 
+@MainActor
 public protocol SingleViewContent {
     static func child(_ content: Content) throws -> Content
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@preconcurrency 
+@MainActor
 public protocol MultipleViewContent {
     static func children(_ content: Content) throws -> LazyGroup<Content>
 }
@@ -32,6 +36,8 @@ public protocol MultipleViewContent {
 internal typealias SupplementaryView = UnwrappedView
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@preconcurrency 
+@MainActor
 internal protocol SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView>
 }
@@ -42,6 +48,7 @@ internal protocol SupplementaryChildrenLabelView: SupplementaryChildren {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension SupplementaryChildrenLabelView {
     static var labelViewPath: String { "label" }
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {

--- a/Sources/ViewInspector/InspectableView+RandomAccessCollection.swift
+++ b/Sources/ViewInspector/InspectableView+RandomAccessCollection.swift
@@ -2,10 +2,13 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension InspectableView: Sequence where View: MultipleViewContent {
     
     public typealias Element = InspectableView<ViewType.ClassifiedView>
     
+    @preconcurrency 
+    @MainActor
     public struct Iterator: IteratorProtocol {
         
         private var index: Int = -1
@@ -17,6 +20,7 @@ extension InspectableView: Sequence where View: MultipleViewContent {
             self.view = view
         }
         
+        @preconcurrency
         mutating public func next() -> Element? {
             index += 1
             guard index < group.count else { return nil }
@@ -25,12 +29,14 @@ extension InspectableView: Sequence where View: MultipleViewContent {
         }
     }
 
+    @preconcurrency
     public func makeIterator() -> Iterator {
         // swiftlint:disable force_try
         return .init(try! View.children(content), view: self)
         // swiftlint:enable force_try
     }
 
+    @preconcurrency
     public var underestimatedCount: Int {
         // swiftlint:disable force_try
         return try! View.children(content).count

--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import XCTest
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@preconcurrency 
+@MainActor
 public struct InspectableView<View> where View: BaseViewType {
     
     internal let content: Content
@@ -71,6 +73,7 @@ public struct InspectableView<View> where View: BaseViewType {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension UnwrappedView {
     func implicitCustomViewChild(index: Int, call: String) throws
     -> (content: Content, parent: InspectableView<ViewType.View<ViewType.Stub>>)? {
@@ -103,6 +106,7 @@ extension InspectableView: UnwrappedView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension UnwrappedView {
     func asInspectableView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try .init(content, parent: parentView, call: inspectionCall, index: inspectionIndex)
@@ -191,14 +195,16 @@ internal extension InspectableView where View: MultipleViewContent {
 // MARK: - Inspection of a Custom View
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-public extension View {
+@MainActor public extension View {
     
+    @preconcurrency 
     func inspect(function: String = #function) throws -> InspectableView<ViewType.ClassifiedView> {
         let medium = ViewHosting.medium(function: function)
         let content = try Inspector.unwrap(view: self, medium: medium)
         return try .init(content, parent: nil, call: "")
     }
     
+    @preconcurrency
     func inspect(function: String = #function, file: StaticString = #file, line: UInt = #line,
                  inspection: (InspectableView<ViewType.View<Self>>) throws -> Void) {
         do {
@@ -214,14 +220,17 @@ public extension View {
 // MARK: - Modifiers
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ViewModifier {
     
+    @preconcurrency
     func inspect(function: String = #function) throws -> InspectableView<ViewType.ViewModifier<Self>> {
         let medium = ViewHosting.medium(function: function)
         let content = try Inspector.unwrap(view: self, medium: medium)
         return try .init(content, parent: nil, call: "")
     }
     
+    @preconcurrency
     func inspect(function: String = #function, file: StaticString = #file, line: UInt = #line,
                  inspection: (InspectableView<ViewType.ViewModifier<Self>>) throws -> Void) {
         do {

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -85,6 +85,16 @@ public extension InspectionEmissary where V: ViewModifier {
         }
     }
     
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    func inspect(after delay: SuspendingClock.Duration = .seconds(0),
+                 function: String = #function, file: StaticString = #file, line: UInt = #line,
+                 _ inspection: @escaping ViewModifierInspection
+    ) async throws {
+        return try await inspect(after: delay, function: function, file: file, line: line) { view in
+            return try await inspection(try view.inspect(function: function))
+        }
+    }
+    
     @discardableResult
     func inspect<P>(onReceive publisher: P,
                     after delay: TimeInterval = 0,

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -203,8 +203,9 @@ private extension InspectionEmissary {
         }
     }
     
-    @MainActor func setup(inspection: @escaping SubjectInspection,
-                          function: String, file: StaticString, line: UInt) async throws {
+    @MainActor 
+    func setup(inspection: @escaping SubjectInspection,
+               function: String, file: StaticString, line: UInt) async throws {
         try await withUnsafeThrowingContinuation { @MainActor continuation in
             callbacks[line] = { view in
                 Task {
@@ -222,8 +223,10 @@ private extension InspectionEmissary {
 // MARK: - on keyPath inspection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor
 public extension View {
     @discardableResult
+    @preconcurrency
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,
                      function: String = #function, file: StaticString = #file, line: UInt = #line,
                      perform: @escaping ((InspectableView<ViewType.View<Self>>) throws -> Void)
@@ -236,8 +239,10 @@ public extension View {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ViewModifier {
     @discardableResult
+    @preconcurrency
     mutating func on(_ keyPath: WritableKeyPath<Self, ((Self) -> Void)?>,
                      function: String = #function, file: StaticString = #file, line: UInt = #line,
                      perform: @escaping ((InspectableView<ViewType.ViewModifier<Self>>) throws -> Void)
@@ -250,6 +255,7 @@ public extension ViewModifier {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension Inspector {
     static func injectInspectionCallback<T>(
         value: inout T, keyPath: WritableKeyPath<T, ((T) -> Void)?>,

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -192,7 +192,7 @@ private extension InspectionEmissary {
             Task {
                 do {
                     try await inspection(view)
-                } catch let error {
+                } catch {
                     XCTFail("\(error.localizedDescription)", file: file, line: line)
                 }
                 if await MainActor.run(body: { [weak self] in self?.callbacks.count }) == 0 {
@@ -211,7 +211,7 @@ private extension InspectionEmissary {
                 Task {
                     do {
                         continuation.resume(returning: try await inspection(view))
-                    } catch let error {
+                    } catch {
                         continuation.resume(throwing: error)
                     }
                 }

--- a/Sources/ViewInspector/InspectionEmissary.swift
+++ b/Sources/ViewInspector/InspectionEmissary.swift
@@ -181,6 +181,21 @@ private extension InspectionEmissary {
             }
         }
     }
+    
+    @MainActor func setup(inspection: @escaping SubjectInspection,
+                function: String, file: StaticString, line: UInt) async throws {
+        try await withUnsafeThrowingContinuation { @MainActor continuation in
+            callbacks[line] = { view in
+                Task {
+                    do {
+                        continuation.resume(returning: try await inspection(view))
+                    } catch let error {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
+    }
 }
 
 // MARK: - on keyPath inspection

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -225,6 +225,7 @@ internal extension Inspector {
 // MARK: - Attributes lookup
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension Inspector {
 
     /**
@@ -233,6 +234,7 @@ public extension Inspector {
      (lldb) po Inspector.print(view) as AnyObject
      ```
      */
+    @preconcurrency
     static func print(_ value: Any) -> String {
         let tree = attributesTree(value: value, medium: .empty, visited: [])
         return typeName(value: value) + print(tree, level: 1)
@@ -303,6 +305,7 @@ public extension Inspector {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 fileprivate extension Dictionary where Key == String {
     func description(level: Int) -> String {
         let indent = Inspector.indent(level: level)
@@ -313,6 +316,7 @@ fileprivate extension Dictionary where Key == String {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 fileprivate extension Array {
     func description(level: Int) -> String {
         guard count > 0 else {
@@ -327,6 +331,7 @@ fileprivate extension Array {
 // MARK: - View Inspection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Inspector {
 
     static func viewsInContainer(view: Any, medium: Content.Medium) throws -> LazyGroup<Content> {

--- a/Sources/ViewInspector/LockExtensions.swift
+++ b/Sources/ViewInspector/LockExtensions.swift
@@ -1,0 +1,22 @@
+//
+//  LockExtensions.swift
+//  ViewInspector
+//
+//  Created by Tyler Thompson on 2/4/24.
+//
+
+import Foundation
+
+extension NSRecursiveLock {
+    func protect<T>(_ instructions: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try instructions()
+    }
+    
+    func protect<T>(_ instructions: @autoclosure () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try instructions()
+    }
+}

--- a/Sources/ViewInspector/LockExtensions.swift
+++ b/Sources/ViewInspector/LockExtensions.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 extension NSRecursiveLock {
-    func protect<T>(_ instructions: () throws -> T) rethrows -> T {
+    @discardableResult func protect<T>(_ instructions: () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
         return try instructions()
     }
     
-    func protect<T>(_ instructions: @autoclosure () throws -> T) rethrows -> T {
+    @discardableResult func protect<T>(_ instructions: @autoclosure () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
         return try instructions()

--- a/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
@@ -3,8 +3,10 @@ import SwiftUI
 // MARK: - Accessibility
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
     
+    @preconcurrency 
     func accessibilityLabel() throws -> InspectableView<ViewType.Text> {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *),
            let text = content.view as? Text,
@@ -35,6 +37,7 @@ public extension InspectableView {
         return try .init(try Inspector.unwrap(content: Content(text, medium: medium)), parent: self)
     }
     
+    @preconcurrency 
     func accessibilityValue() throws -> InspectableView<ViewType.Text> {
         let text: Text
         let call = "accessibilityValue"
@@ -56,6 +59,7 @@ public extension InspectableView {
         return try .init(try Inspector.unwrap(content: Content(text, medium: medium)), parent: self)
     }
     
+    @preconcurrency 
     func accessibilityHint() throws -> InspectableView<ViewType.Text> {
         let text: Text
         let call = "accessibilityHint"
@@ -74,6 +78,7 @@ public extension InspectableView {
         return try .init(try Inspector.unwrap(content: Content(text, medium: medium)), parent: self)
     }
     
+    @preconcurrency 
     func accessibilityHidden() throws -> Bool {
         let call = "accessibilityHidden"
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
@@ -93,6 +98,7 @@ public extension InspectableView {
         }
     }
     
+    @preconcurrency 
     func accessibilityIdentifier() throws -> String {
         let call = "accessibilityIdentifier"
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
@@ -107,6 +113,7 @@ public extension InspectableView {
         }
     }
     
+    @preconcurrency 
     func accessibilitySortPriority() throws -> Double {
         let call = "accessibilitySortPriority"
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
@@ -121,12 +128,14 @@ public extension InspectableView {
     @available(macOS, deprecated, introduced: 10.15)
     @available(tvOS, deprecated, introduced: 13.0)
     @available(watchOS, deprecated, introduced: 6)
+    @preconcurrency 
     func accessibilitySelectionIdentifier() throws -> AnyHashable {
         return try v2AccessibilityElement(
             "SelectionIdentifierKey", type: AnyHashable.self,
             call: "accessibility(selectionIdentifier:)")
     }
     
+    @preconcurrency 
     func accessibilityActivationPoint() throws -> UnitPoint {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try v3AccessibilityElement(
@@ -143,10 +152,12 @@ public extension InspectableView {
         }
     }
     
+    @preconcurrency 
     func callAccessibilityAction<S>(_ named: S) throws where S: StringProtocol {
         try callAccessibilityAction(AccessibilityActionKind(named: Text(named)))
     }
     
+    @preconcurrency 
     func callAccessibilityAction(_ kind: AccessibilityActionKind) throws {
         let shortName: String = {
             if let name = try? kind.name().string() {
@@ -167,6 +178,7 @@ public extension InspectableView {
         callback(())
     }
     
+    @preconcurrency 
     func callAccessibilityAdjustableAction(_ direction: AccessibilityAdjustmentDirection = .increment) throws {
         typealias Callback = (AccessibilityAdjustmentDirection) -> Void
         let callback: Callback
@@ -184,6 +196,7 @@ public extension InspectableView {
         callback(direction)
     }
     
+    @preconcurrency 
     func callAccessibilityScrollAction(_ edge: Edge) throws {
         typealias Callback = (Edge) -> Void
         let callback: Callback
@@ -205,6 +218,7 @@ public extension InspectableView {
 // MARK: - Private
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension AccessibilityActionKind {
     func name() throws -> InspectableView<ViewType.Text> {
         let view: Any = try {
@@ -226,6 +240,8 @@ private extension AccessibilityActionKind {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@preconcurrency 
+@MainActor
 private struct AccessibilityProperty {
     
     let keyPointerValue: UInt64
@@ -258,7 +274,9 @@ private struct AccessibilityProperty {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension InspectableView {
+@MainActor 
+private
+extension InspectableView {
     func v3AccessibilityElement<V, T>(
         path: String? = nil, type: T.Type, call: String, _ reference: (EmptyView) -> V
     ) throws -> T where V: SwiftUI.View {
@@ -372,6 +390,7 @@ extension Dictionary: AccessibilityKeyValues {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension InspectableView {
     
     func v2AccessibilityElement<T>(_ name: String, path: String = "value|some",

--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -73,12 +73,15 @@ extension ViewType.EnvironmentReaderView: SingleViewContent {
 @available(iOS 13.0, tvOS 13.0, *)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)
+@MainActor 
 public extension InspectableView where View: SingleViewContent {
     
+    @preconcurrency
     func navigationBarItems() throws -> InspectableView<ViewType.ClassifiedView> {
         return try navigationBarItems(AnyView.self)
     }
     
+    @preconcurrency
     func navigationBarItems<V>(_ viewType: V.Type) throws ->
         InspectableView<ViewType.ClassifiedView> where V: SwiftUI.View {
         return try navigationBarItems(viewType: viewType, content: try child())
@@ -88,12 +91,15 @@ public extension InspectableView where View: SingleViewContent {
 // MARK: - Extraction from MultipleViewContent parent
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView where View: MultipleViewContent {
     
+    @preconcurrency
     func navigationBarItems(_ index: Int = 0) throws -> InspectableView<ViewType.ClassifiedView> {
         return try navigationBarItems(AnyView.self, index)
     }
     
+    @preconcurrency
     func navigationBarItems<V>(_ viewType: V.Type, _ index: Int = 0) throws ->
         InspectableView<ViewType.ClassifiedView> where V: SwiftUI.View {
         return try navigationBarItems(viewType: viewType, content: try child(at: index))
@@ -103,6 +109,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Unwrapping the EnvironmentReaderView
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension InspectableView {
     
     func navigationBarItems<V>(viewType: V.Type, content: Content) throws ->

--- a/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/PositioningModifiers.swift
@@ -30,7 +30,7 @@ public extension InspectableView {
     }
 }
 
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension InspectableView {
 
     func ignoresSafeArea() throws -> (regions: SafeAreaRegions, edges: Edge.Set) {

--- a/Sources/ViewInspector/Modifiers/SizingModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/SizingModifiers.swift
@@ -88,7 +88,7 @@ public extension InspectableView {
                          leading: try attr.cumulativeValue(edge: .leading) ?? 0,
                          bottom: try attr.cumulativeValue(edge: .bottom) ?? 0,
                          trailing: try attr.cumulativeValue(edge: .trailing) ?? 0)
-        } catch let error {
+        } catch {
             if attr.allSatisfy({ $0.edges == .all }) {
                 throw InspectionError.notSupported(
                     "Please use `hasPadding(_:)` for inspecting padding without explicit value.")

--- a/Sources/ViewInspector/Modifiers/VisualEffectModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/VisualEffectModifiers.swift
@@ -3,8 +3,10 @@ import SwiftUI
 // MARK: - ViewGraphicalEffects
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
     
+    @preconcurrency
     func blur() throws -> (radius: CGFloat, isOpaque: Bool) {
         let radius = try modifierAttribute(
             modifierName: "_BlurEffect", path: "modifier|radius",
@@ -15,60 +17,70 @@ public extension InspectableView {
         return (radius, isOpaque)
     }
     
+    @preconcurrency
     func opacity() throws -> Double {
         return try modifierAttribute(
             modifierName: "_OpacityEffect", path: "modifier|opacity",
             type: Double.self, call: "opacity")
     }
     
+    @preconcurrency
     func brightness() throws -> Double {
         return try modifierAttribute(
             modifierName: "_BrightnessEffect", path: "modifier|amount",
             type: Double.self, call: "brightness")
     }
     
+    @preconcurrency
     func contrast() throws -> Double {
         return try modifierAttribute(
             modifierName: "_ContrastEffect", path: "modifier|amount",
             type: Double.self, call: "contrast")
     }
     
+    @preconcurrency
     func colorInvert() throws {
         _ = try modifierAttribute(
             modifierName: "_ColorInvertEffect", path: "modifier",
             type: Any.self, call: "colorInvert")
     }
     
+    @preconcurrency
     func colorMultiply() throws -> Color {
         return try modifierAttribute(
             modifierName: "_ColorMultiplyEffect", path: "modifier|color",
             type: Color.self, call: "colorMultiply")
     }
     
+    @preconcurrency
     func saturation() throws -> Double {
         return try modifierAttribute(
             modifierName: "_SaturationEffect", path: "modifier|amount",
             type: Double.self, call: "saturation")
     }
     
+    @preconcurrency
     func grayscale() throws -> Double {
         return try modifierAttribute(
             modifierName: "_GrayscaleEffect", path: "modifier|amount",
             type: Double.self, call: "grayscale")
     }
     
+    @preconcurrency
     func hueRotation() throws -> Angle {
         return try modifierAttribute(
             modifierName: "_HueRotationEffect", path: "modifier|angle",
             type: Angle.self, call: "hueRotation")
     }
     
+    @preconcurrency
     func luminanceToAlpha() throws {
         _ = try modifierAttribute(
             modifierName: "_LuminanceToAlphaEffect", path: "modifier",
             type: Any.self, call: "luminanceToAlpha")
     }
     
+    @preconcurrency
     func shadow() throws -> (color: Color, radius: CGFloat, offset: CGSize) {
         let color = try modifierAttribute(
             modifierName: "_ShadowEffect", path: "modifier|color",
@@ -82,6 +94,7 @@ public extension InspectableView {
         return (color, radius, offset)
     }
     
+    @preconcurrency
     func border<S: ShapeStyle>(_ style: S.Type) throws -> (shapeStyle: S, width: CGFloat) {
         let shape = try contentForModifierLookup
             .overlay(parent: self, api: .border, index: nil)
@@ -91,6 +104,7 @@ public extension InspectableView {
         return (shapeStyle, width)
     }
     
+    @preconcurrency
     func blendMode() throws -> BlendMode {
         return try modifierAttribute(
             modifierName: "_BlendModeEffect", path: "modifier|blendMode",
@@ -101,8 +115,10 @@ public extension InspectableView {
 // MARK: - ViewMasking
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
     
+    @preconcurrency
     func clipShape<S>(_ shape: S.Type) throws -> S where S: Shape {
         return try clipShape(shape, call: "clipShape")
     }
@@ -114,23 +130,27 @@ public extension InspectableView {
         return try Inspector.cast(value: shapeValue, type: S.self)
     }
     
+    @preconcurrency
     func clipStyle() throws -> FillStyle {
         return try modifierAttribute(
             modifierName: "_ClipEffect", path: "modifier|style",
             type: FillStyle.self, call: "clipStyle")
     }
     
+    @preconcurrency
     func cornerRadius() throws -> CGFloat {
         let shape = try clipShape(RoundedRectangle.self, call: "cornerRadius")
         return shape.cornerSize.width
     }
     
+    @preconcurrency
     func mask(_ index: Int? = nil) throws -> InspectableView<ViewType.ClassifiedView> {
         return try contentForModifierLookup.mask(parent: self, index: index)
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     func mask(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.ClassifiedView> {
         let rootView = try modifierAttribute(

--- a/Sources/ViewInspector/PopupPresenter.swift
+++ b/Sources/ViewInspector/PopupPresenter.swift
@@ -98,7 +98,9 @@ public extension ItemPopupPresenter where Popup == ActionSheet {
 // MARK: - Popover, Sheet & FullScreenCover
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ViewModifier where Self: BasePopupPresenter {
+    @preconcurrency
     func content() throws -> ViewInspector.Content {
         let view = body(content: _ViewModifier_Content())
         return try view.inspect().viewModifierContent().content
@@ -106,20 +108,26 @@ public extension ViewModifier where Self: BasePopupPresenter {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ViewModifier where Self: PopupPresenter {
+    @preconcurrency
     var isPopoverPresenter: Bool {
         return (try? content().standardPopoverModifier()) != nil
     }
+    @preconcurrency
     var isSheetPresenter: Bool {
         return (try? content().standardSheetModifier()) != nil
     }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ViewModifier where Self: ItemPopupPresenter {
+    @preconcurrency
     var isPopoverPresenter: Bool {
         return (try? content().standardPopoverModifier()) != nil
     }
+    @preconcurrency
     var isSheetPresenter: Bool {
         return (try? content().standardSheetModifier()) != nil
     }
@@ -160,6 +168,7 @@ internal extension ViewType.PopupContainer {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     func popup<Popup: KnownViewType>(
         parent: UnwrappedView, index: Int?,

--- a/Sources/ViewInspector/SwiftUI/ActionSheet.swift
+++ b/Sources/ViewInspector/SwiftUI/ActionSheet.swift
@@ -25,8 +25,10 @@ public extension InspectableView {
 
 @available(iOS 13.0, tvOS 13.0, *)
 @available(macOS, unavailable)
+@MainActor 
 internal extension Content {
     
+    @preconcurrency 
     func actionSheet(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.ActionSheet> {
         return try popup(parent: parent, index: index,
                          modifierPredicate: isActionSheetBuilder(modifier:),
@@ -92,6 +94,7 @@ public extension InspectableView where View == ViewType.ActionSheet {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.ActionSheet: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         let buttons = try Inspector.attribute(

--- a/Sources/ViewInspector/SwiftUI/Alert.swift
+++ b/Sources/ViewInspector/SwiftUI/Alert.swift
@@ -28,6 +28,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func alert(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.Alert> {
@@ -106,28 +107,34 @@ internal extension Content {
 // MARK: - Custom Attributes
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.Alert {
 
+    @preconcurrency
     func title() throws -> InspectableView<ViewType.Text> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.Text.self)
     }
     
+    @preconcurrency
     func message() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func primaryButton() throws -> InspectableView<ViewType.AlertButton> {
         return try View.supplementaryChildren(self).element(at: 2)
             .asInspectableView(ofType: ViewType.AlertButton.self)
     }
     
+    @preconcurrency
     func secondaryButton() throws -> InspectableView<ViewType.AlertButton> {
         return try View.supplementaryChildren(self).element(at: 3)
             .asInspectableView(ofType: ViewType.AlertButton.self)
     }
     
+    @preconcurrency
     func dismiss() throws {
         do {
             let container = try Inspector.cast(
@@ -145,8 +152,10 @@ public extension InspectableView where View == ViewType.Alert {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.Alert {
     
+    @preconcurrency
     func actions() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 2)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
@@ -156,6 +165,7 @@ public extension InspectableView where View == ViewType.Alert {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.Alert: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         let iOS15Modifier = parent.content.isIOS15Modifier
@@ -224,6 +234,7 @@ extension SwiftUI.Alert.Button: CustomViewIdentityMapping {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.AlertButton: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 1) { _ in

--- a/Sources/ViewInspector/SwiftUI/AsyncImage.swift
+++ b/Sources/ViewInspector/SwiftUI/AsyncImage.swift
@@ -31,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.AsyncImage: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -74,23 +75,28 @@ internal extension AsyncImagePhase {
 // MARK: - Custom Attributes
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.AsyncImage {
     
+    @preconcurrency 
     func url() throws -> URL? {
         return try Inspector.attribute(
             label: "url", value: content.view, type: URL?.self)
     }
     
+    @preconcurrency 
     func scale() throws -> CGFloat {
         return try Inspector.attribute(
             label: "scale", value: content.view, type: CGFloat.self)
     }
     
+    @preconcurrency 
     func transaction() throws -> Transaction {
         return try Inspector.attribute(
             label: "transaction", value: content.view, type: Transaction.self)
     }
     
+    @preconcurrency 
     func contentView(_ phase: AsyncImagePhase) throws -> InspectableView<ViewType.ClassifiedView> {
         return try ViewType.AsyncImage.view(for: phase, parent: self)
     }

--- a/Sources/ViewInspector/SwiftUI/Button.swift
+++ b/Sources/ViewInspector/SwiftUI/Button.swift
@@ -98,7 +98,9 @@ public extension InspectableView {
 // MARK: - ButtonStyle and PrimitiveButtonStyle inspection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ButtonStyle {
+    @preconcurrency
     func inspect(isPressed: Bool) throws -> InspectableView<ViewType.ClassifiedView> {
         let config = ButtonStyleConfiguration(isPressed: isPressed)
         let view = try makeBody(configuration: config).inspect()
@@ -107,7 +109,9 @@ public extension ButtonStyle {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension PrimitiveButtonStyle {
+    @preconcurrency
     func inspect(onTrigger: @escaping () -> Void = { }) throws -> InspectableView<ViewType.ClassifiedView> {
         let config = PrimitiveButtonStyleConfiguration(onTrigger: onTrigger)
         return try makeBody(configuration: config).inspect()

--- a/Sources/ViewInspector/SwiftUI/Canvas.swift
+++ b/Sources/ViewInspector/SwiftUI/Canvas.swift
@@ -31,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.Canvas: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/ViewInspector/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ViewInspector/SwiftUI/ConfirmationDialog.swift
@@ -24,6 +24,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func confirmationDialog(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.ConfirmationDialog> {
@@ -52,6 +53,7 @@ internal extension Content {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.ConfirmationDialog: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 3) { index in
@@ -80,28 +82,34 @@ extension ViewType.ConfirmationDialog: SupplementaryChildren {
 // MARK: - Custom Attributes
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.ConfirmationDialog {
     
+    @preconcurrency
     func title() throws -> InspectableView<ViewType.Text> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.Text.self)
     }
     
+    @preconcurrency
     func message() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func actions() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 2)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func titleVisibility() throws -> Visibility {
         return try Inspector.attribute(
             label: "titleVisibility", value: content.view, type: Visibility.self)
     }
     
+    @preconcurrency
     func dismiss() throws {
         try isPresentedBinding().wrappedValue = false
     }

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -48,6 +48,7 @@ extension ViewType.View: MultipleViewContent {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     var isCustomView: Bool {
         return !Inspector.isSystemType(value: view)
@@ -145,6 +146,8 @@ public extension NSViewControllerRepresentable {
 #elseif os(iOS) || os(tvOS) || os(visionOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension UIViewRepresentable {
+    @preconcurrency 
+    @MainActor
     func uiView() throws -> UIViewType {
         return try ViewHosting.lookup(Self.self)
     }
@@ -152,6 +155,8 @@ public extension UIViewRepresentable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension UIViewControllerRepresentable {
+    @preconcurrency 
+    @MainActor
     func viewController() throws -> UIViewControllerType {
         return try ViewHosting.lookup(Self.self)
     }

--- a/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
@@ -18,8 +18,10 @@ public extension ViewType {
 // MARK: - Extraction from SingleViewContent parent
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
 
+    @preconcurrency
     func modifier<T>(_ type: T.Type, _ index: Int? = nil) throws -> InspectableView<ViewType.ViewModifier<T>>
     where T: ViewModifier {
         let name = Inspector.typeName(type: type)
@@ -41,8 +43,10 @@ public extension InspectableView {
 // MARK: - Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.ViewModifier: SingleViewContent {
     
+    @preconcurrency
     public static func child(_ content: Content) throws -> Content {
         if content.isCustomView {
             return try content.extractCustomView()
@@ -62,6 +66,7 @@ extension ViewType.ViewModifier: MultipleViewContent {
 // MARK: - Internal
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     func unwrappedModifiedContent() throws -> Content {
         let view = try Inspector.attribute(label: "content", value: self.view)

--- a/Sources/ViewInspector/SwiftUI/DelayedPreferenceView.swift
+++ b/Sources/ViewInspector/SwiftUI/DelayedPreferenceView.swift
@@ -1,13 +1,16 @@
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
 
+    @preconcurrency
     func overlayPreferenceValue(_ index: Int? = nil) throws -> InspectableView<ViewType.Overlay> {
         return try contentForModifierLookup
             .overlay(parent: self, api: [.overlayPreferenceV1, .overlayPreferenceV2], index: index)
     }
     
+    @preconcurrency
     func backgroundPreferenceValue(_ index: Int? = nil) throws -> InspectableView<ViewType.Overlay> {
         return try contentForModifierLookup
             .overlay(parent: self, api: [.backgroundPreferenceV1, .backgroundPreferenceV2], index: index)

--- a/Sources/ViewInspector/SwiftUI/GroupBox.swift
+++ b/Sources/ViewInspector/SwiftUI/GroupBox.swift
@@ -78,7 +78,9 @@ public extension InspectableView {
 @available(iOS 14.0, macOS 11.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@MainActor 
 public extension GroupBoxStyle {
+    @preconcurrency
     func inspect() throws -> InspectableView<ViewType.ClassifiedView> {
         let config = GroupBoxStyleConfiguration()
         let view = try makeBody(configuration: config).inspect()

--- a/Sources/ViewInspector/SwiftUI/HelpView.swift
+++ b/Sources/ViewInspector/SwiftUI/HelpView.swift
@@ -34,6 +34,7 @@ public extension InspectableView {
 // MARK: - Internal
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     func help(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.Text> {
         let text: Any = try {

--- a/Sources/ViewInspector/SwiftUI/Label.swift
+++ b/Sources/ViewInspector/SwiftUI/Label.swift
@@ -31,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.Label: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 2) { index in
@@ -83,7 +84,9 @@ public extension InspectableView {
 // MARK: - LabelStyle inspection
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@MainActor 
 public extension LabelStyle {
+    @preconcurrency
     func inspect() throws -> InspectableView<ViewType.ClassifiedView> {
         let config = LabelStyleConfiguration()
         let view = try makeBody(configuration: config).inspect()

--- a/Sources/ViewInspector/SwiftUI/LazyHStack.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyHStack.swift
@@ -31,8 +31,10 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Content Extraction
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.LazyHStack: MultipleViewContent {
     
+    @preconcurrency
     public static func children(_ content: Content) throws -> LazyGroup<Content> {
         let view = try Inspector.attribute(path: "tree|content", value: content.view)
         return try Inspector.viewsInContainer(view: view, medium: content.medium)

--- a/Sources/ViewInspector/SwiftUI/List.swift
+++ b/Sources/ViewInspector/SwiftUI/List.swift
@@ -74,6 +74,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func listRowBackground(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.ClassifiedView> {

--- a/Sources/ViewInspector/SwiftUI/MapAnnotation.swift
+++ b/Sources/ViewInspector/SwiftUI/MapAnnotation.swift
@@ -42,18 +42,22 @@ public extension InspectableView where View == ViewType.MapAnnotation {
 // MARK: - SwiftUI MapAnnotation
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
+@MainActor 
 public extension MapAnnotation {
     
+    @preconcurrency
     func coordinate() throws -> CLLocationCoordinate2D {
         return try Inspector.attribute(
             label: "coordinate", value: self, type: CLLocationCoordinate2D.self)
     }
     
+    @preconcurrency
     func anchorPoint() throws -> CGPoint {
         return try Inspector.attribute(
             label: "anchorPoint", value: self, type: CGPoint.self)
     }
     
+    @preconcurrency
     func contentView() throws -> InspectableView<ViewType.ClassifiedView> {
         let view = try Inspector.attribute(label: "content", value: self)
         let content = ViewInspector.Content(view, medium: .empty)

--- a/Sources/ViewInspector/SwiftUI/Menu.swift
+++ b/Sources/ViewInspector/SwiftUI/Menu.swift
@@ -93,8 +93,9 @@ public extension InspectableView {
 @available(iOS 14.0, macOS 11.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@MainActor 
 public extension MenuStyle {
-    func inspect() throws -> InspectableView<ViewType.ClassifiedView> {
+    @preconcurrency func inspect() throws -> InspectableView<ViewType.ClassifiedView> {
         let config = MenuStyleConfiguration()
         let view = try makeBody(configuration: config).inspect()
         return try .init(view.content, parent: nil, index: nil)

--- a/Sources/ViewInspector/SwiftUI/NavigationDestination.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationDestination.swift
@@ -22,6 +22,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
 
     func navigationDestination(parent: UnwrappedView, index: Int?) throws

--- a/Sources/ViewInspector/SwiftUI/NavigationSplitView.swift
+++ b/Sources/ViewInspector/SwiftUI/NavigationSplitView.swift
@@ -50,6 +50,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.NavigationSplitView: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 2) { index in
@@ -72,13 +73,16 @@ extension ViewType.NavigationSplitView: SupplementaryChildren {
 // MARK: - Custom Attributes
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.NavigationSplitView {
     
+    @preconcurrency
     func detailView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func sidebarView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)

--- a/Sources/ViewInspector/SwiftUI/Overlay.swift
+++ b/Sources/ViewInspector/SwiftUI/Overlay.swift
@@ -44,6 +44,7 @@ extension ViewType.Overlay: MultipleViewContent {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func overlay(parent: UnwrappedView, api: ViewType.Overlay.API, index: Int?
@@ -122,6 +123,7 @@ internal extension ViewType.Overlay {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension ViewType.Overlay.API {
     
     var modifierName: String {

--- a/Sources/ViewInspector/SwiftUI/Popover.swift
+++ b/Sources/ViewInspector/SwiftUI/Popover.swift
@@ -54,6 +54,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func popover(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.Popover> {
@@ -124,20 +125,24 @@ public extension InspectableView where View == ViewType.Popover {
 @available(iOS 13.0, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@MainActor 
 public extension InspectableView where View == ViewType.Popover {
     
     @available(*, deprecated, message: "Simply remove `contentView()` from the inspection chain")
+    @preconcurrency
     func contentView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try contentView(EmptyView.self)
     }
     
     @available(*, deprecated, message: "Simply remove `contentView()` from the inspection chain")
+    @preconcurrency
     func contentView<T>(_ viewType: T.Type) throws -> InspectableView<ViewType.ClassifiedView> {
         let content = try ViewType.Popover.child(self.content)
         return try .init(content, parent: self, index: nil)
     }
     
     @available(*, deprecated, message: "Use `popover` inspection call - it throws if Popover is not presented")
+    @preconcurrency
     func isPresented() throws -> Bool {
         return true
     }

--- a/Sources/ViewInspector/SwiftUI/ProgressView.swift
+++ b/Sources/ViewInspector/SwiftUI/ProgressView.swift
@@ -31,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.ProgressView: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 2) { index in
@@ -55,8 +56,10 @@ extension ViewType.ProgressView: SupplementaryChildren {
 // MARK: - Custom Attributes
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.ProgressView {
     
+    @preconcurrency
     func fractionCompleted() throws -> Double? {
         do {
             return try Inspector
@@ -67,6 +70,7 @@ public extension InspectableView where View == ViewType.ProgressView {
             .attribute(path: "base|custom|fractionCompleted", value: content.view, type: Double?.self)
     }
     
+    @preconcurrency
     func progress() throws -> Progress {
         if let value = try? Inspector
             .attribute(path: "base|observing|_progress|wrappedValue|base",
@@ -78,11 +82,13 @@ public extension InspectableView where View == ViewType.ProgressView {
                        value: content.view, type: Progress.self)
     }
     
+    @preconcurrency
     func labelView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func currentValueLabelView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
@@ -105,7 +111,9 @@ public extension InspectableView {
 // MARK: - ProgressViewStyle inspection
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@MainActor 
 public extension ProgressViewStyle {
+    @preconcurrency
     func inspect(fractionCompleted: Double? = nil) throws -> InspectableView<ViewType.ClassifiedView> {
         let config = ProgressViewStyleConfiguration(fractionCompleted: fractionCompleted)
         let view = try makeBody(configuration: config).inspect()

--- a/Sources/ViewInspector/SwiftUI/SafeAreaInset.swift
+++ b/Sources/ViewInspector/SwiftUI/SafeAreaInset.swift
@@ -24,6 +24,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func safeAreaInset(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.SafeAreaInset> {

--- a/Sources/ViewInspector/SwiftUI/Section.swift
+++ b/Sources/ViewInspector/SwiftUI/Section.swift
@@ -42,6 +42,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.Section: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         return .init(count: 2) { index in
@@ -62,13 +63,16 @@ extension ViewType.Section: SupplementaryChildren {
 // MARK: - Custom Attributes
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.Section {
     
+    @preconcurrency
     func header() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func footer() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)

--- a/Sources/ViewInspector/SwiftUI/ShareLink.swift
+++ b/Sources/ViewInspector/SwiftUI/ShareLink.swift
@@ -33,6 +33,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.ShareLink: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         guard #available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
@@ -65,8 +66,10 @@ extension ViewType.ShareLink: SupplementaryChildren {
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
 @available(tvOS, unavailable)
+@MainActor 
 public extension InspectableView where View == ViewType.ShareLink {
     
+    @preconcurrency
     func item<T>(type: T.Type) throws -> T {
         do {
             return try Inspector.attribute(
@@ -82,25 +85,30 @@ public extension InspectableView where View == ViewType.ShareLink {
         }
     }
     
+    @preconcurrency
     func items() throws -> Any {
         return try Inspector.attribute(label: "items", value: content.view)
     }
     
+    @preconcurrency
     func labelView() throws -> InspectableView<ViewType.ClassifiedView> {
         return try View.supplementaryChildren(self).element(at: 0)
             .asInspectableView(ofType: ViewType.ClassifiedView.self)
     }
     
+    @preconcurrency
     func messageView() throws -> InspectableView<ViewType.Text> {
         return try View.supplementaryChildren(self).element(at: 1)
             .asInspectableView(ofType: ViewType.Text.self)
     }
     
+    @preconcurrency
     func subjectView() throws -> InspectableView<ViewType.Text> {
         return try View.supplementaryChildren(self).element(at: 2)
             .asInspectableView(ofType: ViewType.Text.self)
     }
     
+    @preconcurrency
     func sharePreview<DataElement, PreviewImage, PreviewIcon>(
         for element: DataElement, imageType: PreviewImage.Type, iconType: PreviewIcon.Type
     ) throws -> SharePreview<PreviewImage, PreviewIcon> {
@@ -112,17 +120,21 @@ public extension InspectableView where View == ViewType.ShareLink {
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
 @available(tvOS, unavailable)
+@MainActor 
 public extension SharePreview {
     
+    @preconcurrency
     func title() throws -> InspectableView<ViewType.Text> {
         let text = try Inspector.attribute(path: "title|some", value: self, type: Text.self)
         return try .init(Content(text), parent: nil)
     }
     
+    @preconcurrency
     func image() throws -> Image {
         return try Inspector.attribute(path: "image|some", value: self, type: Image.self)
     }
     
+    @preconcurrency
     func icon() throws -> Icon {
         return try Inspector.attribute(path: "icon|some", value: self, type: Icon.self)
     }

--- a/Sources/ViewInspector/SwiftUI/Sheet.swift
+++ b/Sources/ViewInspector/SwiftUI/Sheet.swift
@@ -58,6 +58,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func sheet(parent: UnwrappedView, index: Int?, name: String = "Sheet") throws -> InspectableView<ViewType.Sheet> {

--- a/Sources/ViewInspector/SwiftUI/TabView.swift
+++ b/Sources/ViewInspector/SwiftUI/TabView.swift
@@ -53,19 +53,23 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Global View Modifiers
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
     
+    @preconcurrency
     func tag() throws -> AnyHashable {
         return try modifierAttribute(
             modifierName: "TagValueTraitKey",
             path: "modifier|value|tagged", type: AnyHashable.self, call: "tag")
     }
     
+    @preconcurrency
     func tabItem() throws -> InspectableView<ViewType.ClassifiedView> {
         return try contentForModifierLookup.tabItem(parent: self, index: 0)
     }
 
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+    @preconcurrency
     func tabViewStyle() throws -> Any {
         let modifier = try self.modifier({ modifier -> Bool in
             return modifier.modifierType.hasPrefix("_TabViewStyleWriter")
@@ -75,6 +79,7 @@ public extension InspectableView {
     
     @available(iOS 14.0, tvOS 14.0, *)
     @available(macOS, unavailable)
+    @preconcurrency
     func indexViewStyle() throws -> Any {
         let modifier = try self.modifier({ modifier -> Bool in
             return modifier.modifierType.hasPrefix("IndexViewStyleModifier")
@@ -84,6 +89,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func tabItem(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.ClassifiedView> {

--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -45,6 +45,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Custom Attributes
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView where View == ViewType.Text {
     
     /**
@@ -54,14 +55,17 @@ public extension InspectableView where View == ViewType.Text {
       which is a global default value in the tests scope.
       You can change it by assigning a value to Locale.testsDefault
     */
+    @preconcurrency 
     func string(locale: Locale = .testsDefault) throws -> String {
         return try ViewType.Text.extractString(from: self, locale: locale)
     }
     
+    @preconcurrency 
     func attributes() throws -> ViewType.Text.Attributes {
         return try ViewType.Text.Attributes.extract(from: self)
     }
     
+    @preconcurrency 
     func images() throws -> [Image] {
         return try ViewType.Text.extractImages(from: self)
     }
@@ -72,6 +76,7 @@ public extension InspectableView where View == ViewType.Text {
      consider using `attributes()` instead.
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    @preconcurrency 
     func attributedString() throws -> AttributedString {
         return try ViewType.Text.extractAttributedString(from: self)
     }
@@ -80,6 +85,7 @@ public extension InspectableView where View == ViewType.Text {
 // MARK: - String extraction
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension ViewType.Text {
     
     static func extractString(from view: InspectableView<ViewType.Text>,
@@ -228,6 +234,7 @@ extension FormatStyle {
 // MARK: - Image extraction
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension ViewType.Text {
     
     static func extractImages(from view: InspectableView<ViewType.Text>) throws -> [Image] {

--- a/Sources/ViewInspector/SwiftUI/TextAttributes.swift
+++ b/Sources/ViewInspector/SwiftUI/TextAttributes.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension ViewType.Text.Attributes {
     
     static func extract(from view: InspectableView<ViewType.Text>) throws -> ViewType.Text.Attributes {

--- a/Sources/ViewInspector/SwiftUI/TimelineView.swift
+++ b/Sources/ViewInspector/SwiftUI/TimelineView.swift
@@ -31,6 +31,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.TimelineView: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/ViewInspector/SwiftUI/Toggle.swift
+++ b/Sources/ViewInspector/SwiftUI/Toggle.swift
@@ -95,7 +95,9 @@ public extension InspectableView {
 // MARK: - ToggleStyle inspection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension ToggleStyle {
+    @preconcurrency
     func inspect(isOn: Bool) throws -> InspectableView<ViewType.ClassifiedView> {
         let config = ToggleStyleConfiguration(isOn: isOn)
         let view = try makeBody(configuration: config).inspect()

--- a/Sources/ViewInspector/SwiftUI/Toolbar.swift
+++ b/Sources/ViewInspector/SwiftUI/Toolbar.swift
@@ -38,6 +38,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func toolbar(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.Toolbar> {

--- a/Sources/ViewInspector/SwiftUI/TouchBar.swift
+++ b/Sources/ViewInspector/SwiftUI/TouchBar.swift
@@ -69,7 +69,7 @@ public extension InspectableView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal extension Content {
+@MainActor internal extension Content {
     func touchBar(parent: UnwrappedView, index: Int?) throws -> InspectableView<ViewType.TouchBar> {
         let rootView = try modifierAttribute(
             modifierName: "_TouchBarModifier", path: "modifier|touchBar",

--- a/Sources/ViewInspector/SwiftUI/VideoPlayer.swift
+++ b/Sources/ViewInspector/SwiftUI/VideoPlayer.swift
@@ -40,6 +40,7 @@ public extension InspectableView where View: MultipleViewContent {
 // MARK: - Non Standard Children
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension ViewType.VideoPlayer: SupplementaryChildren {
     static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -15,6 +15,12 @@ public extension ViewHosting {
         var key: String { function }
     }
     
+    @MainActor static func host<V>(_ view: V, size: CGSize? = nil, function: String = #function, whileHosted: (V) async throws -> Void) async throws where V: View {
+        Self.host(view: view, size: size, function: function)
+        try await whileHosted(view)
+        Self.expel(function: function)
+    }
+    
     static func host<V>(view: V, size: CGSize? = nil, function: String = #function) where V: View {
         let viewId = ViewId(function: function)
         let medium = { () -> Content.Medium in

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -5,9 +5,12 @@ import UIKit
 #endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+@preconcurrency 
+@MainActor
 public enum ViewHosting { }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+@MainActor
 public extension ViewHosting {
     
     struct ViewId: Hashable {
@@ -15,12 +18,14 @@ public extension ViewHosting {
         var key: String { function }
     }
     
-    @MainActor static func host<V>(_ view: V, size: CGSize? = nil, function: String = #function, whileHosted: (V) async throws -> Void) async throws where V: View {
+    @preconcurrency 
+    static func host<V>(_ view: V, size: CGSize? = nil, function: String = #function, whileHosted: (V) async throws -> Void) async throws where V: View {
         Self.host(view: view, size: size, function: function)
         try await whileHosted(view)
         Self.expel(function: function)
     }
     
+    @preconcurrency
     static func host<V>(view: V, size: CGSize? = nil, function: String = #function) where V: View {
         let viewId = ViewId(function: function)
         let medium = { () -> Content.Medium in
@@ -63,6 +68,7 @@ public extension ViewHosting {
         #endif
     }
     
+    @preconcurrency
     static func expel(function: String = #function) {
         let viewId = ViewId(function: function)
         #if os(watchOS)
@@ -79,6 +85,7 @@ public extension ViewHosting {
     }
     
     #if os(watchOS)
+    @preconcurrency
     private static func watchOS(host view: AnyView?, viewId: ViewId) throws {
         typealias Subject = CurrentValueSubject<[(String, AnyView)], Never>
         guard let subject: Subject = try subjectForWatchOS(type: Subject.self) else {

--- a/Sources/ViewInspector/ViewSearch.swift
+++ b/Sources/ViewInspector/ViewSearch.swift
@@ -18,6 +18,7 @@ public struct ViewSearch {
 // MARK: - Public search API
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 public extension InspectableView {
     
     /**
@@ -29,6 +30,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found `Text` view
      */
+    @preconcurrency 
     func find(text: String,
               locale: Locale = .testsDefault
     ) throws -> InspectableView<ViewType.Text> {
@@ -45,6 +47,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found `Text` view
      */
+    @preconcurrency 
     func find(textWhere condition: (String, ViewType.Text.Attributes) throws -> Bool,
               locale: Locale = .testsDefault
     ) throws -> InspectableView<ViewType.Text> {
@@ -62,6 +65,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found `Button` view
      */
+    @preconcurrency 
     func find(button title: String,
               locale: Locale = .testsDefault
     ) throws -> InspectableView<ViewType.Button> {
@@ -76,6 +80,7 @@ public extension InspectableView {
       - Returns: A found `Link` view
      */
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+    @preconcurrency 
     func find(link url: URL) throws -> InspectableView<ViewType.Link> {
         return try find(ViewType.Link.self, where: { view in
             try view.url() == url
@@ -92,6 +97,7 @@ public extension InspectableView {
       - Returns: A found `Link` view
      */
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+    @preconcurrency 
     func find(link label: String,
               locale: Locale = .testsDefault
     ) throws -> InspectableView<ViewType.Link> {
@@ -107,6 +113,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found `NavigationLink` view
      */
+    @preconcurrency 
     func find(navigationLink string: String,
               locale: Locale = .testsDefault
     ) throws -> InspectableView<ViewType.NavigationLink> {
@@ -120,6 +127,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view
      */
+    @preconcurrency 
     func find(viewWithId id: AnyHashable) throws -> InspectableView<ViewType.ClassifiedView> {
         return try find { try $0.id() == id }
     }
@@ -131,6 +139,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view
      */
+    @preconcurrency 
     func find(viewWithTag tag: AnyHashable) throws -> InspectableView<ViewType.ClassifiedView> {
         return try find { try $0.tag() == tag }
     }
@@ -143,6 +152,7 @@ public extension InspectableView {
      - Returns: A found view
      */
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+    @preconcurrency 
     func find(
         viewWithAccessibilityLabel accessibilityLabel: String
     ) throws -> InspectableView<ViewType.ClassifiedView> {
@@ -157,6 +167,7 @@ public extension InspectableView {
      - Returns: A found view
      */
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+    @preconcurrency 
     func find(
         viewWithAccessibilityIdentifier accessibilityIdentifier: String
     ) throws -> InspectableView<ViewType.ClassifiedView> {
@@ -173,6 +184,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view
      */
+    @preconcurrency 
     func find<V>(_ customViewType: V.Type,
                  relation: ViewSearch.Relation = .child,
                  where condition: (InspectableView<ViewType.View<V>>) throws -> Bool = { _ in true }
@@ -195,6 +207,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view
      */
+    @preconcurrency 
     func find<V>(_ customViewType: V.Type,
                  containing string: String,
                  locale: Locale = .testsDefault
@@ -217,6 +230,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view
      */
+    @preconcurrency 
     func find<T>(_ viewType: T.Type,
                  containing string: String,
                  locale: Locale = .testsDefault
@@ -239,6 +253,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view of the given type.
      */
+    @preconcurrency 
     func find<T>(_ viewType: T.Type,
                  relation: ViewSearch.Relation = .child,
                  traversal: ViewSearch.Traversal = .breadthFirst,
@@ -263,6 +278,7 @@ public extension InspectableView {
       - Throws: An error if the view cannot be found
       - Returns: A found view of the given type.
      */
+    @preconcurrency
     func find(relation: ViewSearch.Relation = .child,
               traversal: ViewSearch.Traversal = .breadthFirst,
               skipFound: Int = 0,
@@ -287,6 +303,7 @@ public extension InspectableView {
      Thrown errors are interpreted as "this view does not match"
       - Returns: An array of all matching views or an empty array if none are found.
      */
+    @preconcurrency
     func findAll<V>(_ customViewType: V.Type,
                     where condition: (InspectableView<ViewType.View<V>>) throws -> Bool = { _ in true }
     ) -> [InspectableView<ViewType.View<V>>] where V: SwiftUI.View {
@@ -303,6 +320,7 @@ public extension InspectableView {
      Thrown errors are interpreted as "this view does not match"
       - Returns: An array of all matching views or an empty array if none are found.
      */
+    @preconcurrency
     func findAll<T>(_ viewType: T.Type,
                     where condition: (InspectableView<T>) throws -> Bool = { _ in true }
     ) -> [InspectableView<T>] where T: BaseViewType {
@@ -322,6 +340,7 @@ public extension InspectableView {
      Thrown errors are interpreted as "this view does not match"
       - Returns: An array of all matching views or an empty array if none are found.
      */
+    @preconcurrency
     func findAll(where condition: ViewSearch.Condition) -> [InspectableView<ViewType.ClassifiedView>] {
         var results: [InspectableView<ViewType.ClassifiedView>] = []
         depthFirstTraversal(condition, stopOnFoundMatch: { view in
@@ -337,6 +356,7 @@ public extension InspectableView {
 // MARK: - Search
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension UnwrappedView {
     
     func findParent(condition: ViewSearch.Condition, skipFound: Int
@@ -489,6 +509,7 @@ private extension UnwrappedView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension UnwrappedView {
     func recursionAbsenceCheck() -> Bool {
         guard content.isCustomView else { return true }
@@ -507,6 +528,7 @@ private extension UnwrappedView {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension ViewSearch.Traversal {
     func search(in view: UnwrappedView,
                 condition: ViewSearch.Condition,

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - Index
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension ViewSearch {
     
     private static var index: [String: [ViewIdentity]] = {
@@ -178,6 +179,8 @@ internal protocol CustomViewIdentityMapping {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal extension ViewSearch {
     
+    @preconcurrency 
+    @MainActor
     struct ViewIdentity {
         
         typealias ChildrenBuilder = (UnwrappedView) throws -> LazyGroup<UnwrappedView>
@@ -226,6 +229,7 @@ internal extension ViewSearch {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension KnownViewType {
     static func viewSearchIdentity(genericTypeName: String? = nil) -> ViewSearch.ViewIdentity {
         return ViewSearch.ViewIdentity(
@@ -257,6 +261,7 @@ extension KnownViewType {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension KnownViewType where Self: SingleViewContent {
     static func childViewsBuilder() -> ViewSearch.ViewIdentity.ChildrenBuilder {
         return { parent in
@@ -266,6 +271,7 @@ extension KnownViewType where Self: SingleViewContent {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension KnownViewType where Self: MultipleViewContent {
     static func childViewsBuilder() -> ViewSearch.ViewIdentity.ChildrenBuilder {
         return { parent in
@@ -275,6 +281,7 @@ extension KnownViewType where Self: MultipleViewContent {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension KnownViewType where Self: SingleViewContent & MultipleViewContent {
     static func childViewsBuilder() -> ViewSearch.ViewIdentity.ChildrenBuilder {
         return { parent in
@@ -284,6 +291,7 @@ extension KnownViewType where Self: SingleViewContent & MultipleViewContent {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 extension KnownViewType where Self: SupplementaryChildren {
     static func supplementaryViewsBuilder() -> ViewSearch.ViewIdentity.SupplementaryBuilder {
         return { parent in
@@ -295,6 +303,7 @@ extension KnownViewType where Self: SupplementaryChildren {
 // MARK: - Descendants
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension LazyGroup where T == Content {
     func descendants(_ parent: UnwrappedView, indexed: Bool) -> LazyGroup<UnwrappedView> {
         return .init(count: count, { index in
@@ -305,6 +314,7 @@ private extension LazyGroup where T == Content {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 private extension Content {
     func descendants(_ parent: UnwrappedView) -> LazyGroup<UnwrappedView> {
         return .init(count: 1) { _ in
@@ -316,6 +326,7 @@ private extension Content {
 // MARK: - ModifierIdentity
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension ViewType.Overlay.API {
     
     static var viewSearchModifierIdentities: [ViewSearch.ModifierIdentity] {
@@ -329,6 +340,7 @@ internal extension ViewType.Overlay.API {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension ViewSearch {
     
     static private(set) var modifierIdentities: [ModifierIdentity] = ViewType.Overlay.API.viewSearchModifierIdentities
@@ -374,6 +386,8 @@ internal extension ViewSearch {
         }),
     ]
     
+    @preconcurrency 
+    @MainActor
     struct ModifierIdentity {
         typealias Builder = (UnwrappedView, Int?) throws -> UnwrappedView
         let name: String
@@ -395,6 +409,7 @@ internal extension ViewSearch {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+@MainActor 
 internal extension Content {
     
     func modifierDescendants(parent: UnwrappedView) -> LazyGroup<UnwrappedView> {

--- a/Tests/ViewInspectorTests/BaseTypesTests.swift
+++ b/Tests/ViewInspectorTests/BaseTypesTests.swift
@@ -52,7 +52,7 @@ func XCTAssertThrows<T>(_ expression: @autoclosure () throws -> T, _ message: St
     do {
         _ = try expression()
         XCTFail("Expression did not throw any error", file: file, line: line)
-    } catch let error {
+    } catch {
         XCTAssertEqual(error.localizedDescription, message, file: file, line: line)
     }
 }

--- a/Tests/ViewInspectorTests/Gestures/ComposedGestureExampleTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/ComposedGestureExampleTests.swift
@@ -22,7 +22,7 @@ final class ComposedGestureExampleTests: XCTestCase {
             sut.publisher.send()
         }
         
-        let exp2 = sut.inspection.inspect { view in
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
             XCTAssertEqual(try view.actualView().scale, 2.0)
         }
 
@@ -44,7 +44,7 @@ final class ComposedGestureExampleTests: XCTestCase {
             sut.publisher.send()
         }
         
-        let exp2 = sut.inspection.inspect { view in
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
             XCTAssertEqual(try view.actualView().angle, Angle(degrees: 5))
         }
 
@@ -66,7 +66,7 @@ final class ComposedGestureExampleTests: XCTestCase {
             sut.publisher.send()
         }
         
-        let exp2 = sut.inspection.inspect { view in
+        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
             XCTAssertEqual(try view.actualView().scale, 2.0)
         }
 

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -194,98 +194,138 @@ final class InspectionEmissaryTests: XCTestCase {
             }
         }
     }
-//    
-//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-//    func testAsyncViewInspectOnReceive() async throws {
-//        let sut = TestView(flag: false)
-//        let exp1 = sut.inspection.inspect { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//            sut.publisher.send(true)
-//        }
-//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "true")
-//            sut.publisher.send(false)
-//        }
-//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//        }
-//        ViewHosting.host(view: sut)
-//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
-//    }
-//    
-//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-//    func testAsyncViewInspectOnReceiveAfter() async throws {
-//        let sut = TestView(flag: false)
-//        let exp1 = sut.inspection.inspect { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//            sut.publisher.send(true)
-//        }
-//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "true")
-//            sut.publisher.send(false)
-//        }
-//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
-//            let text = try view.button().labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//        }
-//        ViewHosting.host(view: sut)
-//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
-//    }
-//    
-//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-//    func testAsyncViewModifierInspectOnReceive() async throws {
-//        let binding = Binding(wrappedValue: false)
-//        let sut = TestViewModifier(flag: binding)
-//        let exp1 = sut.inspection.inspect { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//            sut.publisher.send(true)
-//        }
-//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "true")
-//            sut.publisher.send(false)
-//        }
-//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//        }
-//        let view = EmptyView()
-//            .modifier(sut)
-//            .environmentObject(ExternalState())
-//        ViewHosting.host(view: view)
-//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
-//    }
-//    
-//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-//    func testAsyncViewModifierInspectOnReceiveAfter() async throws {
-//        let binding = Binding(wrappedValue: false)
-//        let sut = TestViewModifier(flag: binding)
-//        let exp1 = sut.inspection.inspect { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//            sut.publisher.send(true)
-//        }
-//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "true")
-//            sut.publisher.send(false)
-//        }
-//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//        }
-//        let view = EmptyView()
-//            .modifier(sut)
-//            .environmentObject(ExternalState())
-//        ViewHosting.host(view: view)
-//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
-//    }
+    
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    func testAsyncViewInspectOnReceive() async throws {
+        let sut = TestView(flag: false)
+        try await ViewHosting.host(sut) { sut in
+            try await withThrowingDiscardingTaskGroup { group in
+                group.addTask {
+                    try await sut.inspection.inspect { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                        sut.publisher.send(true)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher) { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "true")
+                        sut.publisher.send(false)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                    }
+                }
+            }
+        }
+    }
+    
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    func testAsyncViewInspectOnReceiveAfter() async throws {
+        let sut = TestView(flag: false)
+        try await ViewHosting.host(sut) { sut in
+            try await withThrowingDiscardingTaskGroup { group in
+                group.addTask {
+                    try await sut.inspection.inspect { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                        sut.publisher.send(true)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher, after: .seconds(0.1)) { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "true")
+                        sut.publisher.send(false)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+                        let text = try view.button().labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                    }
+                }
+            }
+        }
+    }
+    
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    func testAsyncViewModifierInspectOnReceive() async throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = TestViewModifier(flag: binding)
+        let view = EmptyView()
+            .modifier(sut)
+            .environmentObject(ExternalState())
+        try await ViewHosting.host(view) { _ in
+            try await withThrowingDiscardingTaskGroup { group in
+                group.addTask {
+                    try await sut.inspection.inspect { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                        sut.publisher.send(true)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher) { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "true")
+                        sut.publisher.send(false)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                    }
+                }
+            }
+        }
+    }
+    
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    func testAsyncViewModifierInspectOnReceiveAfter() async throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = TestViewModifier(flag: binding)
+        let view = EmptyView()
+            .modifier(sut)
+            .environmentObject(ExternalState())
+        try await ViewHosting.host(view) { _ in
+            try await withThrowingDiscardingTaskGroup { group in
+                group.addTask {
+                    try await sut.inspection.inspect { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                        sut.publisher.send(true)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher, after: .seconds(0.1)) { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "true")
+                        sut.publisher.send(false)
+                    }
+                }
+                
+                group.addTask {
+                    try await sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+                        let text = try view.hStack().button(1).labelView().text().string()
+                        XCTAssertEqual(text, "false")
+                    }
+                }
+            }
+        }
+    }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -156,6 +156,135 @@ final class InspectionEmissaryTests: XCTestCase {
         ViewHosting.host(view: view)
         wait(for: [exp1, exp2, exp3], timeout: 0.2)
     }
+    
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    func testAsyncViewInspectAfter() async throws {
+        let sut = TestView(flag: false)
+        ViewHosting.host(view: sut)
+        try await sut.inspection.inspect { view in
+            let text = try view.button().labelView().text().string()
+            XCTAssertEqual(text, "false")
+            sut.publisher.send(true)
+        }
+        try await sut.inspection.inspect(after: .seconds(0.1)) { view in
+            let text = try view.button().labelView().text().string()
+            XCTAssertEqual(text, "true")
+        }
+    }
+    
+//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+//    func testAsyncViewModifierInspectAfter() async throws {
+//        let binding = Binding(wrappedValue: false)
+//        let sut = TestViewModifier(flag: binding)
+//        let view = EmptyView()
+//            .modifier(sut)
+//            .environmentObject(ExternalState())
+//        ViewHosting.host(view: view)
+//        
+//        try await sut.inspection.inspect { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//            sut.publisher.send(true)
+//        }
+//        try await sut.inspection.inspect(after: .seconds(0.1)) { view in
+//            let texts = view.findAll(ViewType.Text.self)
+//            XCTAssertEqual(texts.count, 2)
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "true")
+//        }
+//    }
+//    
+//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+//    func testAsyncViewInspectOnReceive() async throws {
+//        let sut = TestView(flag: false)
+//        let exp1 = sut.inspection.inspect { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//            sut.publisher.send(true)
+//        }
+//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "true")
+//            sut.publisher.send(false)
+//        }
+//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//        }
+//        ViewHosting.host(view: sut)
+//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+//    }
+//    
+//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+//    func testAsyncViewInspectOnReceiveAfter() async throws {
+//        let sut = TestView(flag: false)
+//        let exp1 = sut.inspection.inspect { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//            sut.publisher.send(true)
+//        }
+//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "true")
+//            sut.publisher.send(false)
+//        }
+//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+//            let text = try view.button().labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//        }
+//        ViewHosting.host(view: sut)
+//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+//    }
+//    
+//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+//    func testAsyncViewModifierInspectOnReceive() async throws {
+//        let binding = Binding(wrappedValue: false)
+//        let sut = TestViewModifier(flag: binding)
+//        let exp1 = sut.inspection.inspect { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//            sut.publisher.send(true)
+//        }
+//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher) { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "true")
+//            sut.publisher.send(false)
+//        }
+//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//        }
+//        let view = EmptyView()
+//            .modifier(sut)
+//            .environmentObject(ExternalState())
+//        ViewHosting.host(view: view)
+//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+//    }
+//    
+//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+//    func testAsyncViewModifierInspectOnReceiveAfter() async throws {
+//        let binding = Binding(wrappedValue: false)
+//        let sut = TestViewModifier(flag: binding)
+//        let exp1 = sut.inspection.inspect { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//            sut.publisher.send(true)
+//        }
+//        let exp2 = sut.inspection.inspect(onReceive: sut.publisher, after: 0.1) { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "true")
+//            sut.publisher.send(false)
+//        }
+//        let exp3 = sut.inspection.inspect(onReceive: sut.publisher.dropFirst()) { view in
+//            let text = try view.hStack().button(1).labelView().text().string()
+//            XCTAssertEqual(text, "false")
+//        }
+//        let view = EmptyView()
+//            .modifier(sut)
+//            .environmentObject(ExternalState())
+//        ViewHosting.host(view: view)
+//        wait(for: [exp1, exp2, exp3], timeout: 0.2)
+//    }
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -173,27 +173,27 @@ final class InspectionEmissaryTests: XCTestCase {
         }
     }
     
-//    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-//    func testAsyncViewModifierInspectAfter() async throws {
-//        let binding = Binding(wrappedValue: false)
-//        let sut = TestViewModifier(flag: binding)
-//        let view = EmptyView()
-//            .modifier(sut)
-//            .environmentObject(ExternalState())
-//        ViewHosting.host(view: view)
-//        
-//        try await sut.inspection.inspect { view in
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "false")
-//            sut.publisher.send(true)
-//        }
-//        try await sut.inspection.inspect(after: .seconds(0.1)) { view in
-//            let texts = view.findAll(ViewType.Text.self)
-//            XCTAssertEqual(texts.count, 2)
-//            let text = try view.hStack().button(1).labelView().text().string()
-//            XCTAssertEqual(text, "true")
-//        }
-//    }
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    func testAsyncViewModifierInspectAfter() async throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = TestViewModifier(flag: binding)
+        let view = EmptyView()
+            .modifier(sut)
+            .environmentObject(ExternalState())
+        try await ViewHosting.host(view) { _ in
+            try await sut.inspection.inspect { view in
+                let text = try view.hStack().button(1).labelView().text().string()
+                XCTAssertEqual(text, "false")
+                sut.publisher.send(true)
+            }
+            try await sut.inspection.inspect(after: .seconds(0.1)) { view in
+                let texts = view.findAll(ViewType.Text.self)
+                XCTAssertEqual(texts.count, 2)
+                let text = try view.hStack().button(1).labelView().text().string()
+                XCTAssertEqual(text, "true")
+            }
+        }
+    }
 //    
 //    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 //    func testAsyncViewInspectOnReceive() async throws {

--- a/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
+++ b/Tests/ViewInspectorTests/InspectionEmissaryTests.swift
@@ -160,15 +160,16 @@ final class InspectionEmissaryTests: XCTestCase {
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     func testAsyncViewInspectAfter() async throws {
         let sut = TestView(flag: false)
-        ViewHosting.host(view: sut)
-        try await sut.inspection.inspect { view in
-            let text = try view.button().labelView().text().string()
-            XCTAssertEqual(text, "false")
-            sut.publisher.send(true)
-        }
-        try await sut.inspection.inspect(after: .seconds(0.1)) { view in
-            let text = try view.button().labelView().text().string()
-            XCTAssertEqual(text, "true")
+        try await ViewHosting.host(sut) {
+            try await $0.inspection.inspect { view in
+                let text = try view.button().labelView().text().string()
+                XCTAssertEqual(text, "false")
+                sut.publisher.send(true)
+            }
+            try await $0.inspection.inspect(after: .seconds(0.1)) { view in
+                let text = try view.button().labelView().text().string()
+                XCTAssertEqual(text, "true")
+            }
         }
     }
     

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -4,7 +4,7 @@ import Combine
 @testable import ViewInspector
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-final class InspectorTests: XCTestCase {
+@MainActor final class InspectorTests: XCTestCase {
     
     private let testString = "abc"
     private let testValue = Struct1(value1: "abc", value2: .init(value3: 42))

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -239,7 +239,7 @@ final class InspectableViewModifiersTests: XCTestCase {
         do {
             _ = try sut.parent().group()
             XCTFail("Expected to throw")
-        } catch let error {
+        } catch {
             let message = error.localizedDescription
             XCTAssertTrue(message
                 .hasPrefix("anyView().group().emptyView(1).overlay().hStack().group() found "))

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
@@ -215,6 +215,9 @@ final class NavigationLinkTests: XCTestCase {
     }
 
     func testRecursiveTreeView() throws {
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+
         let sut = TestTreeView(item:
                 .init(name: "Root",
                       childs: [

--- a/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/PositioningModifiersTests.swift
@@ -78,14 +78,14 @@ final class ViewPositioningTests: XCTestCase {
     }
 
     func testIgnoresSafeArea() throws {
-        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let sut = EmptyView().ignoresSafeArea()
         XCTAssertNoThrow(try sut.inspect().emptyView())
     }
 
     func testIgnoresSafeAreaInspection() throws {
-        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let sut = try EmptyView().ignoresSafeArea(.container, edges: .bottom).inspect().emptyView().ignoresSafeArea()
         XCTAssertEqual(sut.regions, .container)
@@ -93,7 +93,7 @@ final class ViewPositioningTests: XCTestCase {
     }
 
     func testIgnoresSafeAreaDefaultsInspection() throws {
-        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let sut = try EmptyView().ignoresSafeArea().inspect().emptyView().ignoresSafeArea()
         XCTAssertEqual(sut.regions, .all)

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		52F356AA267692D100695E43 /* MapAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F356A9267692D100695E43 /* MapAnnotation.swift */; };
 		52F356AC2676940A00695E43 /* MapAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F356AB2676940A00695E43 /* MapAnnotationTests.swift */; };
 		79069A6B238E8490000F6B58 /* OptionalContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79069A6A238E8490000F6B58 /* OptionalContent.swift */; };
+		CA78B9872B700968009E8F64 /* LockExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA78B9862B700968009E8F64 /* LockExtensions.swift */; };
 		CA924CDC265DE87000976FEB /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA924CDB265DE87000976FEB /* MapTests.swift */; };
 		CA924CDF265DE9A000976FEB /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA924CDD265DE97800976FEB /* Map.swift */; };
 		CDA8444D262B6A7100C56C98 /* HitTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA8443D262B68E100C56C98 /* HitTestingTests.swift */; };
@@ -378,6 +379,7 @@
 		52F356A9267692D100695E43 /* MapAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAnnotation.swift; sourceTree = "<group>"; };
 		52F356AB2676940A00695E43 /* MapAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAnnotationTests.swift; sourceTree = "<group>"; };
 		79069A6A238E8490000F6B58 /* OptionalContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalContent.swift; sourceTree = "<group>"; };
+		CA78B9862B700968009E8F64 /* LockExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockExtensions.swift; sourceTree = "<group>"; };
 		CA924CDB265DE87000976FEB /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		CA924CDD265DE97800976FEB /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		CDA84433262B688F00C56C98 /* GestureModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureModifierTests.swift; sourceTree = "<group>"; };
@@ -677,6 +679,7 @@
 				520E916126E69E540090BD1F /* PopupPresenter.swift */,
 				F68108A423A5833D00B32145 /* Modifiers */,
 				F60EEBBD2382EED0007DB53A /* SwiftUI */,
+				CA78B9862B700968009E8F64 /* LockExtensions.swift */,
 			);
 			path = ViewInspector;
 			sourceTree = "<group>";
@@ -1139,6 +1142,7 @@
 				F60EEBD92382EED0007DB53A /* Divider.swift in Sources */,
 				F6FB7F5825476431006658EF /* ColorPicker.swift in Sources */,
 				52A4A7642621F4AE0063E00B /* Overlay.swift in Sources */,
+				CA78B9872B700968009E8F64 /* LockExtensions.swift in Sources */,
 				523CD480277C98FC00D4FD3A /* VideoPlayer.swift in Sources */,
 				F60EEBDA2382EED0007DB53A /* HStack.swift in Sources */,
 				F64057ED238DB1530029D9BA /* ConditionalContent.swift in Sources */,


### PR DESCRIPTION
There are a few places where ViewInspector is falling behind in regards to structured concurrency. This PR is an attempt to work through that. 

Backward compatibility might need some discussion. It's pretty easy to get the 90% case, but if we want to ensure no breaking changes we may have to adopt a brand new `AsyncInspectionEmissary` type protocol (and use similar tricks elsewhere).

Some changes should be totally safe, like synchronizing state on `Inspector`