### PR TITLE
Supply size parameter via ViewHosting method

### DIFF
--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -35,7 +35,7 @@ public extension ViewHosting {
                         function: String = #function,
                         whileHosted: @MainActor () async throws -> Void
     ) async throws where V: View {
-        try await host(view, function: function, whileHosted: { _ in
+        try await host(view, size: size, function: function, whileHosted: { _ in
             try await whileHosted()
         })
     }


### PR DESCRIPTION
The `(V) async throws -> Void` variant of this method passes on its `size`, the one that provides no parameter has it as a parameter, but it's not passed on.