### PR TITLE
Make customInspectableContent MainActor isolated

### DIFF
--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -15,6 +15,7 @@ public protocol Inspectable { }
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol CustomInspectable {
     associatedtype View: SwiftUI.View
+    @MainActor
     var customInspectableContent: View { get }
 }
 


### PR DESCRIPTION
Looks like `customInspectableContent` can be MainActor isolated, which will play more nicely with strict swift concurrency.

<img width="948" alt="Screenshot 2025-05-03 at 10 27 41 AM" src="https://github.com/user-attachments/assets/77726262-fc8d-491d-aa0b-7b29b669d21e" />
