### PR TITLE
Add testStrokeContent to demonstrate how

### DIFF
--- a/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ShapeTests.swift
@@ -140,6 +140,14 @@ final class ShapeTests: XCTestCase {
         XCTAssertEqual(sut, fillStyle)
     }
     
+    
+    func testStrokeContent() throws {
+        let content = Color.blue
+        let view = Ellipse().stroke(content, lineWidth: 1)
+        let sut = try view.inspect().shape().fillShapeStyle(Color.self)
+        XCTAssertEqual(sut, content)
+    }
+    
     func testMissingAttribute() throws {
         let sut = Ellipse().offset()
         XCTAssertThrows(


### PR DESCRIPTION
I couldn’t find a clear way to test shape border color, so I added this test as a helpful example. It aims to guide others facing the same challenge and serve as living documentation.
