### PR TITLE
Add callOnChange(oldValue:newValue:)

### DIFF
--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -36,6 +36,24 @@ public extension InspectableView {
             call: "onChange", index: index)
         callback(value)
     }
+
+    func callOnChange<E: Equatable>(oldValue: E, newValue: E, index: Int = 0) throws {
+        let typeName = Inspector.typeName(type: E.self)
+        if let callback = try? modifierAttribute(
+            modifierName: "_ValueActionModifier2<\(typeName)>",
+            path: "modifier|action",
+            type: ((E, E) -> Void).self,
+            call: "onChange", index: index) {
+            callback(oldValue, newValue)
+            return
+        }
+        let callback = try modifierAttribute(
+            modifierName: "_ValueActionModifier2<Optional<\(typeName)>>",
+            path: "modifier|action",
+            type: ((E?, E?) -> Void).self,
+            call: "onChange", index: index)
+        callback(oldValue, newValue)
+    }
 }
 
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -60,6 +60,50 @@ final class ViewEventsTests: XCTestCase {
         wait(for: [exp], timeout: 0.1)
     }
 
+    func testOnChangeInitial() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let val = ""
+        let sut = EmptyView().onChange(of: val, initial: true) {}
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testOnChangeInitialInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let val = Optional(Inspector.TestValue(value: "initial"))
+        let exp = XCTestExpectation(description: #function)
+        let sut = EmptyView().padding().onChange(of: val, initial: true) {
+            exp.fulfill()
+        }.padding()
+        try sut.inspect().emptyView()
+            .callOnChange(oldValue: val, newValue: Inspector.TestValue(value: "expected"))
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testOnChangeOldValueNewValue() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let val = ""
+        let sut = EmptyView().onChange(of: val) { _, _ in }
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testOnChangeOldValueNewValueInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let val = Optional(Inspector.TestValue(value: "initial"))
+        let exp = XCTestExpectation(description: #function)
+        let sut = EmptyView().padding().onChange(of: val) { oldValue, newValue in
+            XCTAssertEqual(oldValue, Inspector.TestValue(value: "initial"))
+            XCTAssertEqual(newValue, Inspector.TestValue(value: "expected"))
+            exp.fulfill()
+        }.padding()
+        try sut.inspect().emptyView()
+            .callOnChange(oldValue: val, newValue: Inspector.TestValue(value: "expected"))
+        wait(for: [exp], timeout: 0.1)
+    }
+
     func testMultipleOnChangeModifiersSameTypeCallFirst() throws {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }

--- a/readiness.md
+++ b/readiness.md
@@ -350,6 +350,8 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:---:|---|
 |:white_check_mark:| `func onReceive<P>(P, perform: (P.Output) -> Void) -> some View` |
 |:white_check_mark:| `func onChange<V>(of: V, perform: (V) -> Void) -> some View` |
+|:white_check_mark:| `func onChange<V>(of: V, initial: Bool = false, _ action: () -> Void) -> some View` |
+|:white_check_mark:| `func onChange<V>(of: V, initial: Bool = false, _ action: (V, V) -> Void) -> some View` |
 |:white_check_mark:| `func task(...) -> some View` |
 
 ### Handling View Hover and Focus


### PR DESCRIPTION
iOS 17 deprecated the prior `onChange` with a single callback parameter in favor of 2 new ones that can take an `initial:`, and callback with no parameters, or both old & new values.