### PR TITLE
Confine implicit any to compiler version 6.0

### DIFF
--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -164,7 +164,7 @@ public extension InspectableView {
     }
 }
 
-#if compiler(<6)
+#if compiler(<6) || compiler(>=6.1)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView where View: SingleViewContent {
     func implicitAnyView() throws -> InspectableView<View> {

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -75,7 +75,7 @@ final class InspectorTests: XCTestCase {
     
     func testPrintValue() {
         let sut = TestPrintView()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let str = """
                 TestPrintView
                   body: Text
@@ -145,7 +145,7 @@ final class InspectorTests: XCTestCase {
     
     func testPrintTypeReference() {
         let sut = ViewWithTypeReference()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(Inspector.print(sut), """
             ViewWithTypeReference
               body: EmptyView = EmptyView()
@@ -260,7 +260,7 @@ final class InspectableViewModifiersTests: XCTestCase {
                     TestPrintView().padding()
                 })
            })
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let sut = try view.inspect().anyView().group().emptyView(1).overlay()
             .hStack().view(TestPrintView.self, 1).text()
         #else
@@ -300,7 +300,7 @@ final class InspectableViewModifiersTests: XCTestCase {
         let view2 = TestPrintView()
         let sut3 = try view2.inspect()
         XCTAssertEqual(sut3.pathToRoot, "")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let sut4 = try view2.inspect().text()
         XCTAssertEqual(sut4.pathToRoot, "view(TestPrintView.self).text()")
         let sut5 = try view2.inspect().text(0)
@@ -323,7 +323,7 @@ final class InspectableViewModifiersTests: XCTestCase {
                     TestPrintView().padding()
                 })
            })
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let sut1 = try view1.inspect().anyView().group().emptyView(1).overlay()
             .hStack().view(TestPrintView.self, 1).text()
         XCTAssertEqual(sut1.pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ActionSheetTests.swift
@@ -50,7 +50,7 @@ final class ActionSheetTests: XCTestCase {
         let sut = EmptyView().actionSheet2(isPresented: binding) {
             ActionSheet(title: Text("abc"))
         }
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title = try sut.inspect().emptyView().actionSheet().title()
         XCTAssertEqual(try title.string(), "abc")
         XCTAssertEqual(title.pathToRoot, "emptyView().actionSheet().title()")
@@ -66,7 +66,7 @@ final class ActionSheetTests: XCTestCase {
         let sut = EmptyView().actionSheet2(isPresented: binding) {
             ActionSheet(title: Text("abc"), message: Text("123"))
         }
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let message = try sut.inspect().emptyView().actionSheet().message()
         XCTAssertEqual(try message.string(), "123")
         XCTAssertEqual(message.pathToRoot, "emptyView().actionSheet().message()")
@@ -100,7 +100,7 @@ final class ActionSheetTests: XCTestCase {
         XCTAssertEqual(try btn1.labelView().string(), "b1")
         XCTAssertEqual(try btn2.labelView().string(), "b2")
         XCTAssertEqual(try btn3.labelView().string(), "b3")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try btn1.labelView().pathToRoot, "emptyView().actionSheet().button(0).labelView()")
         XCTAssertEqual(try btn2.labelView().pathToRoot, "emptyView().actionSheet().button(1).labelView()")
         XCTAssertEqual(try btn3.labelView().pathToRoot, "emptyView().actionSheet().button(2).labelView()")
@@ -180,7 +180,7 @@ final class ActionSheetTests: XCTestCase {
         let binding3 = Binding(wrappedValue: true)
         let sut = ActionSheetFindTestView(sheet1: binding1, sheet2: binding2, sheet3: binding3)
 
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title1 = try sut.inspect().hStack().emptyView(0).actionSheet().title()
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
@@ -220,7 +220,7 @@ final class ActionSheetTests: XCTestCase {
         let sut = ActionSheetFindTestView(sheet1: binding, sheet2: binding, sheet3: binding)
         
         // 1
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
             "view(ActionSheetFindTestView.self).hStack().emptyView(0).actionSheet().title()")
         XCTAssertEqual(try sut.inspect().find(text: "message_1").pathToRoot,
@@ -255,7 +255,7 @@ final class ActionSheetTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().find(text: "title_2").pathToRoot, noMatchMessage)
         
         // 3
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
             "view(ActionSheetFindTestView.self).hStack().emptyView(0).actionSheet(1).title()")
         
@@ -273,7 +273,7 @@ final class ActionSheetTests: XCTestCase {
     }
     
     func testAlertVsActionSheetMessage() throws {
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let sut = try PopupMixTestView().inspect().emptyView()
         let alert = try sut.alert()
         #else

--- a/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/AlertTests.swift
@@ -50,7 +50,7 @@ final class DeprecatedAlertTests: XCTestCase {
         let sut = EmptyView().alert2(isPresented: binding) { Alert(title: Text("abc")) }
         let title = try sut.inspect().implicitAnyView().emptyView().alert().title()
         XCTAssertEqual(try title.string(), "abc")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(title.pathToRoot, "emptyView().alert().title()")
         #else
         XCTAssertEqual(title.pathToRoot, "anyView().emptyView().alert().title()")
@@ -64,7 +64,7 @@ final class DeprecatedAlertTests: XCTestCase {
         }
         let message = try sut.inspect().implicitAnyView().emptyView().alert().message()
         XCTAssertEqual(try message.text().string(), "123")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(message.pathToRoot, "emptyView().alert().message()")
         #else
         XCTAssertEqual(message.pathToRoot, "anyView().emptyView().alert().message()")
@@ -86,7 +86,7 @@ final class DeprecatedAlertTests: XCTestCase {
         }
         let label = try sut.inspect().implicitAnyView().emptyView().alert().primaryButton().labelView()
         XCTAssertEqual(try label.string(), "xyz")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(label.pathToRoot, "emptyView().alert().primaryButton().labelView()")
         #else
         XCTAssertEqual(label.pathToRoot, "anyView().emptyView().alert().primaryButton().labelView()")
@@ -101,7 +101,7 @@ final class DeprecatedAlertTests: XCTestCase {
         }
         let label = try sut.inspect().implicitAnyView().emptyView().alert().secondaryButton().labelView()
         XCTAssertEqual(try label.string(), "xyz")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(label.pathToRoot, "emptyView().alert().secondaryButton().labelView()")
         #else
         XCTAssertEqual(label.pathToRoot, "anyView().emptyView().alert().secondaryButton().labelView()")
@@ -176,7 +176,7 @@ final class DeprecatedAlertTests: XCTestCase {
         let sut2 = EmptyView().alert2(isPresented: binding) {
             Alert(title: Text(""), message: nil, dismissButton: .destructive(Text("")))
         }
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(
             try sut1.inspect().emptyView().alert().primaryButton().style(), .default)
         XCTAssertEqual(
@@ -230,7 +230,7 @@ final class DeprecatedAlertTests: XCTestCase {
         let binding2 = Binding(wrappedValue: true)
         let binding3 = Binding(wrappedValue: true)
         let sut = AlertFindTestView(alert1: binding1, alert2: binding2, alert3: binding3)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title1 = try sut.inspect().hStack().emptyView(0).alert().title()
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
@@ -264,7 +264,7 @@ final class DeprecatedAlertTests: XCTestCase {
         let sut = AlertFindTestView(alert1: binding, alert2: binding, alert3: binding)
         
         // 1
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
             "view(AlertFindTestView.self).hStack().emptyView(0).alert().title()")
         XCTAssertEqual(try sut.inspect().find(text: "message_1").pathToRoot,
@@ -299,7 +299,7 @@ final class DeprecatedAlertTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().find(text: "title_2").pathToRoot, noMatchMessage)
         
         // 3
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
             "view(AlertFindTestView.self).hStack().emptyView(0).alert(1).title()")
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot, noMatchMessage)
@@ -340,7 +340,7 @@ final class AlertIOS15Tests: XCTestCase {
         XCTAssertEqual(try alert.title().string(), "Title")
         let message = try alert.message().hStack().text(0)
         XCTAssertEqual(try message.string(), "Message: abc")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(message.pathToRoot,
                        "emptyView().alert().message().hStack().text(0)")
         let secondButtonLabel = try alert.actions().button(1).labelView().text()

--- a/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ConditionalContentTests.swift
@@ -25,13 +25,13 @@ final class ConditionalContentTests: XCTestCase {
     
     func testRetainsModifiers() throws {
         let sut = ConditionalViewWithModifier(value: true)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let text = try sut.inspect().text()
         #else
         let text = try sut.inspect().implicitAnyView().anyView().text()
         #endif
         XCTAssertEqual(try text.string(), "True")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().text().padding(),
                        EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
         #else

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewBuilderTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewBuilderTests.swift
@@ -94,7 +94,7 @@ final class CustomViewBuilderTests: XCTestCase {
         }
         let sut = try view.inspect()
         let path1 = try sut.find(text: "Test").pathToRoot
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let path2 = try sut.hStack().view(TestViewBuilderView<EmptyView>.self, 0).text(0).pathToRoot
         XCTAssertEqual(path1, "hStack().view(TestViewBuilderView<EmptyView>.self, 0).text(0)")
         XCTAssertEqual(path2, "hStack().view(TestViewBuilderView<EmptyView>.self, 0).text(0)")
@@ -120,7 +120,7 @@ final class CustomViewBuilderTests: XCTestCase {
         let sut = try view.inspect()
         XCTAssertNoThrow(try sut.find(ViewWrapper<ViewWrapper<Text>>.self))
         XCTAssertNoThrow(try sut.find(ViewWrapper<Text>.self))
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.find(ViewType.Text.self).pathToRoot,
                        "view(ViewWrapper<EmptyView>.self).view(ViewWrapper<EmptyView>.self).text()")
         #else

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewModifierTests.swift
@@ -67,7 +67,7 @@ final class ModifiedContentTests: XCTestCase {
         let sut = try view.inspect().emptyView().modifier(TestModifier.self)
         let content = try sut.implicitAnyView().viewModifierContent()
         XCTAssertNoThrow(try content.callOnAppear())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(content.pathToRoot,
                        "emptyView().modifier(TestModifier.self).viewModifierContent()")
         #else
@@ -87,7 +87,7 @@ final class ModifiedContentTests: XCTestCase {
         let sut1 = try view.inspect().emptyView().modifier(TestModifier.self)
         XCTAssertEqual(try sut1.actualView().tag, 1)
         let content1 = try sut1.implicitAnyView().viewModifierContent()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(content1.pathToRoot,
             "emptyView().modifier(TestModifier.self).viewModifierContent()")
         #else
@@ -96,7 +96,7 @@ final class ModifiedContentTests: XCTestCase {
         #endif
         let sut2 = try view.inspect().emptyView().modifier(TestModifier2.self)
         let content2 = try sut2.find(ViewType.ViewModifierContent.self)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(content2.pathToRoot,
             "emptyView().modifier(TestModifier2.self).hStack().viewModifierContent(1)")
         #else
@@ -106,7 +106,7 @@ final class ModifiedContentTests: XCTestCase {
         let sut3 = try view.inspect().emptyView().modifier(TestModifier.self, 1)
         XCTAssertEqual(try sut3.actualView().tag, 2)
         let content3 = try sut3.implicitAnyView().viewModifierContent()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(content3.pathToRoot,
             "emptyView().modifier(TestModifier.self, 1).viewModifierContent()")
         #else
@@ -161,7 +161,7 @@ final class ModifiedContentTests: XCTestCase {
         let sut2 = EmptyView().modifier(TestModifier3()).environmentObject(ExternalState())
         let content = try sut2.inspect().emptyView().modifier(TestModifier3.self).implicitAnyView().group().viewModifierContent(0)
         let text = try sut2.inspect().emptyView().modifier(TestModifier3.self).implicitAnyView().group().text(1)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(content.pathToRoot,
             "emptyView().modifier(TestModifier3.self).group().viewModifierContent(0)")
         XCTAssertEqual(text.pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/CustomViewTests.swift
@@ -73,7 +73,7 @@ final class CustomViewTests: XCTestCase {
         let explicit = try sut.inspect()
             .view(SimpleTestView.self)
             .implicitAnyView().emptyView().pathToRoot
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(implicit, "view(SimpleTestView.self).emptyView()")
         XCTAssertEqual(explicit, "view(SimpleTestView.self).emptyView()")
         #else
@@ -191,7 +191,7 @@ final class CustomViewTests: XCTestCase {
     }
     
     func testSyncSearch() throws {
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let sut1 = AnyView(SimpleTestView())
         XCTAssertEqual(try sut1.inspect().find(ViewType.EmptyView.self).pathToRoot,
                        "anyView().view(SimpleTestView.self).emptyView()")
@@ -216,7 +216,7 @@ final class CustomViewTests: XCTestCase {
         let sut = AnyView(view)
         let viewModel = ExternalState()
         let exp = view.inspection.inspect { view in
-            #if compiler(<6)
+            #if compiler(<6) || compiler(>=6.1)
             XCTAssertEqual(try view.find(text: viewModel.value).pathToRoot,
                            "view(EnvironmentStateTestView.self).text()")
             #else
@@ -261,7 +261,7 @@ final class CustomViewTests: XCTestCase {
         let sut = try AnyView(NameMatchViewList()).inspect()
         XCTAssertEqual(try sut.find(NameMatchViewList.self).pathToRoot,
                        "anyView().view(NameMatchViewList.self)")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.find(NameMatchView.self).pathToRoot,
                        "anyView().view(NameMatchViewList.self).forEach().view(NameMatchView.self, 0)")
         #else
@@ -274,7 +274,7 @@ final class CustomViewTests: XCTestCase {
         let sut = try AnyView(GenericContainer<String>()).inspect()
         XCTAssertEqual(try sut.find(GenericContainer<String>.self).pathToRoot,
                        "anyView().view(GenericContainer<EmptyView>.self)")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.find(GenericContainer<String>.TestView.self).pathToRoot,
             "anyView().view(GenericContainer<EmptyView>.self).view(TestView.self)")
         #else

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -61,7 +61,7 @@ final class FullScreenCoverTests: XCTestCase {
         }
         let title = try sut.inspect().implicitAnyView().emptyView().fullScreenCover().text()
         XCTAssertEqual(try title.string(), "abc")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(title.pathToRoot, "emptyView().fullScreenCover().text()")
         #else
         XCTAssertEqual(title.pathToRoot, "anyView().emptyView().fullScreenCover().text()")
@@ -79,7 +79,7 @@ final class FullScreenCoverTests: XCTestCase {
         let button = try sut.inspect().implicitAnyView().emptyView().fullScreenCover().button(1)
         try button.tap()
         XCTAssertFalse(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(button.pathToRoot, "emptyView().fullScreenCover().button(1)")
         #else
         XCTAssertEqual(button.pathToRoot, "anyView().emptyView().fullScreenCover().button(1)")
@@ -95,7 +95,7 @@ final class FullScreenCoverTests: XCTestCase {
             exp.fulfill()
         }, content: { Text("") })
         XCTAssertTrue(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         try sut.inspect().fullScreenCover().dismiss()
         XCTAssertFalse(binding.wrappedValue)
         XCTAssertThrows(try sut.inspect().fullScreenCover(), "View for FullScreenCover is absent")
@@ -128,7 +128,7 @@ final class FullScreenCoverTests: XCTestCase {
         let binding3 = Binding(wrappedValue: true)
         let sut = FullScreenCoverFindTestView(
             fullScreenCover1: binding1, fullScreenCover2: binding2, fullScreenCover3: binding3)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title1 = try sut.inspect().hStack().emptyView(0).fullScreenCover().text(0)
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
@@ -142,7 +142,7 @@ final class FullScreenCoverTests: XCTestCase {
             .anyView().emptyView().fullScreenCover().text(0)
             """)
         #endif
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title2 = try sut.inspect().implicitAnyView().hStack().emptyView(0).fullScreenCover(1).text(0)
         XCTAssertEqual(try title2.string(), "title_3")
         XCTAssertEqual(title2.pathToRoot,
@@ -170,7 +170,7 @@ final class FullScreenCoverTests: XCTestCase {
             fullScreenCover1: binding, fullScreenCover2: binding, fullScreenCover3: binding)
 
         // 1
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
             "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).sheet().text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_1").pathToRoot,
@@ -197,7 +197,7 @@ final class FullScreenCoverTests: XCTestCase {
         // 3
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
             "Search did not find a match")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
             "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).sheet(1).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/LabelTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/LabelTests.swift
@@ -99,7 +99,7 @@ final class GlobalModifiersForLabel: XCTestCase {
             "styleConfigurationTitle() found EmptyView instead of LabelStyleConfiguration.Title")
         XCTAssertThrows(try EmptyView().inspect().styleConfigurationIcon(),
             "styleConfigurationIcon() found EmptyView instead of LabelStyleConfiguration.Icon")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(ViewType.StyleConfiguration.Title.self).pathToRoot,
                        "vStack().styleConfigurationTitle(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.StyleConfiguration.Icon.self).pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/MenuTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/MenuTests.swift
@@ -90,7 +90,7 @@ final class MenuTests: XCTestCase {
         let sut = TestMenuStyle()
         let menu = try sut.inspect().implicitAnyView().vStack().menu(0)
         XCTAssertEqual(try menu.blur().radius, 3)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(ViewType.StyleConfiguration.Content.self).pathToRoot,
                        "vStack().menu(0).styleConfigurationContent(0)")
         #else

--- a/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/NavigationLinkTests.swift
@@ -63,7 +63,7 @@ final class NavigationLinkTests: XCTestCase {
                        "anyView().navigationView().navigationLink(0)")
         XCTAssertEqual(try view.inspect().find(navigationLink: "Screen 2").pathToRoot,
                        "anyView().navigationView().navigationLink(1)")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try view.inspect().find(text: "Screen 1").pathToRoot,
                        "anyView().navigationView().navigationLink(0).view(TestView.self).text()")
         #else
@@ -215,7 +215,7 @@ final class NavigationLinkTests: XCTestCase {
             .init(view: TestRecursiveGenericView
                 .init(view: TestRecursiveGenericView
                     .init(view: Text("test"))))
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let container = "view(TestRecursiveGenericView<EmptyView>.self)."
         #else
         let container = "view(TestRecursiveGenericView<EmptyView>.self).anyView()."
@@ -233,7 +233,7 @@ final class NavigationLinkTests: XCTestCase {
                       childs: [
                         .init(name: "A", childs: [.init(name: "A.1"), .init(name: "A.2")]),
                       ]))
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "A.2").pathToRoot,
             """
             view(TestTreeView.self).vStack().forEach(1).view(TestTreeView.self, \

--- a/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/OptionalViewTests.swift
@@ -39,7 +39,7 @@ final class OptionalViewTests: XCTestCase {
     func testSearch() throws {
         let view1 = AnyView(MixedOptionalView(flag: true))
         let view2 = AnyView(MixedOptionalView(flag: false))
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try view1.inspect().find(text: "ABC").pathToRoot,
                        "anyView().view(MixedOptionalView.self).hStack().text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "XYZ").pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PopoverTests.swift
@@ -53,7 +53,7 @@ final class PopoverTests: XCTestCase {
         }
         let title = try sut.inspect().implicitAnyView().emptyView().popover().text()
         XCTAssertEqual(try title.string(), "abc")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(title.pathToRoot, "emptyView().popover().text()")
         #else
         XCTAssertEqual(title.pathToRoot, "anyView().emptyView().popover().text()")
@@ -69,7 +69,7 @@ final class PopoverTests: XCTestCase {
         let button = try sut.inspect().implicitAnyView().emptyView().popover().button(1)
         try button.tap()
         XCTAssertFalse(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(button.pathToRoot, "emptyView().popover().button(1)")
         #else
         XCTAssertEqual(button.pathToRoot, "anyView().emptyView().popover().button(1)")
@@ -80,7 +80,7 @@ final class PopoverTests: XCTestCase {
         let binding = Binding(wrappedValue: true)
         let sut = EmptyView().popover2(isPresented: binding, content: { Text("") })
         XCTAssertTrue(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         try sut.inspect().popover().dismiss()
         XCTAssertFalse(binding.wrappedValue)
         XCTAssertThrows(try sut.inspect().popover(), "View for Popover is absent")
@@ -99,7 +99,7 @@ final class PopoverTests: XCTestCase {
         XCTAssertEqual(binding.wrappedValue, 6)
         try popover.dismiss()
         XCTAssertNil(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertThrows(try sut.inspect().popover(), "View for Popover is absent")
         #else
         XCTAssertThrows(try sut.inspect().implicitAnyView().emptyView().popover(), "View for Popover is absent")
@@ -111,7 +111,7 @@ final class PopoverTests: XCTestCase {
         let binding2 = Binding(wrappedValue: true)
         let binding3 = Binding(wrappedValue: true)
         let sut = PopoverFindTestView(popover1: binding1, popover2: binding2, popover3: binding3)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title1 = try sut.inspect().hStack().emptyView(0).popover().text(0)
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
@@ -146,7 +146,7 @@ final class PopoverTests: XCTestCase {
         let sut = PopoverFindTestView(popover1: binding, popover2: binding, popover3: binding)
         
         // 1
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
             "view(PopoverFindTestView.self).hStack().emptyView(0).popover().text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_1").pathToRoot,
@@ -168,7 +168,7 @@ final class PopoverTests: XCTestCase {
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
             "Search did not find a match")
 
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
             "view(PopoverFindTestView.self).hStack().emptyView(0).popover(1).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/PreferenceTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/PreferenceTests.swift
@@ -98,7 +98,7 @@ final class PreferenceTests: XCTestCase {
     
     func testOverlaySearch() throws {
         let sut1 = try ManyOverlaysView().inspect()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut1.find(text: "Test").pathToRoot,
             "view(ManyOverlaysView.self).emptyView().overlay().anyView().text()")
         XCTAssertEqual(try sut1.find(text: Key.defaultValue).pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/ProgressViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ProgressViewTests.swift
@@ -106,7 +106,7 @@ final class ProgressViewTests: XCTestCase {
         """)
         XCTAssertEqual(try sut.inspect(fractionCompleted: 0.42).implicitAnyView()
                         .vStack().text(2).string(), "Completed: 42%")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(ViewType.StyleConfiguration.Label.self).pathToRoot,
                        "vStack().styleConfigurationLabel(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.StyleConfiguration.CurrentValueLabel.self).pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
@@ -49,7 +49,7 @@ final class SheetTests: XCTestCase {
         }
         let title = try sut.inspect().implicitAnyView().emptyView().sheet().text()
         XCTAssertEqual(try title.string(), "abc")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(title.pathToRoot, "emptyView().sheet().text()")
         #else
         XCTAssertEqual(title.pathToRoot, "anyView().emptyView().sheet().text()")
@@ -65,7 +65,7 @@ final class SheetTests: XCTestCase {
         let button = try sut.inspect().implicitAnyView().emptyView().sheet().button(1)
         try button.tap()
         XCTAssertFalse(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(button.pathToRoot, "emptyView().sheet().button(1)")
         #else
         XCTAssertEqual(button.pathToRoot, "anyView().emptyView().sheet().button(1)")
@@ -79,7 +79,7 @@ final class SheetTests: XCTestCase {
             exp.fulfill()
         }, content: { Text("") })
         XCTAssertTrue(binding.wrappedValue)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         try sut.inspect().sheet().dismiss()
         XCTAssertFalse(binding.wrappedValue)
         XCTAssertThrows(try sut.inspect().sheet(), "View for Sheet is absent")
@@ -107,7 +107,7 @@ final class SheetTests: XCTestCase {
         let binding2 = Binding(wrappedValue: true)
         let binding3 = Binding(wrappedValue: true)
         let sut = SheetFindTestView(sheet1: binding1, sheet2: binding2, sheet3: binding3)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         let title1 = try sut.inspect().hStack().emptyView(0).sheet().text(0)
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
@@ -140,7 +140,7 @@ final class SheetTests: XCTestCase {
         let sut = SheetFindTestView(sheet1: binding, sheet2: binding, sheet3: binding)
         
         // 1
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_1").pathToRoot,
             "view(SheetFindTestView.self).hStack().emptyView(0).sheet().text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_1").pathToRoot,
@@ -161,7 +161,7 @@ final class SheetTests: XCTestCase {
         // 3
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
             "Search did not find a match")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
             "view(SheetFindTestView.self).hStack().emptyView(0).sheet(1).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
@@ -30,7 +30,7 @@ final class TupleViewTests: XCTestCase {
     func testSearch() throws {
         let view1 = TupleInsideTupleView(flag: true)
         let view2 = TupleInsideTupleView(flag: false)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try view1.inspect().find(text: "xyz").pathToRoot,
                        "view(TupleInsideTupleView.self).hStack().text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "abc").pathToRoot,

--- a/Tests/ViewInspectorTests/SwiftUI/ViewThatFitsTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ViewThatFitsTests.swift
@@ -79,7 +79,7 @@ final class ViewThatFitsTests: XCTestCase {
         guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
         else { throw XCTSkip() }
         let view = AnyView(TestViewThatFits())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try view.inspect().find(text: TestViewThatFits.longString).pathToRoot,
             "anyView().view(TestViewThatFits.self).viewThatFits().text(0)")
         XCTAssertEqual(try view.inspect().find(text: TestViewThatFits.shortString).pathToRoot,

--- a/Tests/ViewInspectorTests/ViewModifiers/CustomStyleModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/CustomStyleModifiersTests.swift
@@ -16,7 +16,7 @@ final class CustomStyleModifiersTests: XCTestCase {
 
     func testHelloWorldStyleInspection() throws {
         let sut = EmptyView().helloWorldStyle(RedOutlineHelloWorldStyle())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertTrue(try sut.inspect().customStyle("helloWorldStyle") is RedOutlineHelloWorldStyle)
         #else
         XCTAssertTrue(try sut.inspect().implicitAnyView().emptyView().customStyle("helloWorldStyle") is RedOutlineHelloWorldStyle)

--- a/Tests/ViewInspectorTests/ViewModifiers/TransitiveModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/TransitiveModifiersTests.swift
@@ -10,7 +10,7 @@ final class TransitiveModifiersTests: XCTestCase {
         let sut = try HittenTestView().inspect()
         XCTAssertFalse(try sut.find(text: "abc").isHidden())
         XCTAssertTrue(try sut.find(text: "123").isHidden())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertThrows(try sut.find(button: "123").tap(),
             "Button is unresponsive: view(HittenTestView.self).vStack().hStack(1) is hidden")
         #else
@@ -24,7 +24,7 @@ final class TransitiveModifiersTests: XCTestCase {
         XCTAssertFalse(try sut.find(button: "1").isDisabled())
         XCTAssertFalse(try sut.find(button: "2").isDisabled())
         XCTAssertTrue(try sut.find(button: "3").isDisabled())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertThrows(try sut.find(button: "3").tap(),
             "Button is unresponsive: view(TestDisabledView.self).vStack().vStack(1).vStack(1) is disabled")
         #else
@@ -70,7 +70,7 @@ final class TransitiveModifiersTests: XCTestCase {
         XCTAssertTrue(try sut.find(button: "1").allowsHitTesting())
         XCTAssertTrue(try sut.find(button: "2").allowsHitTesting())
         XCTAssertFalse(try sut.find(button: "3").allowsHitTesting())
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertThrows(try sut.find(button: "3").tap(),
             """
             Button is unresponsive: view(AllowsHitTestingTestView.self).vStack()\

--- a/Tests/ViewInspectorTests/ViewSearchTests.swift
+++ b/Tests/ViewInspectorTests/ViewSearchTests.swift
@@ -97,7 +97,7 @@ final class ViewSearchTests: XCTestCase {
         let testView = Test.MainView()
         XCTAssertEqual(try testView.inspect().find(text: "123").pathToRoot,
         "view(MainView.self).anyView().group().text(1)")
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try testView.inspect().find(text: "Test_en").pathToRoot,
         """
         view(MainView.self).anyView().group().emptyView(0).overlay().hStack()\
@@ -228,7 +228,7 @@ final class ViewSearchTests: XCTestCase {
         else { throw XCTSkip() }
         let style = Test.ConflictingViewTypeNamesStyle()
         let sut = try style.inspect(isPressed: true)
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.find(text: "empty").pathToRoot,
                        "group().view(EmptyView.self, 0).text()")
         XCTAssertEqual(try sut.find(ViewType.Label.self).pathToRoot,
@@ -284,7 +284,7 @@ extension ViewSearchTests {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let sut = Test.AccessibleView()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(viewWithAccessibilityLabel: "text1_access").pathToRoot,
                        "view(AccessibleView.self).button().labelView().hStack().text(0)")
         #else
@@ -301,7 +301,7 @@ extension ViewSearchTests {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let sut = Test.AccessibleView()
-        #if compiler(<6)
+        #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(viewWithAccessibilityIdentifier: "text2_access").pathToRoot,
                        "view(AccessibleView.self).button().mask().group().text(0)")
         #else


### PR DESCRIPTION
Xcode 16.3 with Swift 6.1 removes the implicit `AnyView`s except when actually previewing. In the long run this is simpler, though it's a bit of a pain here in a library that needs to support both way for a time.