### PR TITLE
Fix accessibility label & value, & lazy stacks & grids in iOS 26

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Color.swift
+++ b/Sources/ViewInspector/SwiftUI/Color.swift
@@ -44,6 +44,10 @@ public extension InspectableView where View == ViewType.Color {
             colorProvider = try Inspector.attribute(label: "color", value: colorProvider)
             providerName = Inspector.typeName(value: colorProvider)
         }
+        if providerName == "ResolvedHDR" {
+            colorProvider = try Inspector.attribute(label: "base", value: colorProvider)
+            providerName = Inspector.typeName(value: colorProvider)
+        }
         if ["_Resolved", "Resolved"].contains(providerName) {
             let red = try Inspector.attribute(label: "linearRed", value: colorProvider, type: Float.self)
             let green = try Inspector.attribute(label: "linearGreen", value: colorProvider, type: Float.self)

--- a/Sources/ViewInspector/SwiftUI/LazyHGrid.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyHGrid.swift
@@ -64,6 +64,9 @@ public extension InspectableView where View == ViewType.LazyHGrid {
     }
     
     private func lazyHGridLayout() throws -> Any {
+        if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
+            return layout
+        }
         return try Inspector.attribute(path: "tree|root", value: content.view)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/LazyHStack.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyHStack.swift
@@ -60,6 +60,9 @@ public extension InspectableView where View == ViewType.LazyHStack {
     }
     
     private func lazyHStackLayout() throws -> Any {
+        if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
+            return layout
+        }
         return try Inspector.attribute(path: "tree|root", value: content.view)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/LazyVGrid.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyVGrid.swift
@@ -64,6 +64,9 @@ public extension InspectableView where View == ViewType.LazyVGrid {
     }
     
     private func lazyVGridLayout() throws -> Any {
+        if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
+            return layout
+        }
         return try Inspector.attribute(path: "tree|root", value: content.view)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/LazyVStack.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyVStack.swift
@@ -59,6 +59,9 @@ public extension InspectableView where View == ViewType.LazyVStack {
     }
     
     private func lazyVStackLayout() throws -> Any {
+        if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
+            return layout
+        }
         return try Inspector.attribute(path: "tree|root", value: content.view)
     }
 }


### PR DESCRIPTION
Generalizes the fix for accessibilityIdentifier to apply it to accessibilityLabel & accessibilityValue. There are more accessibility changes needed for iOS 26, but they are a bit more complicated.

Fixed HDR colors in iOS 26.

Fixed layout changes in Lazy{H|V}{Stack|Grid}.