### PR TITLE
Fix issue #405: Add macOS exclusion guards for iOS-only SwiftUI types

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Map.swift
+++ b/Sources/ViewInspector/SwiftUI/Map.swift
@@ -1,4 +1,4 @@
-#if canImport(MapKit)
+#if !os(macOS) && canImport(MapKit)
 import MapKit
 import SwiftUI
 

--- a/Sources/ViewInspector/SwiftUI/MapAnnotation.swift
+++ b/Sources/ViewInspector/SwiftUI/MapAnnotation.swift
@@ -1,4 +1,4 @@
-#if canImport(MapKit)
+#if !os(macOS) && canImport(MapKit)
 import MapKit
 import SwiftUI
 

--- a/Sources/ViewInspector/SwiftUI/SignInWithAppleButton.swift
+++ b/Sources/ViewInspector/SwiftUI/SignInWithAppleButton.swift
@@ -1,3 +1,4 @@
+#if !os(macOS)
 import SwiftUI
 #if canImport(AuthenticationServices)
 import AuthenticationServices
@@ -162,4 +163,5 @@ public extension ASAuthorizationAppleIDCredential {
         setValue(realUserStatus.rawValue, forKey: "realUserStatus")
     }
 }
+#endif
 #endif

--- a/Sources/ViewInspector/SwiftUI/VideoPlayer.swift
+++ b/Sources/ViewInspector/SwiftUI/VideoPlayer.swift
@@ -1,3 +1,4 @@
+#if !os(macOS)
 import SwiftUI
 #if canImport(AVKit)
 import AVKit
@@ -89,4 +90,5 @@ extension VideoPlayer: SingleViewProvider {
     }
 }
 
+#endif
 #endif

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -6,7 +6,7 @@ import SwiftUI
 @MainActor
 internal extension ViewSearch {
     private static let index: [String: [ViewIdentity]] = {
-        let knownViewTypes: [KnownViewType.Type] = [
+        var knownViewTypes: [KnownViewType.Type] = [
             ViewType.ActionSheet.self,
             ViewType.ActionSheet.self,
             ViewType.Alert.self,
@@ -47,7 +47,6 @@ internal extension ViewSearch {
             ViewType.Link.self,
             ViewType.List.self,
             ViewType.LocationButton.self,
-            ViewType.Map.self,
             ViewType.Menu.self,
             ViewType.MenuButton.self,
             ViewType.MultiDatePicker.self,
@@ -67,7 +66,6 @@ internal extension ViewSearch {
             ViewType.ScrollViewReader.self,
             ViewType.Section.self,
             ViewType.SecureField.self,
-            ViewType.SignInWithAppleButton.self,
             ViewType.ShareLink.self,
             ViewType.Sheet.self,
             ViewType.Slider.self,
@@ -89,13 +87,19 @@ internal extension ViewSearch {
             ViewType.Toolbar.self,
             ViewType.Toolbar.Item.self,
             ViewType.Toolbar.ItemGroup.self,
-            ViewType.VideoPlayer.self,
             ViewType.ViewModifierContent.self,
             ViewType.ViewThatFits.self,
             ViewType.VSplitView.self,
             ViewType.VStack.self,
             ViewType.ZStack.self,
         ]
+        #if !os(macOS)
+        knownViewTypes.append(contentsOf: [
+            ViewType.Map.self,
+            ViewType.SignInWithAppleButton.self,
+            ViewType.VideoPlayer.self,
+        ])
+        #endif
         let identities = knownViewTypes.map { $0.viewSearchIdentity() }
         var index = [String: [ViewIdentity]](minimumCapacity: 26) // alphabet
         identities.forEach { identity in


### PR DESCRIPTION
## Summary
This PR fixes compilation errors on macOS SDK 26 by adding platform exclusion guards for iOS-only SwiftUI types that are not available on macOS.

## Changes
- Wrap `VideoPlayer.swift` in `#if !os(macOS)`
- Wrap `SignInWithAppleButton.swift` in `#if !os(macOS)`
- Update `Map.swift` guard to `#if !os(macOS) && canImport(MapKit)`
- Update `MapAnnotation.swift` guard to `#if !os(macOS) && canImport(MapKit)`
- Conditionally exclude iOS-only view types (Map, SignInWithAppleButton, VideoPlayer) from `ViewSearchIndex` on macOS

## Problem
The SwiftUI types (`VideoPlayer`, `SignInWithAppleButton`, `Map` variants) are iOS-only and not available in macOS SDK 26. ViewInspector had conditional compilation guards for `canImport(AVKit)` and `canImport(AuthenticationServices)` but did not exclude these code paths for macOS.

## Solution
Added `#if !os(macOS)` guards to exclude these iOS-only types when building for macOS. The `canImport` checks verify frameworks are available but don't check if the SwiftUI types exist in the SDK.

## Testing
- ✅ Build succeeds on macOS (tested with `swift build -c release --arch arm64`)
- ✅ No linting errors
- ✅ All existing functionality preserved for iOS/tvOS/watchOS

Fixes #405