### PR TITLE
Add support for TextEditor changes in iOS 26

### DIFF
--- a/Sources/ViewInspector/SwiftUI/TextEditor.swift
+++ b/Sources/ViewInspector/SwiftUI/TextEditor.swift
@@ -46,6 +46,12 @@ public extension InspectableView where View == ViewType.TextEditor {
     }
     
     private func inputBinding() throws -> Binding<String> {
+        #if compiler(>=6.2)
+        if #available(iOS 26, macOS 26, visionOS 26, *),
+           let binding = try? stringSelectionBindings().0 {
+            return binding
+        }
+        #endif
         if let binding = try? Inspector.attribute(
             label: "text", value: content.view, type: Binding<String>.self) {
             return binding
@@ -54,3 +60,54 @@ public extension InspectableView where View == ViewType.TextEditor {
             label: "_text", value: content.view, type: Binding<String>.self)
     }
 }
+
+#if compiler(>=6.2)
+@available(iOS 26, macOS 26, visionOS 26, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public extension InspectableView where View == ViewType.TextEditor {
+
+    func attributedInput() throws -> AttributedString {
+        return try attributedInputBinding().wrappedValue
+    }
+
+    func setInput(_ value: AttributedString) throws {
+        try guardIsResponsive()
+        try attributedInputBinding().wrappedValue = value
+    }
+
+    func selection() throws -> TextSelection? {
+        return try stringSelectionBindings().1?.wrappedValue
+    }
+
+    func setSelection(_ value: TextSelection?) throws {
+        try guardIsResponsive()
+        try stringSelectionBindings().1?.wrappedValue = value
+    }
+
+    func attributedSelection() throws -> AttributedTextSelection? {
+        return try attributedSelectionBinding()?.wrappedValue
+    }
+
+    func setSelection(_ value: AttributedTextSelection) throws {
+        try guardIsResponsive()
+        try attributedSelectionBinding()?.wrappedValue = value
+    }
+
+    private func stringSelectionBindings() throws -> (Binding<String>, Binding<TextSelection?>?) {
+        return try Inspector.attribute(
+            path: "storage|string", value: content.view, type: (Binding<String>, Binding<TextSelection?>?).self)
+    }
+
+    private func attributedInputBinding() throws -> Binding<AttributedString> {
+        return try Inspector.attribute(
+            path: "storage|attributedString|text", value: content.view, type: Binding<AttributedString>.self)
+    }
+
+    private func attributedSelectionBinding() throws -> Binding<AttributedTextSelection>? {
+        return try Inspector.attribute(
+            path: "storage|attributedString|selection", value: content.view,
+            type: Binding<AttributedTextSelection>?.self)
+    }
+}
+#endif

--- a/Tests/ViewInspectorTests/SwiftUI/TextEditorTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TextEditorTests.swift
@@ -58,5 +58,81 @@ final class TextEditorTests: XCTestCase {
             "TextEditor is unresponsive: it is disabled")
         XCTAssertEqual(try sut.input(), "123")
     }
