### PR TITLE
Check `ResizableProvider` on SwiftUI.Image -> parameters that were set via `.resizable()`

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Image.swift
+++ b/Sources/ViewInspector/SwiftUI/Image.swift
@@ -122,6 +122,24 @@ public extension SwiftUI.Image {
             type: TemplateRenderingMode?.self, call: "renderingMode")
     }
     
+    func resizableParameters() throws -> (capInsets: EdgeInsets, resizingMode: Image.ResizingMode) {
+        let capInsets = try imageContent().modifierAttribute(
+            modifierName: "ResizableProvider",
+            path: "provider|capInsets",
+            type: EdgeInsets.self,
+            call: "capInsets"
+        )
+
+        let resizingMode = try imageContent().modifierAttribute(
+            modifierName: "ResizableProvider",
+            path: "provider|resizingMode",
+            type: Image.ResizingMode.self,
+            call: "resizingMode"
+        )
+        
+        return (capInsets, resizingMode)
+    }
+    
     private func rawImage() throws -> Any {
         return try Inspector.attribute(path: "provider|base", value: try imageContent().view)
     }

--- a/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ImageTests.swift
@@ -53,6 +53,33 @@ final class ImageTests: XCTestCase {
         XCTAssertEqual(renderingMode, .template)
     }
     
+    func testResizableCapInsets() throws {
+        let capInsets = EdgeInsets(
+            top: 1.1,
+            leading: 2.2,
+            bottom: 3.3,
+            trailing: 4.4
+        )
+        let view = AnyView(imageView().resizable(capInsets: capInsets))
+        let resizable = try view.inspect().anyView().image().actualImage().resizableParameters()
+        
+        XCTAssertEqual(
+            capInsets,
+            resizable.capInsets
+        )
+    }
+    
+    func testResizableResizingMode() throws {
+        let resizingMode: Image.ResizingMode = .stretch
+        let view = AnyView(imageView().resizable(resizingMode: resizingMode))
+        let resizable = try view.inspect().anyView().image().actualImage().resizableParameters()
+        
+        XCTAssertEqual(
+            resizingMode,
+            resizable.resizingMode
+        )
+    }
+    
     func testExtractionCGImage() throws {
         let cgImage = testImage.cgImage!
         let image = Image(cgImage, scale: 2.0, orientation: .down, label: Text("CGImage").bold())

--- a/readiness.md
+++ b/readiness.md
@@ -61,7 +61,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| HSplitView | `contained view` |
 |:white_check_mark:| HStack | `contained view`, `alignment: VerticalAlignment`, `spacing: CGFloat?` |
 |:white_check_mark:| Image | `label view`, `actualImage: Image` |
-|:white_check_mark:| Image (*) | `rootImage: Image`, `name: String?`, `(ui,ns,cg)Image: (UI,NS,CG)Image`, `orientation: Image.Orientation`, `scale: CGFloat`, `renderingMode: Image.TemplateRenderingMode` |
+|:white_check_mark:| Image (*) | `rootImage: Image`, `name: String?`, `(ui,ns,cg)Image: (UI,NS,CG)Image`, `orientation: Image.Orientation`, `scale: CGFloat`, `renderingMode: Image.TemplateRenderingMode`, `resizableParameters: (capInsets: EdgeInsets, resizingMode: Image.ResizingMode)`|
 |:white_check_mark:| Label | `title view`, `icon view` |
 |:white_check_mark:| LabeledContent | `contained view`, `label view` |
 |:white_check_mark:| LabelStyleConfiguration.Icon | |


### PR DESCRIPTION
extended public SwiftUI.Image extension  with `func resizableParameters() throws -> (capInsets: EdgeInsets, resizingMode: Image.ResizingMode)`  in `../Sources/ViewInspector/SwiftUI/Image.swift` in favour to get parameters that were set via `.resizable()` to native SwiftUI.Image