### PR TITLE
Add support for extracting LocalizedStringResource

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -132,6 +132,11 @@ private extension ViewType.Text {
                 throw InspectionError.notSupported("AttributedString is not supported in this OS version")
             }
             return String(try view.attributedString().characters)
+        case "LocalizedStringResourceStorage":
+            guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
+                throw InspectionError.notSupported("LocalizedStringResource is not supported in this OS version")
+            }
+            return try extractString(localizedStringResourceStorage: textStorage)
         default:
             throw InspectionError.notSupported("Unknown text storage: \(storageType)")
         }
@@ -192,6 +197,15 @@ private extension ViewType.Text {
     
     private static func extractString(dateTextStorage: Any) throws -> String {
         throw InspectionError.notSupported("Inspection of formatted Date is currently not supported")
+    }
+    
+    // MARK: - LocalizedStringResourceStorage
+    
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    private static func extractString(localizedStringResourceStorage: Any) throws -> String {
+        let resource = try Inspector
+            .attribute(label: "resource", value: localizedStringResourceStorage, type: LocalizedStringResource.self)
+        return String(localized: resource)
     }
     
     // MARK: - LocalizedTextStorage

--- a/Sources/ViewInspector/SwiftUI/Text.swift
+++ b/Sources/ViewInspector/SwiftUI/Text.swift
@@ -136,7 +136,7 @@ private extension ViewType.Text {
             guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
                 throw InspectionError.notSupported("LocalizedStringResource is not supported in this OS version")
             }
-            return try extractString(localizedStringResourceStorage: textStorage)
+            return try extractString(localizedStringResourceStorage: textStorage, locale)
         default:
             throw InspectionError.notSupported("Unknown text storage: \(storageType)")
         }
