### PR TITLE
Add support for MagnifyGesture

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Gesture.swift
+++ b/Sources/ViewInspector/SwiftUI/Gesture.swift
@@ -311,6 +311,7 @@ internal extension InspectableView {
             "GestureStateGesture": .state,
             "LongPressGesture": .simple,
             "MagnificationGesture": .simple,
+            "MagnifyGesture": .simple,
             "RotationGesture": .simple,
             "SequenceGesture": .composed,
             "SimultaneousGesture": .composed,
@@ -446,4 +447,31 @@ public extension SpatialTapGesture.Value {
             to: SpatialTapGesture.Value.self
         )
    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public extension MagnifyGesture.Value {
+
+    private struct Allocator {
+        var time: Date
+        var magnification: CGFloat
+        var velocity: CGFloat
+        var startAnchor: UnitPoint
+        var startLocation: CGPoint
+    }
+
+    init(time: Date, magnification: CGFloat, velocity: CGFloat, startAnchor: UnitPoint, startLocation: CGPoint) {
+        self = unsafeBitCast(
+            Allocator(
+                time: time,
+                magnification: magnification,
+                velocity: velocity,
+                startAnchor: startAnchor,
+                startLocation: startLocation
+            ),
+            to: MagnifyGesture.Value.self
+        )
+    }
 }

--- a/Tests/ViewInspectorTests/Gestures/ExclusiveGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/ExclusiveGestureTests.swift
@@ -61,6 +61,18 @@ final class ExclusiveGestureTests: XCTestCase {
         XCTAssertEqual(exclusiveGesture.second.minimumAngleDelta, Angle(degrees: 5))
     }
     
+    @available(iOS 17.0, macOS 14.0, *)
+    func testExclusiveGestureWithMagnifyAndRotateGestures() throws {
+        let sut = EmptyView().gesture(ExclusiveGesture(
+            MagnifyGesture(minimumScaleDelta: 1.5),
+            RotationGesture(minimumAngleDelta: Angle(degrees: 5))))
+        let emptyView = try sut.inspect().emptyView()
+        let gesture = try emptyView.gesture(ExclusiveGesture<MagnifyGesture, RotationGesture>.self)
+        let exclusiveGesture = try gesture.actualGesture()
+        XCTAssertEqual(exclusiveGesture.first.minimumScaleDelta, 1.5)
+        XCTAssertEqual(exclusiveGesture.second.minimumAngleDelta, Angle(degrees: 5))
+    }
+    
     func testExclusiveGestureWithUpdatingModifier() throws {
         try gestureTests!.propertiesWithUpdatingModifierTest()
     }

--- a/Tests/ViewInspectorTests/Gestures/GestureModifiers/HighPriorityGestureModifierTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/GestureModifiers/HighPriorityGestureModifierTests.swift
@@ -102,4 +102,15 @@ final class HighPriorityGestureModifierTests: XCTestCase {
         let path = try sut.inspect().emptyView().highPriorityGesture(LongPressGesture.self, 1).pathToRoot
         XCTAssertEqual(path, "emptyView().highPriorityGesture(LongPressGesture.self, 1)")
     }
+    
+    func testHighPriorityGestureWithSimultaneousGestureContainingDragGestureAndMagnificationGesture() throws {
+        guard #available(iOS 17.0, macOS 14.0, *) else { throw XCTSkip() }
+        let sut = EmptyView()
+            .padding(100)
+            .highPriorityGesture(SimultaneousGesture(DragGesture(), MagnifyGesture()))
+        
+        XCTAssertNoThrow(
+            try sut.inspect().emptyView().highPriorityGesture(SimultaneousGesture<DragGesture, MagnifyGesture>.self)
+        )
+    }
 }

