### PR TITLE
Add support for inspecting `.task(id: ...)` modifier

### DIFF
--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -62,4 +62,15 @@ public extension InspectableView {
             type: (@Sendable () async -> Void).self, call: "task")
         await callback()
     }
+
+    func callTask(id: some Equatable, index: Int = 0) async throws {
+        let typeName = Inspector.typeName(type: type(of: id))
+        let callback = try modifierAttribute(
+            modifierName: "_TaskValueModifier<\(typeName)>",
+            path: "modifier|action",
+            type: (@Sendable () async -> Void).self,
+            call: "task",
+            index: index)
+        await callback()
+    }
 }

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -157,6 +157,69 @@ final class ViewEventsTests: XCTestCase {
         try await sut.inspect().emptyView().callTask()
         await fulfillment(of: [exp], timeout: 0.1)
     }
+
+    func testTaskIdInspection() async throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
+        let exp = XCTestExpectation(description: #function)
+        let sut = EmptyView().padding()
+            .task(id: "id") {
+                exp.fulfill()
+            }
+        try await sut.inspect().emptyView().callTask(id: "id")
+        await fulfillment(of: [exp], timeout: 0.1)
+    }
+
+    func testTaskIdInspectionWithIndex() async throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
+        let exp1 = XCTestExpectation(description: "task1")
+        let exp2 = XCTestExpectation(description: "task2")
+        exp1.assertForOverFulfill = true
+        exp2.assertForOverFulfill = true
+
+        let sut = EmptyView().padding()
+            .task(id: "id1") {
+                exp1.fulfill()
+            }
+            .task(id: "id2") {
+                exp2.fulfill()
+            }
+
+        try await sut.inspect().emptyView().callTask(id: "id1", index: 0)
+        await fulfillment(of: [exp1], timeout: 0.1)
+
+        try await sut.inspect().emptyView().callTask(id: "id2", index: 1)
+        await fulfillment(of: [exp2], timeout: 0.1)
+    }
+
+    func testTaskIdInspectionMultipleDifferentTypes() async throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
+        struct CustomEquatableStruct: Equatable {
+            let value: Int
+        }
+        let exp1 = XCTestExpectation(description: "task1")
+        let exp2 = XCTestExpectation(description: "task2")
+        let exp3 = XCTestExpectation(description: "task3")
+        exp1.assertForOverFulfill = true
+        exp2.assertForOverFulfill = true
+        exp3.assertForOverFulfill = true
+
+        let sut = EmptyView().padding()
+            .task(id: "id") {
+                exp1.fulfill()
+            }
+            .task(id: 2) {
+                exp2.fulfill()
+            }
+            .task(id: CustomEquatableStruct(value: 1)) {
+                exp3.fulfill()
+            }
+
+        async let _ = try sut.inspect().emptyView().callTask(id: 2)
+        async let _ = try sut.inspect().emptyView().callTask(id: "id")
+        async let _ = try sut.inspect().emptyView().callTask(id: CustomEquatableStruct(value: 1))
+
+        await fulfillment(of: [exp1, exp2, exp3], timeout: 0.1)
+    }
 }
 
 // MARK: - ViewPublisherEventsTests

--- a/readiness.md
+++ b/readiness.md
@@ -350,7 +350,8 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:---:|---|
 |:white_check_mark:| `func onReceive<P>(P, perform: (P.Output) -> Void) -> some View` |
 |:white_check_mark:| `func onChange<V>(of: V, perform: (V) -> Void) -> some View` |
-|:white_check_mark:| `func task(...) -> some View` |
+|:white_check_mark:| `func task(priority: TaskPriority, () async -> Void) -> some View` |
+|:white_check_mark:| `func task<T>(id: T, priority: TaskPriority, () async -> Void) -> some View` |
 
 ### Handling View Hover and Focus
 


### PR DESCRIPTION
Added support for inspecting [task(id:priority:_:)](https://developer.apple.com/documentation/swiftui/view/task(id:priority:_:)) modifier.

Added unit-tests to cover different types/index.

Also updated readiness documentation.