+
+    #if compiler(>=6.2)
+    func testAttributedInput() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: AttributedString("123"))
+        let view = TextEditor(text: binding)
+        let sut = try view.inspect().textEditor()
+        XCTAssertEqual(try sut.attributedInput(), AttributedString("123"))
+        try sut.setInput(AttributedString("abc"))
+        XCTAssertEqual(try sut.attributedInput(), AttributedString("abc"))
+    }
+
+    func testSetAttributedInputWhenDisabled() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: AttributedString("123"))
+        let view = TextEditor(text: binding).disabled(true)
+        let sut = try view.inspect().textEditor()
+        XCTAssertThrows(try sut.setInput(AttributedString("abc")),
+            "TextEditor is unresponsive: it is disabled")
+        XCTAssertEqual(try sut.attributedInput(), AttributedString("123"))
+    }
+
+    func testSelection() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let text = "123"
+        let binding = Binding(wrappedValue: text)
+        let selection = Binding(wrappedValue: Optional(TextSelection(insertionPoint: text.endIndex)))
+        let view = TextEditor(text: binding, selection: selection)
+        let sut = try view.inspect().textEditor()
+        XCTAssertEqual(try sut.selection(), TextSelection(insertionPoint: text.endIndex))
+        try sut.setSelection(TextSelection(insertionPoint: text.startIndex))
+        XCTAssertEqual(try sut.selection(), TextSelection(insertionPoint: text.startIndex))
+    }
+
+    func testSetSelectionWhenDisabled() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let text = "123"
+        let binding = Binding(wrappedValue: text)
+        let selection = Binding(wrappedValue: Optional(TextSelection(insertionPoint: text.endIndex)))
+        let view = TextEditor(text: binding, selection: selection).disabled(true)
+        let sut = try view.inspect().textEditor()
+        XCTAssertThrows(try sut.setSelection(nil),
+            "TextEditor is unresponsive: it is disabled")
+        XCTAssertEqual(try sut.selection(), TextSelection(insertionPoint: text.endIndex))
+    }
+
+    func testAttributedSelection() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let text = AttributedString("123")
+        let binding = Binding(wrappedValue: text)
+        let selection = Binding(wrappedValue: AttributedTextSelection(insertionPoint: text.endIndex))
+        let view = TextEditor(text: binding, selection: selection)
+        let sut = try view.inspect().textEditor()
+        XCTAssertEqual(try sut.attributedSelection(), AttributedTextSelection(insertionPoint: text.endIndex))
+        try sut.setSelection(AttributedTextSelection(insertionPoint: text.startIndex))
+        XCTAssertEqual(try sut.attributedSelection(), AttributedTextSelection(insertionPoint: text.startIndex))
+    }
+
+    func testSetAttributedSelectionWhenDisabled() throws {
+        guard #available(iOS 26, macOS 26, visionOS 26, *)
+        else { throw XCTSkip() }
+        let text = AttributedString("123")
+        let binding = Binding(wrappedValue: text)
+        let selection = Binding(wrappedValue: AttributedTextSelection(insertionPoint: text.endIndex))
+        let view = TextEditor(text: binding, selection: selection).disabled(true)
+        let sut = try view.inspect().textEditor()
+        XCTAssertThrows(try sut.setSelection(AttributedTextSelection()),
+            "TextEditor is unresponsive: it is disabled")
+        XCTAssertEqual(try sut.attributedSelection(), AttributedTextSelection(insertionPoint: text.endIndex))
+    }
+    #endif
 }
 #endif

--- a/readiness.md
+++ b/readiness.md
@@ -124,7 +124,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| TabView | `contained view` |
 |:technologist:| Table | |
 |:white_check_mark:| Text | `string(locale: Locale) -> String`, `attributes: TextAttributes`, `attributedString: AttributedString`, `images: [Image]` |
-|:white_check_mark:| TextEditor | `input: String`, `setInput(_: String)` |
+|:white_check_mark:| TextEditor | `input: String`, `setInput(_: String)`, `attributedInput: AttributedString`, `setInput(_: AttributedString)`, `selection: TextSelection?`, `setSelection(_: TextSelection?)`, `attributedSelection: AttributedTextSelection?`, `setSelection(_: AttributedTextSelection)` |
 |:white_check_mark:| TextField | `label view`, `prompt`, `callOnEditingChanged()`, `callOnCommit()`, `input: String`, `setInput(_: String)` |
 |:technologist:| TextFieldLink | |
 |:white_check_mark:| TimelineView | `contentView(Context)` |


### PR DESCRIPTION
Existing `input()` and `setInput()` were broken by internal changes to `TextEditor` in iOS/macOS 26.
There were also additional properties added in iOS/macOS 26 for attributed string bindings, and text selection.

This fixes the broken methods for previous simple TextEditor cases, and adds support for the attributed input & text selection.