--- a/Tests/ViewInspectorTests/Gestures/MagnifyGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/MagnifyGestureTests.swift
@@ -1,0 +1,191 @@
+#if !os(watchOS) && !os(tvOS)
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+// MARK: - Magnify Gesture Tests
+@MainActor
+@available(iOS 17.0, macOS 14.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+final class MagnifyGestureTests: XCTestCase {
+    var magnifyTime: Date?
+    var magnifyMagnification: CGFloat?
+    var magnifyVelocity: CGFloat?
+    var magnifyStartAnchor: UnitPoint?
+    var magnifyStartLocation: CGPoint?
+    var magnifyValue: MagnifyGesture.Value?
+    
+    var gestureTests: CommonGestureTests<MagnifyGesture>?
+    
+    override func setUpWithError() throws {
+        magnifyTime = Date()
+        magnifyMagnification = 10
+        magnifyVelocity = 2.5
+        magnifyStartAnchor = .center
+        magnifyStartLocation = CGPoint(x: 5, y: 5)
+        magnifyValue = MagnifyGesture.Value(
+            time: magnifyTime!,
+            magnification: magnifyMagnification!,
+            velocity: magnifyVelocity!,
+            startAnchor: magnifyStartAnchor!,
+            startLocation: magnifyStartLocation!
+        )
+        gestureTests = CommonGestureTests<MagnifyGesture>(testCase: self,
+                                                          gesture: MagnifyGesture(),
+                                                          value: magnifyValue!,
+                                                          assert: assertMagnifyValue)
+    }
+    
+    override func tearDownWithError() throws {
+        magnifyTime = nil
+        magnifyMagnification = nil
+        magnifyVelocity = nil
+        magnifyStartAnchor = nil
+        magnifyStartLocation = nil
+        magnifyValue = nil
+        gestureTests = nil
+    }
+    
+    func testMagnifyGestureValueAllocator() throws {
+        let date = Date(timeIntervalSince1970: 53513627)
+        let magnification: CGFloat = 2.5
+        let velocity: CGFloat = 1.2
+        let startAnchor = UnitPoint(x: 0.3, y: 0.7)
+        let startLocation = CGPoint(x: 123, y: -456)
+        let sut = MagnifyGesture.Value(
+            time: date,
+            magnification: magnification,
+            velocity: velocity,
+            startAnchor: startAnchor,
+            startLocation: startLocation
+        )
+        XCTAssertEqual(sut.time, date)
+        XCTAssertEqual(sut.magnification, magnification)
+        XCTAssertEqual(sut.velocity, velocity)
+        XCTAssertEqual(sut.startAnchor, startAnchor)
+        XCTAssertEqual(sut.startLocation, startLocation)
+    }
+
+    func testCreateMagnifyGestureValue() throws {
+        XCTAssertNotNil(magnifyTime)
+        XCTAssertNotNil(magnifyMagnification)
+        XCTAssertNotNil(magnifyVelocity)
+        XCTAssertNotNil(magnifyStartAnchor)
+        XCTAssertNotNil(magnifyStartLocation)
+        let value = try XCTUnwrap(magnifyValue)
+        assertMagnifyValue(value)
+    }
+    
+    func testMagnifyGestureMask() throws {
+        try gestureTests!.maskTest()
+    }
+    
+    func testMagnifyGesture() throws {
+        let sut = EmptyView()
+            .gesture(MagnifyGesture(minimumScaleDelta: 1.5))
+        let magnificationGesture = try sut.inspect().emptyView().gesture(MagnifyGesture.self).actualGesture()
+        XCTAssertEqual(magnificationGesture.minimumScaleDelta, 1.5)
+    }
+
+    func testMagnifyGestureWithUpdatingModifier() throws {
+        try gestureTests!.propertiesWithUpdatingModifierTest()
+    }
+    
+    func testMagnifyGestureWithOnChangedModifier() throws {
+        try gestureTests!.propertiesWithOnChangedModifierTest()
+    }
+    
+    func testMagnifyGestureWithOnEndedModifier() throws {
+        try gestureTests!.propertiesWithOnEndedModifierTest()
+    }
+    
+    #if os(macOS)
+    func testMagnifyGestureWithModifiers() throws {
+        try gestureTests!.propertiesWithModifiersTest()
+    }
+    #endif
+    
+    func testMagnifyGestureFailure() throws {
+        try gestureTests!.propertiesFailureTest("MagnifyGesture")
+    }
+
+    func testMagnifyGestureCallUpdating() throws {
+        try gestureTests!.callUpdatingTest()
+    }
+    
+    func testMagnifyGestureCallUpdatingNotFirst() throws {
+        try gestureTests!.callUpdatingNotFirstTest()
+    }
+
+    func testMagnifyGestureCallUpdatingMultiple() throws {
+        try gestureTests!.callUpdatingMultipleTest()
+    }
+    
+    func testMagnifyGestureCallUpdatingFailure() throws {
+        try gestureTests!.callUpdatingFailureTest()
+    }
+    
+    func testMagnifyGestureCallOnChanged() throws {
+        try gestureTests!.callOnChangedTest()
+    }
+    
+    func testMagnifyGestureCallOnChangedNotFirst() throws {
+        try gestureTests!.callOnChangedNotFirstTest()
+    }
+    
+    func testMagnifyGestureCallOnChangedMultiple() throws {
+        try gestureTests!.callOnChangedMultipleTest()
+    }
+    
+    func testMagnifyGestureCallOnChangedFailure() throws {
+        try gestureTests!.callOnChangedFailureTest()
+    }
+    
+    func testMagnifyGestureCallOnEnded() throws {
+        try gestureTests!.callOnEndedTest()
+    }
+    
+    func testMagnifyGestureCallOnEndedNotFirst() throws {
+        try gestureTests!.callOnEndedNotFirstTest()
+    }
+
+    func testMagnifyGestureCallOnEndedMultiple() throws {
+        try gestureTests!.callOnEndedMultipleTest()
+    }
+    
+    func testMagnifyGestureCallOnEndedFailure() throws {
+        try gestureTests!.callOnEndedFailureTest()
+    }
+    
+    #if os(macOS)
+    func testMagnifyGestureModifiers() throws {
+        try gestureTests!.modifiersTest()
+    }
+        
+    func testMagnifyGestureModifiersNotFirst() throws {
+        try gestureTests!.modifiersNotFirstTest()
+    }
+    
+    func testMagnifyGestureModifiersMultiple() throws {
+        try gestureTests!.modifiersMultipleTest()
+    }
+    
+    func testMagnifyGestureModifiersNone() throws {
+        try gestureTests!.modifiersNoneTest()
+    }
+    #endif
+
+    func assertMagnifyValue(
+        _ value: MagnifyGesture.Value,
+        file: StaticString = #filePath,
+        line: UInt = #line) {
+        XCTAssertEqual(value.time, magnifyTime, file: file, line: line)
+        XCTAssertEqual(value.magnification, magnifyMagnification, file: file, line: line)
+        XCTAssertEqual(value.velocity, magnifyVelocity, file: file, line: line)
+        XCTAssertEqual(value.startAnchor, magnifyStartAnchor, file: file, line: line)
+        XCTAssertEqual(value.startLocation, magnifyStartLocation, file: file, line: line)
+    }
+}
+
+#endif

--- a/Tests/ViewInspectorTests/Gestures/SequenceGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/SequenceGestureTests.swift
@@ -61,6 +61,18 @@ final class SequenceGestureTests: XCTestCase {
         XCTAssertEqual(sequenceGesture.first.minimumScaleDelta, 1.5)
         XCTAssertEqual(sequenceGesture.second.minimumAngleDelta, Angle(degrees: 5))
     }
+    
+    @available(iOS 17.0, macOS 14.0, *)
+    func testSequenceGestureWithMagnifyAndRotateGestures() throws {
+        let sut = EmptyView().gesture(SequenceGesture(
+            MagnifyGesture(minimumScaleDelta: 1.5),
+            RotationGesture(minimumAngleDelta: Angle(degrees: 5))))
+        let emptyView = try sut.inspect().emptyView()
+        let gesture = try emptyView.gesture(SequenceGesture<MagnifyGesture, RotationGesture>.self)
+        let sequenceGesture = try gesture.actualGesture()
+        XCTAssertEqual(sequenceGesture.first.minimumScaleDelta, 1.5)
+        XCTAssertEqual(sequenceGesture.second.minimumAngleDelta, Angle(degrees: 5))
+    }
 
     func testSequenceGestureWithUpdatingModifier() throws {
         try gestureTests!.propertiesWithUpdatingModifierTest()

--- a/Tests/ViewInspectorTests/Gestures/SimultaneousGestureTests.swift
+++ b/Tests/ViewInspectorTests/Gestures/SimultaneousGestureTests.swift
@@ -72,6 +72,18 @@ final class SimultaneousGestureTests: XCTestCase {
         XCTAssertEqual(simultaneousGesture.second.minimumAngleDelta, Angle(degrees: 5))
     }
     
+    @available(iOS 17.0, macOS 14.0, *)
+    func testSimultaneousGestureWithMagnifyAndRotateGestures() throws {
+        let sut = EmptyView().gesture(SimultaneousGesture(
+            MagnifyGesture(minimumScaleDelta: 1.5),
+            RotationGesture(minimumAngleDelta: Angle(degrees: 5))))
+        let emptyView = try sut.inspect().emptyView()
+        let gesture = try emptyView.gesture(SimultaneousGesture<MagnifyGesture, RotationGesture>.self)
+        let simultaneousGesture = try gesture.actualGesture()
+        XCTAssertEqual(simultaneousGesture.first.minimumScaleDelta, 1.5)
+        XCTAssertEqual(simultaneousGesture.second.minimumAngleDelta, Angle(degrees: 5))
+    }
+    
     func testSimultaneousGestureWithUpdatingModifier() throws {
         try gestureTests!.propertiesWithUpdatingModifierTest()
     }

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0A77CAAA2E38D506005AA6AA /* MagnifyGestureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77CAA92E38D503005AA6AA /* MagnifyGestureTests.swift */; };
 		1F5B24C02C73962300F884E7 /* ContentUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B24BF2C73962300F884E7 /* ContentUnavailableView.swift */; };
 		1F5B24C32C73A06800F884E7 /* ContentUnavailableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B24C12C73A01F00F884E7 /* ContentUnavailableViewTests.swift */; };
 		1FA29F102AF0503000CCE6FA /* NavigationDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */; };
