### PR TITLE
Add test demonstrating how to test fill color of a shape

### DIFF
--- a/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
@@ -127,6 +127,12 @@ final class ShapeTests: XCTestCase {
         XCTAssertEqual(try sut.endPoint(), UnitPoint.bottomLeading)
     }
     
+    func testFillColor() throws {
+        let view = Ellipse().fill(Color.blue)
+        let fillColor = try view.inspect().shape().fillShapeStyle(Color.self)
+        XCTAssertEqual(fillColor, Color.blue)
+    }
+
     func testFillStyle() throws {
         let fillStyle = FillStyle(eoFill: true, antialiased: false)
         let view = Ellipse().fill(style: fillStyle)


### PR DESCRIPTION
When I want to know how to test something in ViewInspector, the first place I look is in ViewInspector's tests. This test doesn't help development, but it does help me with "tests as documentation."

https://github.com/nalexn/ViewInspector/issues/357