@@ -202,9 +202,10 @@ private extension ViewType.Text {
     // MARK: - LocalizedStringResourceStorage
     
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    private static func extractString(localizedStringResourceStorage: Any) throws -> String {
-        let resource = try Inspector
+    private static func extractString(localizedStringResourceStorage: Any, _ locale: Locale) throws -> String {
+        var resource = try Inspector
             .attribute(label: "resource", value: localizedStringResourceStorage, type: LocalizedStringResource.self)
+        resource.locale = locale
         return String(localized: resource)
     }
     

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -45,6 +45,19 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test")
     }
     
+    func testLocalizedStringResourceStringWithLocaleNoParams() throws {
+        let bundle = try Bundle.testResources()
+        let resource = LocalizedStringResource("Test", table: "Test", bundle: .atURL(bundle.bundleURL))
+        let sut = Text(resource)
+        let text = try sut.inspect().text()
+        let value1 = try text.string(locale: Locale(identifier: "en"))
+        XCTAssertEqual(value1, "Test_en")
+        let value2 = try text.string(locale: Locale(identifier: "en_AU"))
+        XCTAssertEqual(value2, "Test_en_au")
+        let value3 = try text.string(locale: Locale(identifier: "ru"))
+        XCTAssertEqual(value3, "Тест_ru")
+    }
+    
     func testResourceLocalizationStringNoParams() throws {
         let bundle = try Bundle.testResources()
         let sut = Text("Test", tableName: "Test", bundle: bundle)

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -38,44 +38,6 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test")
     }
     
-    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    func testLocalizedStringResourceStringNoParams() throws {
-        let resource = LocalizedStringResource("Test")
-        let sut = Text(resource)
-        let value = try sut.inspect().text().string()
-        XCTAssertEqual(value, "Test")
-    }
-    
-    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    func testLocalizedStringResourceStringWithLocaleNoParams() throws {
-        let bundle = try Bundle.testResources()
-        let resource = LocalizedStringResource("Test", table: "Test", bundle: .atURL(bundle.bundleURL))
-        let sut = Text(resource)
-        let text = try sut.inspect().text()
-        let value1 = try text.string(locale: Locale(identifier: "en"))
-        XCTAssertEqual(value1, "Test_en")
-        let value2 = try text.string(locale: Locale(identifier: "en_AU"))
-        XCTAssertEqual(value2, "Test_en_au")
-        let value3 = try text.string(locale: Locale(identifier: "ru"))
-        XCTAssertEqual(value3, "Тест_ru")
-    }
-    
-    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    func testLocalizedStringResourceWithOneParam() throws {
-        let resource = LocalizedStringResource("Test \(12)")
-        let sut = Text(resource)
-        let value = try sut.inspect().text().string()
-        XCTAssertEqual(value, "Test 12")
-    }
-    
-    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    func testLocalizedStringResourceWithMultipleParams() throws {
-        let resource = LocalizedStringResource("Test \(12) \(5.7, specifier: "%.1f") \("abc")")
-        let sut = Text(resource)
-        let value = try sut.inspect().text().string()
-        XCTAssertEqual(value, "Test 12 5.7 abc")
-    }
-    
     func testResourceLocalizationStringNoParams() throws {
         let bundle = try Bundle.testResources()
         let sut = Text("Test", tableName: "Test", bundle: bundle)
@@ -295,6 +257,54 @@ final class TextTests: XCTestCase {
         else { throw XCTSkip() }
         let sut = Text(5000, format: .currency(code: "USD").scale(100).locale(Locale(identifier: "en")))
         XCTAssertEqual(try sut.inspect().text().string(), "$500,000.00")
+    }
+    
+    // MARK: - LocalizedStringResource
+    
+    func testLocalizedStringResourceStringNoParams() throws {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+        else { throw XCTSkip() }
+        
+        let resource = LocalizedStringResource("Test")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test")
+    }
+    
+    func testLocalizedStringResourceStringWithLocaleNoParams() throws {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+        else { throw XCTSkip() }
+        
+        let bundle = try Bundle.testResources()
+        let resource = LocalizedStringResource("Test", table: "Test", bundle: .atURL(bundle.bundleURL))
+        let sut = Text(resource)
+        let text = try sut.inspect().text()
+        let value1 = try text.string(locale: Locale(identifier: "en"))
+        XCTAssertEqual(value1, "Test_en")
+        let value2 = try text.string(locale: Locale(identifier: "en_AU"))
+        XCTAssertEqual(value2, "Test_en_au")
+        let value3 = try text.string(locale: Locale(identifier: "ru"))
+        XCTAssertEqual(value3, "Тест_ru")
+    }
+    
+    func testLocalizedStringResourceWithOneParam() throws {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+        else { throw XCTSkip() }
+        
+        let resource = LocalizedStringResource("Test \(12)")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test 12")
+    }
+    
+    func testLocalizedStringResourceWithMultipleParams() throws {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+        else { throw XCTSkip() }
+        
+        let resource = LocalizedStringResource("Test \(12) \(5.7, specifier: "%.1f") \("abc")")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test 12 5.7 abc")
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -38,6 +38,7 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test")
     }
     
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     func testLocalizedStringResourceStringNoParams() throws {
         let resource = LocalizedStringResource("Test")
         let sut = Text(resource)
@@ -45,6 +46,7 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test")
     }
     
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     func testLocalizedStringResourceStringWithLocaleNoParams() throws {
         let bundle = try Bundle.testResources()
         let resource = LocalizedStringResource("Test", table: "Test", bundle: .atURL(bundle.bundleURL))
@@ -58,6 +60,7 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value3, "Тест_ru")
     }
     
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     func testLocalizedStringResourceWithOneParam() throws {
         let resource = LocalizedStringResource("Test \(12)")
         let sut = Text(resource)
@@ -65,6 +68,7 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test 12")
     }
     
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     func testLocalizedStringResourceWithMultipleParams() throws {
         let resource = LocalizedStringResource("Test \(12) \(5.7, specifier: "%.1f") \("abc")")
         let sut = Text(resource)

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -38,6 +38,13 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value, "Test")
     }
     
+    func testLocalizedStringResourceStringNoParams() throws {
+        let resource = LocalizedStringResource("Test")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test")
+    }
+    
     func testResourceLocalizationStringNoParams() throws {
         let bundle = try Bundle.testResources()
         let sut = Text("Test", tableName: "Test", bundle: bundle)

--- a/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextTests.swift
@@ -58,6 +58,20 @@ final class TextTests: XCTestCase {
         XCTAssertEqual(value3, "Тест_ru")
     }
     
+    func testLocalizedStringResourceWithOneParam() throws {
+        let resource = LocalizedStringResource("Test \(12)")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test 12")
+    }
+    
+    func testLocalizedStringResourceWithMultipleParams() throws {
+        let resource = LocalizedStringResource("Test \(12) \(5.7, specifier: "%.1f") \("abc")")
+        let sut = Text(resource)
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, "Test 12 5.7 abc")
+    }
+    
     func testResourceLocalizationStringNoParams() throws {
         let bundle = try Bundle.testResources()
         let sut = Text("Test", tableName: "Test", bundle: bundle)


### PR DESCRIPTION
This feature branch adds support for extracting strings from Text backed by `LocalizedStringResource`.
Resolves #375, Extracting localized strings from Text views

Tested on macOS 15.2, iOS 16.0 (Simulator), iOS 17.2 (Simulator),  iOS 18.0 (Simulator)

Usage:
```swift
let resource = LocalizedStringResource("Test")
let text = Text(resource)
let value = try text.inspect().text().string()
```

Please let me know if you would like me to change something in the PR.