### PR TITLE
[Xcode 26] Add support for retrieving `accessibilityIdentifier` on iOS 26.

### DIFF
--- a/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
@@ -106,7 +106,13 @@ public extension InspectableView {
     
     func accessibilityIdentifier() throws -> String {
         let call = "accessibilityIdentifier"
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+            return try modifierAttribute(
+                modifierName: "AccessibilityAttachmentModifier",
+                path: "modifier|storage|value|properties|identifier|some|rawValue",
+                type: String.self,
+                call: call)
+        } else if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try v3AccessibilityElement(
                 path: "some|rawValue", type: String.self,
                 call: call, { $0.accessibilityIdentifier("") })


### PR DESCRIPTION
## Problem 
As we're working to support Xcode 26 and prepare our app to run on iOS 26, we noticed failures in our tests related to the inspection of the `accessibilityIdentifier` value.

Searching by the accessibility identifier no longer works on iOS 26.
This failure can be reproduced by the [test](https://github.com/nalexn/ViewInspector/blob/8283ec2485689e32874e2bf4f90afde6ff953215/Tests/ViewInspectorTests/ViewSearchTests.swift#L300) `testFindViewWithAccessibilityIdentifier()`:

| ✅ Xcode 26 running on iOS 18.5  | ❌ Xcode 26 running on iOS 26 | 
| --------------------------------- | ------------------------------- |
| <img width="1588" height="968" alt="before_iOS18_pass" src="https://github.com/user-attachments/assets/2b3a178e-9cd5-47f1-8101-4fc49704d225" /> |  <img width="1582" height="980" alt="before_iOS26_fail" src="https://github.com/user-attachments/assets/beaeeba9-500f-45a6-86d6-879f628bc485" /> |

## Root cause

The root cause of the issue is the layout change of the inspected type `AccessibilityProperties`.

Consider the inspection of the following SwiftUI Button:

```swift
Button("SecondButton") {
  print(("SecondButton tapped"))
}
.accessibilityIdentifier("Button2_Identifier")
```

### iOS 18.5:
```
▿ AccessibilityProperties
  ▿ storage : 1 element
    ▿ 0 : 2 elements
      ▿ key : ObjectIdentifier(0x00000001ef446678)
        - _value : (Opaque Value)
      ▿ value : AccessibilityPropertiesEntry<Optional<AccessibilityIdentifierStorage>>
        ▿ typedValue : Optional<AccessibilityIdentifierStorage>
          ▿ some : AccessibilityIdentifierStorage
            - rawValue : "Button2_Identifier"
            - placement : SwiftUI.AccessibilityIdentifierStorage.Placement.assign
``` 

### iOS 26:
```
▿ AccessibilityProperties
  ▿ identifier : Optional<AccessibilityIdentifierStorage>
    ▿ some : AccessibilityIdentifierStorage
      - rawValue : "Button2_Identifier"
      - placement : SwiftUI.AccessibilityIdentifierStorage.Placement.assign
  - label : nil
  - traits : nil
  - value : nil
  - visibility : nil
  - textLayoutProperties : nil
  ▿ storage : CustomPropertyStorage
    - storage : 0 elements
``` 

## The fix

The fix consists of adding support for the new layout in the `InspectableView.accessibilityIdentifier()` implementation.

## Validation

I verified that the aforementioned test (`testFindViewWithAccessibilityIdentifier()`) that failed on iOS 26 caused by this issue now passes.
I also ensured that it still pass on iOS 18.5.

## Please review

@nalexn 
@bachand 
