### PR TITLE
Add support for callRefreshable()

### DIFF
--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -186,7 +186,23 @@ final class ViewEventsTests: XCTestCase {
         try sut.inspect().callOnSubmit(of: .search)
         wait(for: [expSearch, expText], timeout: 0.1)
     }
-    
+
+    func testRefreshable() throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
+        let sut = EmptyView().refreshable { }
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testRefreshableInspection() async throws {
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
+        let exp = XCTestExpectation(description: #function)
+        let sut = EmptyView().padding().refreshable {
+            exp.fulfill()
+        }.padding().onDisappear(perform: { })
+        try await sut.inspect().emptyView().callRefreshable()
+        await fulfillment(of: [exp], timeout: 0.1)
+    }
+
     func testTask() throws {
         guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { throw XCTSkip() }
         let sut = EmptyView().task { }

--- a/readiness.md
+++ b/readiness.md
@@ -525,7 +525,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:technologist:| `func listSectionSeparator(_ visibility: Visibility, edges: VerticalEdge.Set) -> some View` |
 |:technologist:| `func listSectionSeparatorTint(_ color: Color?, edges: VerticalEdge.Set) -> some View` |
 |:technologist:| `func headerProminence(_ prominence: Prominence) -> some View` |
-|:technologist:| `func refreshable(action: @Sendable () async -> Void) -> some View` |
+|:white_check_mark:| `func refreshable(action: @Sendable () async -> Void) -> some View` |
 |:technologist:| `func searchable(text: Binding<String>, placement: SearchFieldPlacement, prompt: LocalizedStringKey) -> some View` |
 |:technologist:| `func searchCompletion(_ completion: String) -> some View` |
 


### PR DESCRIPTION
Adds support for `callRefreshable()`

iOS 17 changed the modifier, but both before & after got branches that worked. `readiness.md` was also updated to show support.

nalexn/ViewInspector#348