### PR TITLE
Add navigationTitle (Binding) support

### DIFF
--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -45,7 +45,11 @@ public extension InspectableView {
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func navigationTitle() throws -> String {
-        return try navigationTitleBinding().wrappedValue
+        do {
+            return try navigationTitleBinding().wrappedValue
+        } catch {
+            throw InspectionError.notSupported("navigationTitle() is only supported with a Binding<String> parameter.")
+        }
     }
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)

--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -42,6 +42,23 @@ public extension InspectableView {
             modifierName: "TransactionalPreferenceModifier<Bool, StatusBarKey>",
             path: "modifier|value", type: Bool.self, call: "statusBar(hidden:)")
     }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func navigationTitle() throws -> String {
+        return try navigationTitleBinding().wrappedValue
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func setNavigationTitle(_ value: String) throws {
+        try navigationTitleBinding().wrappedValue = value
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    private func navigationTitleBinding() throws -> Binding<String> {
+        return try modifierAttribute(
+            modifierName: "NavigationPropertiesModifier<Never, EmptyView, TextField<Text>>",
+            path: "modifier|title|some|_text", type: Binding<String>.self, call: "navigationTitle")
+    }
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)

--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -54,7 +54,11 @@ public extension InspectableView {
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func setNavigationTitle(_ value: String) throws {
-        try navigationTitleBinding().wrappedValue = value
+        do {
+            try navigationTitleBinding().wrappedValue = value
+        } catch {
+            throw InspectionError.notSupported("navigationTitle() is only supported with a Binding<String> parameter.")
+        }
     }
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)

--- a/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
@@ -216,4 +216,13 @@ final class NavigationTitleBindingTests: XCTestCase {
         try sut.setNavigationTitle("abc")
         XCTAssertEqual(try sut.navigationTitle(), "abc")
     }
+
+    func testNavigationTitleText() throws {
+        XCTAssertThrows(try EmptyView().navigationTitle(Text("123")).inspect().navigationTitle(),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
+        XCTAssertThrows(try EmptyView().navigationTitle("123").inspect().navigationTitle(),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
+        XCTAssertThrows(try EmptyView().navigationTitle(String("123")).inspect().navigationTitle(),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
+    }
 }

--- a/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
@@ -224,5 +224,11 @@ final class NavigationTitleBindingTests: XCTestCase {
                         "navigationTitle() is only supported with a Binding<String> parameter.")
         XCTAssertThrows(try EmptyView().navigationTitle(String("123")).inspect().navigationTitle(),
                         "navigationTitle() is only supported with a Binding<String> parameter.")
+        XCTAssertThrows(try EmptyView().navigationTitle(Text("123")).inspect().setNavigationTitle(""),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
+        XCTAssertThrows(try EmptyView().navigationTitle("123").inspect().setNavigationTitle(""),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
+        XCTAssertThrows(try EmptyView().navigationTitle(String("123")).inspect().setNavigationTitle(""),
+                        "navigationTitle() is only supported with a Binding<String> parameter.")
     }
 }

--- a/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/NavigationBarModifiersTests.swift
@@ -199,3 +199,21 @@ final class StatusBarConfigurationTests: XCTestCase {
     }
     #endif
 }
+
+@MainActor
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+final class NavigationTitleBindingTests: XCTestCase {
+
+    func testNavigationTitleInspection() throws {
+        let sut = EmptyView().navigationTitle(.constant("bound"))
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testNavigationTitleBinding() throws {
+        let binding = Binding(wrappedValue: "123")
+        let sut = try EmptyView().navigationTitle(binding).inspect()
+        XCTAssertEqual(try sut.navigationTitle(), "123")
+        try sut.setNavigationTitle("abc")
+        XCTAssertEqual(try sut.navigationTitle(), "abc")
+    }
+}

--- a/readiness.md
+++ b/readiness.md
@@ -536,6 +536,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| `func navigationBarItems(...) -> some View` |
 |:technologist:| `func navigationBarTitle(...) -> some View` |
 |:technologist:| `func navigationTitle(...) -> some View` |
+|:white_check_mark:| `func navigationTitle(_ title: Binding<String>) -> some View` |
 |:technologist:| `func navigationSubtitle(...) -> some View` |
 |:technologist:| `func navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode) -> some View` |
 |:white_check_mark:| `func navigationBarHidden(Bool) -> some View` |


### PR DESCRIPTION
While `navigationTitle(String | Text | LocalizedStringKey)` is a bit difficult to pin down for inspection, we can get the binding from `navigationTitle(Binding<String>)` fairly simply. This PR adds `navigationTitle() -> String`, and `setNavigationTitle(String)` methods.

I would hope the same `navigationTitle() -> String` VI method eventually is extended to handle the SwiftUI `navigationTitle(String | Text | LocalizedStringKey)` cases too.