### PR TITLE
Add support for ContentUnavailableView

### DIFF
--- a/Sources/ViewInspector/PopupPresenter.swift
+++ b/Sources/ViewInspector/PopupPresenter.swift
@@ -102,6 +102,7 @@ public extension ItemPopupPresenter where Popup == ActionSheet {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewModifier where Self: BasePopupPresenter {
+    @MainActor
     func content() throws -> ViewInspector.Content {
         let view = body(content: _ViewModifier_Content())
         return try view.inspect().implicitAnyView().viewModifierContent().content
@@ -110,9 +111,11 @@ public extension ViewModifier where Self: BasePopupPresenter {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewModifier where Self: PopupPresenter {
+    @MainActor
     var isPopoverPresenter: Bool {
         return (try? content().standardPopoverModifier()) != nil
     }
+    @MainActor
     var isSheetPresenter: Bool {
         return (try? content().standardSheetModifier()) != nil
     }
@@ -120,9 +123,11 @@ public extension ViewModifier where Self: PopupPresenter {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewModifier where Self: ItemPopupPresenter {
+    @MainActor
     var isPopoverPresenter: Bool {
         return (try? content().standardPopoverModifier()) != nil
     }
+    @MainActor
     var isSheetPresenter: Bool {
         return (try? content().standardSheetModifier()) != nil
     }

--- a/Sources/ViewInspector/SwiftUI/ContentUnavailableView.swift
+++ b/Sources/ViewInspector/SwiftUI/ContentUnavailableView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension ViewType {
+
+    struct ContentUnavailableView: KnownViewType {
+        public static let typePrefix: String = "ContentUnavailableView"
+    }
+}
+
+// MARK: - Extraction from SingleViewContent parent
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public extension InspectableView where View: SingleViewContent {
+
+    func contentUnavailableView() throws -> InspectableView<ViewType.ContentUnavailableView> {
+        return try .init(try child(), parent: self)
+    }
+}
+
+// MARK: - Extraction from MultipleViewContent parent
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public extension InspectableView where View: MultipleViewContent {
+
+    func contentUnavailableView(_ index: Int) throws -> InspectableView<ViewType.ContentUnavailableView> {
+        return try .init(try child(at: index), parent: self, index: index)
+    }
+}
+
+// MARK: - Non Standard Children
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+extension ViewType.ContentUnavailableView: SupplementaryChildrenLabelView {
+
+    static func supplementaryChildren(_ parent: UnwrappedView) throws -> LazyGroup<SupplementaryView> {
+        return .init(count: 3) { index in
+            let medium = parent.content.medium.resettingViewModifiers()
+            switch index {
+            case 0:
+                let child = try Inspector.attribute(label: "label", value: parent.content.view)
+                let content = try Inspector.unwrap(content: Content(child, medium: medium))
+                return try InspectableView<ViewType.ClassifiedView>(
+                    content, parent: parent, call: "labelView()")
+            case 1:
+                let child = try Inspector.attribute(label: "description", value: parent.content.view)
+                let content = try Inspector.unwrap(content: Content(child, medium: medium))
+                return try InspectableView<ViewType.ClassifiedView>(
+                    content, parent: parent, call: "description()")
+            default:
+                let child = try Inspector.attribute(label: "actions", value: parent.content.view)
+                let content = try Inspector.unwrap(content: Content(child, medium: medium))
+                return try InspectableView<ViewType.ClassifiedView>(
+                    content, parent: parent, call: "actions()")
+            }
+        }
+    }
+}
+
+// MARK: - Custom Attributes
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public extension InspectableView where View == ViewType.ContentUnavailableView {
+
+    func labelView() throws -> InspectableView<ViewType.ClassifiedView> {
+        return try View.supplementaryChildren(self).element(at: 0)
+            .asInspectableView(ofType: ViewType.ClassifiedView.self)
+    }
+
+    func description() throws -> InspectableView<ViewType.ClassifiedView> {
+        return try View.supplementaryChildren(self).element(at: 1)
+            .asInspectableView(ofType: ViewType.ClassifiedView.self)
+    }
+
+    func actions() throws -> InspectableView<ViewType.ClassifiedView> {
+        return try View.supplementaryChildren(self).element(at: 2)
+            .asInspectableView(ofType: ViewType.ClassifiedView.self)
+    }
+}

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -19,6 +19,7 @@ internal extension ViewSearch {
             ViewType.Color.self,
             ViewType.ColorPicker.self,
             ViewType.ConfirmationDialog.self,
+            ViewType.ContentUnavailableView.self,
             ViewType.ControlGroup.self,
             ViewType.DatePicker.self,
             ViewType.DisclosureGroup.self,

--- a/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
@@ -300,11 +300,13 @@ final class ActionSheetTests: XCTestCase {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension View {
+    @MainActor
     func actionSheet2(isPresented: Binding<Bool>,
                       content: @escaping () -> ActionSheet) -> some View {
         return self.modifier(InspectableActionSheet(isPresented: isPresented, popupBuilder: content))
     }
     
+    @MainActor
     func actionSheet2<Item>(item: Binding<Item?>,
                             content: @escaping (Item) -> ActionSheet
     ) -> some View where Item: Identifiable {

--- a/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
@@ -390,11 +390,13 @@ extension String: Identifiable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension View {
+    @MainActor
     func alert2(isPresented: Binding<Bool>,
                 content: @escaping () -> Alert) -> some View {
         return self.modifier(InspectableAlert(isPresented: isPresented, popupBuilder: content))
     }
     
+    @MainActor
     func alert2<Item>(item: Binding<Item?>,
                       content: @escaping (Item) -> Alert
     ) -> some View where Item: Identifiable {

--- a/Tests/ViewInspectorTests/SwiftUI/ContentUnavailableViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ContentUnavailableViewTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class ContentUnavailableViewTests: XCTestCase {
+
+    func testInspect() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        XCTAssertNoThrow(try ContentUnavailableView("title", systemImage: "swift", description: Text("desc")).inspect())
+    }
+
+    func testExtractionFromSingleViewContainer() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = AnyView(ContentUnavailableView("title", systemImage: "swift", description: Text("desc")))
+        XCTAssertNoThrow(try view.inspect().anyView().contentUnavailableView())
+    }
+
+    func testExtractionFromMultipleViewContainer() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = HStack {
+            Text("")
+            ContentUnavailableView("title", systemImage: "swift", description: Text("desc"))
+            Text("")
+        }
+        XCTAssertNoThrow(try view.inspect().hStack().contentUnavailableView(1))
+    }
+
+    func testSearch() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = HStack {
+            ContentUnavailableView { Text("tx") } description: { Text("desc") } actions: { Text("act") }
+        }
+        XCTAssertEqual(try view.inspect().find(ViewType.ContentUnavailableView.self).pathToRoot,
+                       "hStack().contentUnavailableView(0)")
+        XCTAssertEqual(try view.inspect().find(text: "tx").pathToRoot,
+                       "hStack().contentUnavailableView(0).labelView().text()")
+        XCTAssertEqual(try view.inspect().find(text: "desc").pathToRoot,
+                       "hStack().contentUnavailableView(0).description().text()")
+        XCTAssertEqual(try view.inspect().find(text: "act").pathToRoot,
+                       "hStack().contentUnavailableView(0).actions().text()")
+    }
+
+    func testLabelViewInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = ContentUnavailableView {
+            HStack { Text("abc") }
+        }
+        let sut = try view.inspect().contentUnavailableView().labelView().hStack(0).text(0).string()
+        XCTAssertEqual(sut, "abc")
+    }
+
+    func testDescriptionInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = ContentUnavailableView {
+        } description: {
+            VStack { Text("xyz") }
+        }
+        let sut = try view.inspect().contentUnavailableView().description().vStack(0).text(0).string()
+        XCTAssertEqual(sut, "xyz")
+    }
+
+    func testActionsInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let view = ContentUnavailableView {
+        } description: {
+        } actions: {
+            Group { Text("lmnop") }
+        }
+        let sut = try view.inspect().contentUnavailableView().actions().group(0).text(0).string()
+        XCTAssertEqual(sut, "lmnop")
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -225,6 +225,7 @@ final class FullScreenCoverTests: XCTestCase {
 @available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 @available(macOS, unavailable)
 private extension View {
+    @MainActor
     func fullScreenCover2<FullScreenCover>(isPresented: Binding<Bool>,
                                            onDismiss: (() -> Void)? = nil,
                                            @ViewBuilder content: @escaping () -> FullScreenCover
@@ -233,6 +234,7 @@ private extension View {
             isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content))
     }
 
+    @MainActor
     func fullScreenCover2<Item, FullScreenCover>(item: Binding<Item?>,
                                                  onDismiss: (() -> Void)? = nil,
                                                  content: @escaping (Item) -> FullScreenCover

--- a/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
@@ -255,6 +255,7 @@ final class PopoverDeprecatedTests: XCTestCase {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension View {
+    @MainActor
     func popover2<Popover>(isPresented: Binding<Bool>,
                            attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
                            arrowEdge: Edge = .top,
@@ -267,6 +268,7 @@ private extension View {
             popupBuilder: content))
     }
     
+    @MainActor
     func popover2<Item, Popover>(item: Binding<Item?>,
                                  attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
                                  arrowEdge: Edge = .top,

--- a/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
@@ -184,6 +184,7 @@ final class SheetTests: XCTestCase {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension View {
+    @MainActor
     func sheet2<Sheet>(isPresented: Binding<Bool>,
                        onDismiss: (() -> Void)? = nil,
                        @ViewBuilder content: @escaping () -> Sheet
@@ -191,6 +192,7 @@ private extension View {
         return self.modifier(InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content))
     }
     
+    @MainActor
     func sheet2<Item, Sheet>(item: Binding<Item?>,
                              onDismiss: (() -> Void)? = nil,
                              content: @escaping (Item) -> Sheet

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1F5B24C02C73962300F884E7 /* ContentUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B24BF2C73962300F884E7 /* ContentUnavailableView.swift */; };
+		1F5B24C32C73A06800F884E7 /* ContentUnavailableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B24C12C73A01F00F884E7 /* ContentUnavailableViewTests.swift */; };
 		1FA29F102AF0503000CCE6FA /* NavigationDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */; };
 		1FA29F132AF051AD00CCE6FA /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */; };
 		1FFB701D2B0C21DC004975B3 /* SpatialTapGestureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */; };
@@ -313,6 +315,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F5B24BF2C73962300F884E7 /* ContentUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableView.swift; sourceTree = "<group>"; };
+		1F5B24C12C73A01F00F884E7 /* ContentUnavailableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableViewTests.swift; sourceTree = "<group>"; };
 		1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestinationTests.swift; sourceTree = "<group>"; };
 		1FA29F112AF0515400CCE6FA /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
 		1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatialTapGestureTests.swift; sourceTree = "<group>"; };
@@ -696,6 +700,7 @@
 				F6FB7F5725476431006658EF /* ColorPicker.swift */,
 				F64057EC238DB1530029D9BA /* ConditionalContent.swift */,
 				52E24E9826E9378A00711987 /* ConfirmationDialog.swift */,
+				1F5B24BF2C73962300F884E7 /* ContentUnavailableView.swift */,
 				5220904B27763ABA001A899A /* ControlGroup.swift */,
 				F60EEBBE2382EED0007DB53A /* CustomView.swift */,
 				520F8C12266D0E600026BC57 /* CustomViewModifier.swift */,
@@ -824,6 +829,7 @@
 				F6FB7F6125476480006658EF /* ColorPickerTests.swift */,
 				F6F08E6723A2A67D001F04DF /* ConditionalContentTests.swift */,
 				52E24E9A26E93A4700711987 /* ConfirmationDialogTests.swift */,
+				1F5B24C12C73A01F00F884E7 /* ContentUnavailableViewTests.swift */,
 				5220904D27763ACF001A899A /* ControlGroupTests.swift */,
 				F60EEBEF2382F004007DB53A /* CustomViewTests.swift */,
 				F6B7D0092494E12F00ABB5E0 /* CustomViewBuilderTests.swift */,
@@ -1238,6 +1244,7 @@
 				F6C2E4D623AB214A00C7308F /* VisualEffectModifiers.swift in Sources */,
 				F60EEBDD2382EED0007DB53A /* Button.swift in Sources */,
 				F6C15AA3254DA270000240F1 /* ProgressView.swift in Sources */,
+				1F5B24C02C73962300F884E7 /* ContentUnavailableView.swift in Sources */,
 				F6ECF6CA23A66FE2000FC591 /* AnimationModifiers.swift in Sources */,
 				523E973D2A9B25FD002E8EB5 /* MultiDatePicker.swift in Sources */,
 				F66EDB5B23EDC19000A01B9F /* Spacer.swift in Sources */,
@@ -1290,6 +1297,7 @@
 				F6D933A12385B48100358E0E /* NavigationLinkTests.swift in Sources */,
 				F6C15A7B254B7555000240F1 /* OutlineGroupTests.swift in Sources */,
 				CDA844A1262B747000C56C98 /* CommonGestureTests.swift in Sources */,
+				1F5B24C32C73A06800F884E7 /* ContentUnavailableViewTests.swift in Sources */,
 				F64105CE257C3E1F0033D82D /* ViewSearchTests.swift in Sources */,
 				CDA844D4262B81AB00C56C98 /* SequenceGestureTests.swift in Sources */,
 				1FFB701D2B0C21DC004975B3 /* SpatialTapGestureTests.swift in Sources */,

--- a/readiness.md
+++ b/readiness.md
@@ -33,6 +33,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| ControlGroup | |
 |:white_check_mark:| ConditionalContent | `contained view` |
 |:white_check_mark:| ConfirmationDialog | `title view`, `message view`, `actions view`, `titleVisibility: Visibility`, `dismiss()` |
+|:white_check_mark:| ContentUnavailableView | `label view`, `description view`, `actions view` |
 |:white_check_mark:| Custom View | `actualView: CustomView`, `viewBuilder container` |
 |:white_check_mark:| Custom ViewModifier | |
 |:white_check_mark:| Custom ViewModifier.Content | |


### PR DESCRIPTION
iOS 17 added the `ContentUnavailableView` for use in empty state views. This PR adds support for finding these views & their subviews.