### PR TITLE
[Xcode 26] Add support for inspecting `tag` modifier value on iOS 26.

### DIFF
--- a/Sources/ViewInspector/SwiftUI/TabView.swift
+++ b/Sources/ViewInspector/SwiftUI/TabView.swift
@@ -56,9 +56,15 @@ public extension InspectableView where View: MultipleViewContent {
 public extension InspectableView {
     
     func tag() throws -> AnyHashable {
-        return try modifierAttribute(
-            modifierName: "TagValueTraitKey",
-            path: "modifier|value|tagged", type: AnyHashable.self, call: "tag")
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+            return try modifierAttribute(
+                modifierName: "_TagTraitWritingModifier",
+                path: "modifier|tag", type: AnyHashable.self, call: "tag")
+        } else {
+            return try modifierAttribute(
+                modifierName: "TagValueTraitKey",
+                path: "modifier|value|tagged", type: AnyHashable.self, call: "tag")
+        }
     }
     
     func tabItem() throws -> InspectableView<ViewType.ClassifiedView> {


### PR DESCRIPTION
## Problem 
Following up on the updates to support Xcode 26:
 - #393

Searching for SwiftUI views based on the `tag` modifier does not work on iOS 26.

This failure can be reproduced by the [test](https://github.com/nalexn/ViewInspector/blob/e755279608f57bd451db34fc95d314847d2e4864/Tests/ViewInspectorTests/ViewSearchTests.swift#L203-L209) `testFindViewWithTag()`:

| ✅ Xcode 26 running on iOS 18.5  | ❌ Xcode 26 running on iOS 26 | 
| --------------------------------- | ------------------------------- |
| <img width="1735" height="974" alt="before_iOS18_pass" src="https://github.com/user-attachments/assets/162d2c34-22b6-4008-adc2-b48ad80026b9" /> | <img width="1741" height="971" alt="before_iOS26_fail" src="https://github.com/user-attachments/assets/512ca77f-a186-488a-9563-7cba49f2abdd" /> |

## Root cause

The root cause of the issue is the change of the modifier genetic type.
Consider the following simple view with a `Int` tag:

```swift
Text("Tagged View") . tag (4)
```

The undocumented type representing the `Int` tag changed from `_TraitWritingModifier<TagValueTraitKey<Optional<Int>>>` to `_TagTraitWritingModifier<Int>`.

Below are representations of the same `InspectableView` for the same SwiftUI View above in both iOS versions:

### iOS 18.5:
```
▿ InspectableView<ClassifiedView>
  ▿ content : Content
    ▿ view : Text
      ▿ storage : Storage
        ▿ anyTextStorage : <LocalizedTextStorage: 0x0000600002114000>: "Tagged View"
      - modifiers : 0 elements
    ▿ medium : Medium
      ▿ viewModifiers : 2 elements
        ▿ 0 : ModifiedContent<ModifiedContent<Text, _TraitWritingModifier<TagValueTraitKey<Int>>>, _TraitWritingModifier<TagValueTraitKey<Optional<Int>>>>
          ▿ content : ModifiedContent<Text, _TraitWritingModifier<TagValueTraitKey<Int>>>
            ▿ content : Text
              ▿ storage : Storage
                ▿ anyTextStorage : <LocalizedTextStorage: 0x0000600002114000>: "Tagged View"
              - modifiers : 0 elements
            ▿ modifier : _TraitWritingModifier<TagValueTraitKey<Int>>
              ▿ value : Value
                - tagged : 4
          ▿ modifier : _TraitWritingModifier<TagValueTraitKey<Optional<Int>>>
            ▿ value : Value
              ▿ tagged : Optional<Int>
                - some : 4
        ▿ 1 : ModifiedContent<Text, _TraitWritingModifier<TagValueTraitKey<Int>>>
          ▿ content : Text
            ▿ storage : Storage
              ▿ anyTextStorage : <LocalizedTextStorage: 0x0000600002114000>: "Tagged View"
            - modifiers : 0 elements
          ▿ modifier : _TraitWritingModifier<TagValueTraitKey<Int>>
            ▿ value : Value
              - tagged : 4
      - transitiveViewModifiers : 0 elements
      - environmentModifiers : 0 elements
      - environmentObjects : 0 elements
  - parentView : nil
  - inspectionCall : "text()"
  - inspectionIndex : nil
  - isUnwrappedSupplementaryChild : false
``` 

### iOS 26:
```
▿ InspectableView<ClassifiedView>
  ▿ content : Content
    ▿ view : Text
      ▿ storage : Storage
        ▿ anyTextStorage : <LocalizedTextStorage: 0x000060000211c050>: "Tagged View"
      - modifiers : 0 elements
    ▿ medium : Medium
      ▿ viewModifiers : 1 element
        ▿ 0 : ModifiedContent<Text, _TagTraitWritingModifier<Int>>
          ▿ content : Text
            ▿ storage : Storage
              ▿ anyTextStorage : <LocalizedTextStorage: 0x000060000211c050>: "Tagged View"
            - modifiers : 0 elements
          ▿ modifier : _TagTraitWritingModifier<Int>
            - tag : 4
            - includeOptional : true
      - transitiveViewModifiers : 0 elements
      - environmentModifiers : 0 elements
      - environmentObjects : 0 elements
  - parentView : nil
  - inspectionCall : "text()"
  - inspectionIndex : nil
  - isUnwrappedSupplementaryChild : false
``` 

## The fix

The fix consists of searching for the new type `_TagTraitWritingModifier` when running iOS 26.

## Validation

I verified that the aforementioned test (`testFindViewWithTag()`) that failed on iOS 26 caused by this issue now passes.
I also ensured that it still pass on iOS 18.5.

## Please review

@nalexn 
@bachand 
