### PR TITLE
Fix callOnTapGesture for iOS 26

### DIFF
--- a/Sources/ViewInspector/Modifiers/GestureModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/GestureModifiers.swift
@@ -5,12 +5,21 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension InspectableView {
     func callOnTapGesture() throws {
-        typealias Callback = ((()) -> Void)
-        let callback = try modifierAttribute(
-            modifierName: "TapGesture",
-            path: "modifier|gesture|_body|modifier|callbacks|ended",
-            type: Callback.self, call: "onTapGesture")
-        callback(())
+        if #available(iOS 26, *) {
+            typealias Closure = () -> ()
+            let callback = try modifierAttribute(
+                modifierName: "TapGestureModifier",
+                path: "modifier|action",
+                type: Closure.self, call: "onTapGesture")
+            callback()
+        } else {
+            typealias Callback = ((()) -> Void)
+            let callback = try modifierAttribute(
+                modifierName: "TapGesture",
+                path: "modifier|gesture|_body|modifier|callbacks|ended",
+                type: Callback.self, call: "onTapGesture")
+            callback(())
+        }
     }
     
     func callOnLongPressGesture() throws {


### PR DESCRIPTION
Following up on the updates to support Xcode 26:

using `callOnTapGesture()` did not work on iOS 26.
This failure could be reproduced by the [test](https://github.com/nalexn/ViewInspector/blob/e755279608f57bd451db34fc95d314847d2e4864/Tests/ViewInspectorTests/Gestures/GestureModifiers/GestureActionTests.swift) `testOnTapGestureInspection`

Pre iOS 26:
```
▿ ModifiedContent<EmptyView, AddGestureModifier<_EndedGesture<TapGesture>>>
  - content : SwiftUI.EmptyView()
  ▿ modifier : AddGestureModifier<_EndedGesture<TapGesture>>
    ▿ gesture : _EndedGesture<TapGesture>
      ▿ _body : ModifierGesture<CallbacksGesture<EndedCallbacks<()>>, TapGesture>
        ▿ content : TapGesture
          - count : 1
        ▿ modifier : CallbacksGesture<EndedCallbacks<()>>
          ▿ callbacks : EndedCallbacks<()>
            - ended : (Function)
    - name : nil
    ▿ gestureMask : GestureMask
      - rawValue : 3
```
iOS 26:
```
▿ ModifiedContent<EmptyView, TapGestureModifier>
  - content : SwiftUI.EmptyView()
  ▿ modifier : TapGestureModifier
    - count : 1
    - action : (Function)
```