### PR TITLE
Fix type-checking timeout build error under Xcode 16

### DIFF
--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -455,16 +455,19 @@ internal extension Content {
         #else
         let popoverModifiers: [ViewSearch.ModifierIdentity] = []
         #endif
-        return
-            .init(count: sheetModifiers.count, { index -> UnwrappedView in
-                try sheetModifiers[index].builder(parent, index)
-            }) + .init(count: actionSheetModifiers.count, { index -> UnwrappedView in
-                try actionSheetModifiers[index].builder(parent, index)
-            }) + .init(count: alertModifiers.count, { index -> UnwrappedView in
-                try alertModifiers[index].builder(parent, index)
-            }) + .init(count: popoverModifiers.count, { index -> UnwrappedView in
-                try popoverModifiers[index].builder(parent, index)
-            })
+        let sheetModifiersGroup = LazyGroup(count: sheetModifiers.count, { index -> UnwrappedView in
+            try sheetModifiers[index].builder(parent, index)
+        })
+        let actionSheetGroup = LazyGroup(count: actionSheetModifiers.count, { index -> UnwrappedView in
+            try actionSheetModifiers[index].builder(parent, index)
+        })
+        let alertModifiersGroup = LazyGroup(count: alertModifiers.count, { index -> UnwrappedView in
+            try alertModifiers[index].builder(parent, index)
+        })
+        let popoverModifiersGroup = LazyGroup(count: popoverModifiers.count, { index -> UnwrappedView in
+            try popoverModifiers[index].builder(parent, index)
+        })
+        return sheetModifiersGroup + actionSheetGroup + alertModifiersGroup + popoverModifiersGroup
     }
 }
 


### PR DESCRIPTION
Fixes the Xcode 16 build error reported in https://github.com/nalexn/ViewInspector/issues/307:

```
ViewSearchIndex.swift:444:13: error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
            .init(count: sheetModifiers.count, { index -> UnwrappedView in
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Issue is fixed by splitting the return statement out into sub-expressions.