### PR TITLE
Add support for inspecting Image rendering mode

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Image.swift
+++ b/Sources/ViewInspector/SwiftUI/Image.swift
@@ -115,6 +115,14 @@ public extension SwiftUI.Image {
         return try Inspector
             .attribute(label: "scale", value: rawImage(), type: CGFloat.self)
     }
+  
+    func renderingMode() throws -> TemplateRenderingMode? {
+        guard let renderingMode = try imageContent().medium.viewModifiers
+            .compactMap({ try? Inspector.attribute(label: "renderingMode", value: $0, type: TemplateRenderingMode.self) }).first else {
+                throw InspectionError.attributeNotFound(label: "renderingMode", type: "Image")
+        }
+        return renderingMode
+    }
     
     private func rawImage() throws -> Any {
         return try Inspector.attribute(path: "provider|base", value: try imageContent().view)

--- a/Sources/ViewInspector/SwiftUI/Image.swift
+++ b/Sources/ViewInspector/SwiftUI/Image.swift
@@ -116,11 +116,18 @@ public extension SwiftUI.Image {
             .attribute(label: "scale", value: rawImage(), type: CGFloat.self)
     }
   
-    func renderingMode() throws -> TemplateRenderingMode? {
-        guard let renderingMode = try imageContent().medium.viewModifiers
-            .compactMap({ try? Inspector.attribute(label: "renderingMode", value: $0, type: TemplateRenderingMode.self) }).first else {
-                throw InspectionError.attributeNotFound(label: "renderingMode", type: "Image")
+    func renderingMode() throws -> TemplateRenderingMode {
+        guard let renderingMode = try imageContent().medium.viewModifiers.compactMap({
+                try? Inspector.attribute(
+                    label: "renderingMode",
+                    value: $0,
+                    type: TemplateRenderingMode.self
+                )
+            }).first
+        else {
+            throw InspectionError.attributeNotFound(label: "renderingMode", type: "Image")
         }
+        
         return renderingMode
     }
     

--- a/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
@@ -46,6 +46,12 @@ final class ImageTests: XCTestCase {
         #endif
         XCTAssertEqual(image, testImage)
     }
+  
+    func testRenderingMode() throws {
+        let view = AnyView(imageView().renderingMode(.template).resizable())
+        let renderingMode = try view.inspect().anyView().image().actualImage().renderingMode()
+        XCTAssertEqual(renderingMode, .template)
+    }
     
     func testExtractionCGImage() throws {
         let cgImage = testImage.cgImage!

--- a/readiness.md
+++ b/readiness.md
@@ -61,7 +61,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| HSplitView | `contained view` |
 |:white_check_mark:| HStack | `contained view`, `alignment: VerticalAlignment`, `spacing: CGFloat?` |
 |:white_check_mark:| Image | `label view`, `actualImage: Image` |
-|:white_check_mark:| Image (*) | `rootImage: Image`, `name: String?`, `(ui,ns,cg)Image: (UI,NS,CG)Image`, `orientation: Image.Orientation`, `scale: CGFloat` |
+|:white_check_mark:| Image (*) | `rootImage: Image`, `name: String?`, `(ui,ns,cg)Image: (UI,NS,CG)Image`, `orientation: Image.Orientation`, `scale: CGFloat`, `renderingMode: Image.TemplateRenderingMode` |
 |:white_check_mark:| Label | `title view`, `icon view` |
 |:white_check_mark:| LabeledContent | `contained view`, `label view` |
 |:white_check_mark:| LabelStyleConfiguration.Icon | |


### PR DESCRIPTION
This feature branch adds support for inspecting Image rendering mode.

Usage:
```swift
let renderingMode = try view.inspect()
    .implicitAnyView()
    .image()
    .actualImage()
    .renderingMode()
```