@@ -315,6 +316,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A77CAA92E38D503005AA6AA /* MagnifyGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagnifyGestureTests.swift; sourceTree = "<group>"; };
 		1F5B24BF2C73962300F884E7 /* ContentUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableView.swift; sourceTree = "<group>"; };
 		1F5B24C12C73A01F00F884E7 /* ContentUnavailableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableViewTests.swift; sourceTree = "<group>"; };
 		1FA29F0F2AF0503000CCE6FA /* NavigationDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestinationTests.swift; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 				CDA844AB262B771F00C56C98 /* DragGestureTests.swift */,
 				CDA844B5262B7E6900C56C98 /* LongPressGestureTests.swift */,
 				CDA844BB262B7EA800C56C98 /* MagnificationGestureTests.swift */,
+				0A77CAA92E38D503005AA6AA /* MagnifyGestureTests.swift */,
 				CDA844C1262B7EEE00C56C98 /* RotationGestureTests.swift */,
 				1FFB701C2B0C21DC004975B3 /* SpatialTapGestureTests.swift */,
 				CDA844C7262B7F3100C56C98 /* TapGestureTests.swift */,
@@ -1293,6 +1296,7 @@
 				CDA8451C262CC34D00C56C98 /* CommonComposedGestureChangedTests.swift in Sources */,
 				525076282650000600ADE4E7 /* AlertTests.swift in Sources */,
 				F60EEBF92382F004007DB53A /* InspectorTests.swift in Sources */,
+				0A77CAAA2E38D506005AA6AA /* MagnifyGestureTests.swift in Sources */,
 				F6D933A52385DC0F00358E0E /* TabViewTests.swift in Sources */,
 				F6D933A12385B48100358E0E /* NavigationLinkTests.swift in Sources */,
 				F6C15A7B254B7555000240F1 /* OutlineGroupTests.swift in Sources */,


### PR DESCRIPTION
This PR adds support for [MagnifyGesture](https://developer.apple.com/documentation/swiftui/magnifygesture) introduced in iOS 17

It resolves [Issue #391](https://github.com/nalexn/ViewInspector/issues/391), where gesture inspection failed due to `MagnifyGesture` not being recognized in knownGestures by:
- Adding `"MagnifyGesture"` to the `knownGestures` dictionary
- Providing an initializer for `MagnifyGesture.Value`
- Covering the new gesture with multiple test cases



Let me know if anything needs to be adjusted!