### PR TITLE
Ported iOS16 ToggleState enum fix from SoundCloud/Axt to ViewInspector

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Toggle.swift
+++ b/Sources/ViewInspector/SwiftUI/Toggle.swift
@@ -63,7 +63,7 @@ public extension InspectableView where View == ViewType.Toggle {
     private func isOnBinding() throws -> Binding<Bool> {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             // In iOS16, the toggle state is no longer a bool - but an enum.
-            // ViewInspector equivalent of: https://github.com/soundcloud/Axt/blob/master/Sources/Axt/Native/Toggle.swift
+            // Inspector equivalent of: https://github.com/soundcloud/Axt/blob/master/Sources/Axt/Native/Toggle.swift
             let toggleStateBinding = try Inspector.attribute(label: "_toggleState", value: content.view)
             let toggleState = withUnsafePointer(to: toggleStateBinding) {
                 $0.withMemoryRebound(to: Binding<ToggleState>.self, capacity: 1) {

--- a/Sources/ViewInspector/SwiftUI/Toggle.swift
+++ b/Sources/ViewInspector/SwiftUI/Toggle.swift
@@ -62,13 +62,18 @@ public extension InspectableView where View == ViewType.Toggle {
     
     private func isOnBinding() throws -> Binding<Bool> {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-            throw InspectionError.notSupported(
-                """
-                Toggle's tap() and isOn() are currently unavailable for \
-                inspection on iOS 16. Situation may change with a minor \
-                OS version update. In the meanwhile, please add XCTSkip \
-                for iOS 16 and use an earlier OS version for testing.
-                """)
+            // In iOS16, the toggle state is no longer a bool - but an enum.
+            // ViewInspector equivalent of: https://github.com/soundcloud/Axt/blob/master/Sources/Axt/Native/Toggle.swift
+            let toggleStateBinding = try Inspector.attribute(label: "_toggleState", value: content.view)
+            let toggleState = withUnsafePointer(to: toggleStateBinding) {
+                $0.withMemoryRebound(to: Binding<ToggleState>.self, capacity: 1) {
+                    $0.pointee
+                }
+            }
+            return Binding(
+                get: { toggleState.wrappedValue == .on },
+                set: { toggleState.wrappedValue = $0 ? .on : .off }
+            )
         }
         if let binding = try? Inspector
             .attribute(label: "__isOn", value: content.view, type: Binding<Bool>.self) {
@@ -76,6 +81,13 @@ public extension InspectableView where View == ViewType.Toggle {
         }
         return try Inspector
             .attribute(label: "_isOn", value: content.view, type: Binding<Bool>.self)
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    private enum ToggleState {
+        case on
+        case off
+        case mixed
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/ToggleTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ToggleTests.swift
@@ -20,9 +20,6 @@ final class ToggleTests: XCTestCase {
     }
     
     func testTapAndIsOn() throws {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-            throw XCTSkip()
-        }
         let binding = Binding(wrappedValue: false)
         let view = Toggle(isOn: binding) { Text("") }
         let sut = try view.inspect().toggle()
@@ -34,9 +31,6 @@ final class ToggleTests: XCTestCase {
     }
     
     func testTapWhenDisabled() throws {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-            throw XCTSkip()
-        }
         let binding = Binding(wrappedValue: false)
         let view = Toggle(isOn: binding) { Text("") }.disabled(true)
         let sut = try view.inspect().toggle()


### PR DESCRIPTION
Closes #230 

Uses the solution discovered here to handle the new SwiftUI.ToggleState (instead of Bool) problem: https://github.com/soundcloud/Axt/blob/master/Sources/Axt/Native/Toggle.swift

Essentially, for iOS16+, we use a new ToggleState enum and do some unsafe pointer shenanigans to map the local enum to the SwiftUI internals enum.

Removed the forced skips from the two remaining toggle.

There could be an outstanding question of how we should handle `.mixed` - but I treat it as a `false` in this PR.