### PR TITLE
[Experimental] Opt-in @Environment resolution to prevent warnings during inspection

### DIFF
--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -10,24 +10,30 @@ internal struct ContentExtractor {
         self.contentSource = try Self.contentSource(from: source)
     }
 
-    internal func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+    internal func extractContent(environmentObjects: [AnyObject],
+                                   environmentModifiers: [EnvironmentModifier] = []) throws -> Any {
         #if swift(>=6.0)
-        return try isolatedExtractContent(environmentObjects: environmentObjects)
+        return try isolatedExtractContent(environmentObjects: environmentObjects,
+                                          environmentModifiers: environmentModifiers)
         #else
         return try MainActor.assumeIsolated {
-            try isolatedExtractContent(environmentObjects: environmentObjects)
+            try isolatedExtractContent(environmentObjects: environmentObjects,
+                                       environmentModifiers: environmentModifiers)
         }
         #endif
     }
 
     @MainActor
-    private func isolatedExtractContent(environmentObjects: [AnyObject]) throws -> Any {
+    private func isolatedExtractContent(environmentObjects: [AnyObject],
+                                        environmentModifiers: [EnvironmentModifier]) throws -> Any {
         try validateSourceBeforeExtraction()
         switch contentSource {
         case .view(let view):
-            return try view.extractContent(environmentObjects: environmentObjects)
+            return try view.extractContent(environmentObjects: environmentObjects,
+                                           environmentModifiers: environmentModifiers)
         case .viewModifier(let viewModifier):
-            return try viewModifier.extractContent(environmentObjects: environmentObjects)
+            return try viewModifier.extractContent(environmentObjects: environmentObjects,
+                                                   environmentModifiers: environmentModifiers)
         case .gesture(let gesture):
             return try gesture.extractContent(environmentObjects: environmentObjects)
         }
@@ -131,6 +137,15 @@ private extension ViewModifier {
 public extension View {
     @MainActor
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        try extractContent(environmentObjects: environmentObjects, environmentModifiers: [])
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension View {
+    @MainActor
+    func extractContent(environmentObjects: [AnyObject],
+                        environmentModifiers: [EnvironmentModifier]) throws -> Any {
         var copy = self
         environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
         let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
@@ -138,6 +153,10 @@ public extension View {
             let view = Inspector.typeName(value: self)
             throw InspectionError
                 .missingEnvironmentObjects(view: view, objects: missingObjects)
+        }
+        if ViewInspectorConfig.resolveEnvironmentValues {
+            let env = EnvironmentInjection.environmentValues(from: environmentModifiers)
+            copy = EnvironmentInjection.resolveEnvironmentProperties(in: copy, using: env)
         }
         return copy.body
     }
@@ -147,6 +166,15 @@ public extension View {
 public extension ViewModifier {
     @MainActor
     func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        try extractContent(environmentObjects: environmentObjects, environmentModifiers: [])
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension ViewModifier {
+    @MainActor
+    func extractContent(environmentObjects: [AnyObject],
+                        environmentModifiers: [EnvironmentModifier]) throws -> Any {
         var copy = self
         environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
         let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
@@ -157,10 +185,15 @@ public extension ViewModifier {
         }
         if let envModifier = copy as? (any EnvironmentalModifier) {
             let resolved = envModifier.resolve(in: EnvironmentValues())
-            return try resolved.extractContent(environmentObjects: environmentObjects)
+            return try resolved.extractContent(environmentObjects: environmentObjects,
+                                               environmentModifiers: environmentModifiers)
         }
         guard copy.hasBody else {
             return "<Never>"
+        }
+        if ViewInspectorConfig.resolveEnvironmentValues {
+            let env = EnvironmentInjection.environmentValues(from: environmentModifiers)
+            copy = EnvironmentInjection.resolveEnvironmentProperties(in: copy, using: env)
         }
         return copy.body()
     }

--- a/Sources/ViewInspector/EnvironmentInjection.swift
+++ b/Sources/ViewInspector/EnvironmentInjection.swift
@@ -1,5 +1,25 @@
 import SwiftUI
 
+// MARK: - ViewInspectorConfig
+
+/// Global configuration for ViewInspector behavior.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public enum ViewInspectorConfig {
+    /// When enabled, `@Environment` properties are resolved to their default
+    /// `EnvironmentValues` before body evaluation, preventing
+    /// "Accessing Environment<T>'s value outside of being installed on a View" warnings.
+    ///
+    /// Defaults to the `VIEWINSPECTOR_RESOLVE_ENVIRONMENT` environment variable
+    /// (set to "1", "YES", or "TRUE"). Can be overridden per-test via direct assignment.
+    nonisolated(unsafe) public static var resolveEnvironmentValues: Bool = {
+        if let value = ProcessInfo.processInfo.environment["VIEWINSPECTOR_RESOLVE_ENVIRONMENT"] {
+            return value == "1" || value.uppercased() == "YES" || value.uppercased() == "TRUE"
+        }
+        return false
+    }()
+
+}
+
 // MARK: - EnvironmentObject injection
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
@@ -60,11 +80,306 @@ internal enum EnvironmentInjection {
     }
 }
 
+// MARK: - @Environment resolution
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension EnvironmentInjection {
+
+    /// Builds an `EnvironmentValues` by applying tracked `.environment()` modifiers
+    /// on top of SwiftUI defaults. This allows test code like
+    /// `MyView().environment(\.colorScheme, .dark)` to be reflected during resolution.
+    static func environmentValues(from modifiers: [EnvironmentModifier]) -> EnvironmentValues {
+        var env = EnvironmentValues()
+        for modifier in modifiers {
+            guard let keyPath = try? modifier.keyPath(),
+                  let value = try? modifier.value(),
+                  let applicable = keyPath as? AnyWritableEnvironmentKeyPath
+            else { continue }
+            _ = applicable._apply(value: value, to: &env)
+        }
+        return env
+    }
+
+    /// Resolves `@Environment` properties from `.keyPath` state to `.value` state,
+    /// preventing "Accessing Environment<T>'s value outside of being installed on a View" warnings.
+    ///
+    /// - Parameter environmentValues: The `EnvironmentValues` to resolve from. Defaults to
+    ///   `EnvironmentValues()` (SwiftUI defaults). Pass a customized instance to override
+    ///   specific values, including custom `EnvironmentKey` types.
+    static func resolveEnvironmentProperties<T>(
+        in entity: T,
+        using environmentValues: EnvironmentValues = EnvironmentValues()
+    ) -> T {
+        guard ViewInspectorConfig.resolveEnvironmentValues else { return entity }
+
+        let prefix = "SwiftUI.Environment<"
+        let mirror = Mirror(reflecting: entity)
+        var copy = entity
+
+        for child in mirror.children {
+            let typeName = Inspector.typeName(value: child.value, namespaced: true)
+            guard typeName.hasPrefix(prefix), let label = child.label else { continue }
+
+            // Use EnvironmentResolvable protocol to resolve with correct generic context.
+            // The protocol returns both the original bytes (from the real generic type,
+            // NOT the existential container) and the resolved .value state bytes.
+            guard let resolvable = child.value as? any EnvironmentResolvable,
+                  let resolution = resolvable._resolve(using: environmentValues)
+            else { continue }
+
+            copy = writeFieldBytes(
+                resolution.resolvedBytes,
+                referenceBytes: resolution.originalBytes,
+                fieldSize: resolution.fieldSize,
+                matchSize: resolution.matchSize,
+                label: label,
+                into: copy
+            )
+        }
+        return copy
+    }
+
+    /// Finds a field in the parent struct by byte-matching then overwrites with new bytes.
+    ///
+    /// Only `matchSize` bytes are compared for field identification (the keypath pointer).
+    /// This is necessary because Mirror-extracted copies of @Environment may have different
+    /// "spare" payload bytes when `sizeof(Value) > sizeof(KeyPath)` — the enum's payload
+    /// area is `max(sizeof(keyPath), sizeof(Value))`, and bytes beyond the keypath pointer
+    /// in the `.keyPath` case are uninitialized/undefined.
+    ///
+    /// Writing the resolved `.value` state bytes into a Swift-managed copy is safe because
+    /// `@Environment`'s destroy checks the enum tag: tag=1 (.value) destroys the value
+    /// payload (which we already verified is non-reference), so no keypath release occurs.
+    private static func writeFieldBytes<T>(
+        _ newBytes: [UInt8],
+        referenceBytes: [UInt8],
+        fieldSize: Int,
+        matchSize: Int,
+        label: String,
+        into entity: T
+    ) -> T {
+        let entitySize = MemoryLayout<T>.size
+        let entityAlignment = MemoryLayout<T>.alignment
+        // Scan forward from offset 0 in alignment-sized steps.
+        // @Environment fields are aligned to their internal alignment (pointer-sized),
+        // which matches the parent struct's alignment.
+        let step = max(entityAlignment, 1)
+
+        var offset = 0
+        while offset + fieldSize <= entitySize {
+            var matches = false
+            withUnsafeBytes(of: entity) { bytes in
+                guard offset + matchSize <= bytes.count else { return }
+                // Only compare the keypath pointer bytes — these are unique per field
+                // and guaranteed to be identical between Mirror copy and original.
+                matches = Array(bytes[offset..<offset + matchSize])
+                    == Array(referenceBytes.prefix(matchSize))
+            }
+
+            if matches {
+                // Overwrite the matched field with the resolved .value state bytes.
+                var result = entity
+                withUnsafeMutableBytes(of: &result) { bytes in
+                    for i in 0..<min(fieldSize, newBytes.count) {
+                        (bytes.baseAddress! + offset + i)
+                            .assumingMemoryBound(to: UInt8.self).pointee = newBytes[i]
+                    }
+                }
+                return result
+            }
+            offset += step
+        }
+        return entity
+    }
+}
+
+/// Result of resolving an @Environment field.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal struct EnvironmentResolution {
+    /// The real size of the @Environment<Value> struct (not the existential container).
+    let fieldSize: Int
+    /// How many bytes from the start to compare for field identification.
+    /// This is the keypath pointer size — only these bytes are guaranteed to be identical
+    /// between a Mirror-extracted copy and the original in the parent struct.
+    /// When `sizeof(Value) > sizeof(KeyPath)`, the `.keyPath` enum case has spare payload
+    /// bytes that Mirror may not preserve, causing full-field comparison to fail.
+    let matchSize: Int
+    /// The original bytes of the @Environment in .keyPath state (real struct bytes).
+    let originalBytes: [UInt8]
+    /// The bytes of the @Environment in .value state after resolution.
+    let resolvedBytes: [UInt8]
+}
+
+/// Protocol for type-erased @Environment resolution.
+/// Environment<Value> conforms to this, allowing us to call generic code
+/// with the correct Value type at runtime.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal protocol EnvironmentResolvable {
+    /// Resolves this @Environment using the given `EnvironmentValues` and returns the resolution
+    /// data including the real struct size and bytes (not existential container bytes).
+    func _resolve(using environmentValues: EnvironmentValues) -> EnvironmentResolution?
+    /// Returns the raw bytes of this @Environment struct (real generic type, not existential).
+    func _originalBytes() -> [UInt8]
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension Environment: EnvironmentResolvable {
+    func _originalBytes() -> [UInt8] {
+        withUnsafeBytes(of: self) { Array($0) }
+    }
+
+    func _resolve(using environmentValues: EnvironmentValues) -> EnvironmentResolution? {
+        // Check if already in .value state
+        let mirror = Mirror(reflecting: self)
+        guard let contentChild = mirror.children.first(where: { $0.label == "content" }) else {
+            return nil
+        }
+        let contentMirror = Mirror(reflecting: contentChild.value)
+        guard let enumCase = contentMirror.children.first,
+              enumCase.label != ".value" // Already resolved
+        else { return nil }
+
+        // Extract the keyPath
+        guard let keyPath = enumCase.value as? KeyPath<EnvironmentValues, Value> else {
+            return nil
+        }
+
+        // Resolve from the provided EnvironmentValues
+        let resolvedValue = environmentValues[keyPath: keyPath]
+
+        // Skip resolution for Value types that contain references (closures, objects).
+        // Raw byte manipulation of reference types breaks ARC and causes crashes.
+        guard !containsReferenceTypes(resolvedValue) else { return nil }
+
+        // Get the REAL size and bytes of this @Environment<Value> struct
+        // (not the existential container that Mirror wraps it in)
+        let realSize = MemoryLayout<Self>.size
+        let keyPathSize = MemoryLayout<KeyPath<EnvironmentValues, Value>>.size
+        let originalBytes: [UInt8] = withUnsafeBytes(of: self) { Array($0) }
+        let resolvedBytes = buildValueStateBytes(resolvedValue)
+
+        return EnvironmentResolution(
+            fieldSize: realSize,
+            matchSize: keyPathSize,
+            originalBytes: originalBytes,
+            resolvedBytes: resolvedBytes
+        )
+    }
+
+    /// Checks whether a value contains reference types (classes, closures, etc.)
+    /// that would be unsafe to manipulate via raw bytes.
+    private func containsReferenceTypes(_ value: Any) -> Bool {
+        // Class instances
+        if type(of: value) is AnyClass { return true }
+        // Check Mirror children recursively (1 level deep)
+        let mirror = Mirror(reflecting: value)
+        for child in mirror.children {
+            if type(of: child.value) is AnyClass { return true }
+            // Function/closure types show up as "() -> ()" etc.
+            let typeName = String(describing: type(of: child.value))
+            if typeName.contains("->") { return true }
+            // Optional wrapping a reference type
+            let childMirror = Mirror(reflecting: child.value)
+            if childMirror.displayStyle == .optional {
+                for inner in childMirror.children {
+                    if type(of: inner.value) is AnyClass { return true }
+                    let innerName = String(describing: type(of: inner.value))
+                    if innerName.contains("->") { return true }
+                }
+            }
+        }
+        return false
+    }
+
+    /// Constructs the raw bytes of this @Environment<Value> in `.value(v)` state.
+    ///
+    /// @Environment<Value> is @frozen and contains a single `content` field of type Content,
+    /// which is an enum:
+    ///   case keyPath(KeyPath<EnvironmentValues, Value>)  — tag 0
+    ///   case value(Value)                                — tag 1
+    ///
+    /// For multi-payload enums, Swift uses:
+    ///   [payload area: max(sizeof(case0), sizeof(case1)) bytes][tag: 1 byte]
+    private func buildValueStateBytes(_ value: Value) -> [UInt8] {
+        // Use raw memory to avoid ARC issues. Creating `var copy = self` and zeroing
+        // its bytes would corrupt reference-counted fields (e.g. the keypath pointer),
+        // causing crashes when `copy` is deallocated.
+        let size = MemoryLayout<Self>.size
+        let buffer = UnsafeMutableRawBufferPointer.allocate(
+            byteCount: size, alignment: MemoryLayout<Self>.alignment)
+        defer { buffer.deallocate() }
+
+        memset(buffer.baseAddress!, 0, size)
+
+        // Write value payload at the start
+        withUnsafeBytes(of: value) { valueBytes in
+            let count = min(valueBytes.count, size)
+            if count > 0 {
+                buffer.baseAddress!.copyMemory(from: valueBytes.baseAddress!, byteCount: count)
+            }
+        }
+
+        // Write tag = 1 (for .value case) after the payload area
+        let keyPathPayloadSize = MemoryLayout<KeyPath<EnvironmentValues, Value>>.size
+        let valuePayloadSize = MemoryLayout<Value>.size
+        let tagOffset = max(keyPathPayloadSize, valuePayloadSize)
+        if tagOffset < size {
+            (buffer.baseAddress! + tagOffset).assumingMemoryBound(to: UInt8.self).pointee = 1
+        }
+
+        return Array(buffer)
+    }
+}
+
+// MARK: - ViewHosting environment defaults
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension EnvironmentInjection {
+
+    /// Wraps a view with explicit default environment values to prevent
+    /// "Accessing Environment<T>'s value outside of being installed on a View" warnings
+    /// when the view is hosted via UIHostingController in tests.
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    static func viewWithResolvedEnvironment<V: View>(_ view: V) -> some View {
+        view
+            .environment(\.isEnabled, true)
+            .environment(\.dynamicTypeSize, .large)
+            .environment(\.redactionReasons, [])
+    }
+
+    /// Fallback for older OS versions — resolves only iOS 13+ environment keys.
+    static func viewWithResolvedEnvironmentBase<V: View>(_ view: V) -> some View {
+        view
+            .environment(\.isEnabled, true)
+    }
+}
+
+// MARK: - Type-erased environment keyPath application
+
+/// Protocol for applying a type-erased WritableKeyPath + value to EnvironmentValues.
+/// WritableKeyPath<EnvironmentValues, T> conforms to this, enabling generic application
+/// without a fixed list of supported types.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal protocol AnyWritableEnvironmentKeyPath {
+    func _apply(value: Any, to env: inout EnvironmentValues) -> Bool
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension WritableKeyPath: AnyWritableEnvironmentKeyPath where Root == EnvironmentValues {
+    internal func _apply(value: Any, to env: inout EnvironmentValues) -> Bool {
+        guard let typedValue = value as? Value else { return false }
+        env[keyPath: self] = typedValue
+        return true
+    }
+}
+
+// MARK: - EnvObject (EnvironmentObject injection support)
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 internal struct EnvObject {
     static var seedOffset: Int { 8 }
     static var structSize: Int { 16 }
-    
+
     struct Forgery {
         let object: AnyObject?
         let seed: Int = 0

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -55,14 +55,18 @@ internal extension Content {
     
     func extractCustomView() throws -> Content {
         let contentExtractor = try ContentExtractor(source: view)
-        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
+        let view = try contentExtractor.extractContent(
+            environmentObjects: medium.environmentObjects,
+            environmentModifiers: medium.environmentModifiers)
         let medium = self.medium.resettingViewModifiers()
         return try Inspector.unwrap(view: view, medium: medium)
     }
-    
+
     func extractCustomViewGroup() throws -> LazyGroup<Content> {
         let contentExtractor = try ContentExtractor(source: view)
-        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
+        let view = try contentExtractor.extractContent(
+            environmentObjects: medium.environmentObjects,
+            environmentModifiers: medium.environmentModifiers)
         return try Inspector.viewsInContainer(view: view, medium: medium)
     }
 }

--- a/Sources/ViewInspector/ViewHosting.swift
+++ b/Sources/ViewInspector/ViewHosting.swift
@@ -25,7 +25,7 @@ public extension ViewHosting {
                         whileHosted: @MainActor (V) async throws -> Void
     ) async throws where V: View {
         let viewId = ViewId(function: function)
-        host(view: view, size: size, viewId: viewId)
+        hostResolvingIfNeeded(view: view, size: size, viewId: viewId)
         try await whileHosted(view)
         expel(viewId: viewId)
     }
@@ -43,6 +43,19 @@ public extension ViewHosting {
     static func host<V>(view: V, size: CGSize? = nil, function: String = #function) where V: View {
         let viewId = ViewId(function: function)
         MainActor.assumeIsolated {
+            hostResolvingIfNeeded(view: view, size: size, viewId: viewId)
+        }
+    }
+
+    @MainActor
+    private static func hostResolvingIfNeeded<V>(view: V, size: CGSize? = nil, viewId: ViewId) where V: View {
+        if ViewInspectorConfig.resolveEnvironmentValues {
+            if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+                host(view: EnvironmentInjection.viewWithResolvedEnvironment(view), size: size, viewId: viewId)
+            } else {
+                host(view: EnvironmentInjection.viewWithResolvedEnvironmentBase(view), size: size, viewId: viewId)
+            }
+        } else {
             host(view: view, size: size, viewId: viewId)
         }
     }

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentInjectionTests.swift
@@ -1,0 +1,259 @@
+import XCTest
+import SwiftUI
+
+@testable import ViewInspector
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+class EnvironmentInjectionTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        ViewInspectorConfig.resolveEnvironmentValues = false
+    }
+
+    override func tearDown() {
+        ViewInspectorConfig.resolveEnvironmentValues = false
+        super.tearDown()
+    }
+
+    // MARK: - EnvironmentResolvable protocol
+
+    func testBoolEnvironmentResolvesToValueState() throws {
+        let env = Environment(\.isEnabled)
+        let resolution = env._resolve(using: EnvironmentValues())
+        XCTAssertNotNil(resolution)
+        XCTAssertEqual(resolution!.fieldSize, MemoryLayout<Environment<Bool>>.size)
+        XCTAssertNotEqual(resolution!.originalBytes, resolution!.resolvedBytes)
+    }
+
+    func testEnumEnvironmentResolvesToValueState() throws {
+        let env = Environment(\.colorScheme)
+        let resolution = env._resolve(using: EnvironmentValues())
+        XCTAssertNotNil(resolution)
+        XCTAssertEqual(resolution!.fieldSize, MemoryLayout<Environment<ColorScheme>>.size)
+    }
+
+    func testActionEnvironmentDoesNotCrashDuringResolution() throws {
+        guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, *) else { throw XCTSkip("iOS 15+") }
+        let env = Environment(\.dismiss)
+        _ = env._resolve(using: EnvironmentValues())
+    }
+
+    func testUnresolvedEnvironmentIsInKeyPathState() throws {
+        let env = Environment(\.colorScheme)
+        let mirror = Mirror(reflecting: env)
+        let contentChild = mirror.children.first { $0.label == "content" }
+        XCTAssertNotNil(contentChild, "@Environment should have a 'content' child")
+        let contentMirror = Mirror(reflecting: contentChild!.value)
+        let enumCase = contentMirror.children.first
+        XCTAssertEqual(enumCase?.label, "keyPath")
+    }
+
+    // MARK: - resolveEnvironmentProperties disabled
+
+    @MainActor
+    func testResolutionSkippedWhenFlagIsDisabled() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = false
+        let view = SimpleEnvironmentView()
+        let result = EnvironmentInjection.resolveEnvironmentProperties(in: view)
+        let mirror = Mirror(reflecting: result)
+        for child in mirror.children {
+            let typeName = Inspector.typeName(value: child.value, namespaced: true)
+            guard typeName.hasPrefix("SwiftUI.Environment") else { continue }
+            let contentMirror = Mirror(reflecting: child.value)
+                .children.first { $0.label == "content" }
+                .flatMap { Mirror(reflecting: $0.value).children.first }
+            XCTAssertEqual(contentMirror?.label, "keyPath")
+        }
+    }
+
+    // MARK: - resolveEnvironmentProperties enabled
+
+    @MainActor
+    func testSimpleViewResolvedWhenFlagIsEnabled() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let view = SimpleEnvironmentView()
+        let resolved = EnvironmentInjection.resolveEnvironmentProperties(in: view)
+        let text = try resolved.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "enabled")
+    }
+
+    @MainActor
+    func testMultipleEnvironmentFieldsResolvedInSameView() throws {
+        guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, *) else { throw XCTSkip("iOS 15+") }
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let view = MultiEnvironmentView()
+        let resolved = EnvironmentInjection.resolveEnvironmentProperties(in: view)
+        let text = try resolved.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "light_large")
+    }
+
+    @MainActor
+    func testDismissEnvironmentDoesNotCrashDuringViewResolution() throws {
+        guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, *) else { throw XCTSkip("iOS 15+") }
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        _ = EnvironmentInjection.resolveEnvironmentProperties(in: DismissEnvironmentView())
+    }
+
+    // MARK: - ViewInspector integration
+
+    @MainActor
+    func testInspectionOfViewWithMultipleEnvironmentFields() throws {
+        guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, *) else { throw XCTSkip("iOS 15+") }
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let text = try MultiEnvironmentView().inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "light_large")
+    }
+
+    @MainActor
+    func testInspectionOfViewWithEnvironmentAndEnvironmentObject() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let obj = TestEnvObj()
+        let sut = MixedEnvironmentView().environmentObject(obj)
+        let text = try sut.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "light_hello")
+    }
+
+    @MainActor
+    func testInspectionOfViewModifierWithEnvironment() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let text = try EnvironmentModifierTestView().inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "content")
+    }
+
+    // MARK: - Custom environment values
+
+    @MainActor
+    func testEnvironmentModifierOverrideUsedDuringResolution() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let sut = ColorSchemeView().environment(\.colorScheme, .dark)
+        let text = try sut.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "dark")
+    }
+
+    @MainActor
+    func testEnvironmentValuesFromModifiersAppliesCustomKeys() throws {
+        // Build EnvironmentValues from a tracked modifier and verify the value is applied
+        let sut = CustomKeyView().environment(\.testString, "custom_value")
+        let inspected = try sut.inspect().find(ViewType.View<CustomKeyView>.self)
+        let modifiers = inspected.content.medium.environmentModifiers
+        XCTAssertFalse(modifiers.isEmpty, "Environment modifier should be tracked")
+        let env = EnvironmentInjection.environmentValues(from: modifiers)
+        XCTAssertEqual(env.testString, "custom_value")
+    }
+
+    @MainActor
+    func testCustomEnvironmentKeyUsedDuringResolution() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let sut = CustomKeyView().environment(\.testString, "custom_value")
+        let text = try sut.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "custom_value")
+    }
+
+    @MainActor
+    func testDefaultEnvironmentValuesUsedWhenNoOverride() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let text = try CustomKeyView().inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "default")
+    }
+
+    // MARK: - Regression
+
+    @MainActor
+    func testEnvironmentObjectInjectionStillWorksWithResolutionEnabled() throws {
+        ViewInspectorConfig.resolveEnvironmentValues = true
+        let obj = TestEnvObj()
+        var sut = EnvironmentObjectOnlyView()
+        sut = EnvironmentInjection.inject(environmentObject: obj, into: sut)
+        let text = try sut.inspect().find(ViewType.Text.self).string()
+        XCTAssertEqual(text, "hello")
+    }
+}
+
+// MARK: - Test Views
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct SimpleEnvironmentView: View {
+    @Environment(\.isEnabled) var isEnabled
+    var body: some View { Text(isEnabled ? "enabled" : "disabled") }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private struct MultiEnvironmentView: View {
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    var body: some View {
+        let scheme = colorScheme == .dark ? "dark" : "light"
+        let size = dynamicTypeSize == .large ? "large" : "other"
+        Text("\(scheme)_\(size)")
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private struct DismissEnvironmentView: View {
+    @Environment(\.dismiss) var dismiss
+    var body: some View { Button("Dismiss") { dismiss() } }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private class TestEnvObj: ObservableObject {
+    @Published var value = "hello"
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct MixedEnvironmentView: View {
+    @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var obj: TestEnvObj
+    var body: some View { Text("\(colorScheme == .dark ? "dark" : "light")_\(obj.value)") }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct EnvironmentModifierTestView: View {
+    var body: some View {
+        Text("content")
+            .modifier(EnvironmentTestModifier())
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+struct EnvironmentTestModifier: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Self.Content) -> some View {
+        VStack {
+            content
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct EnvironmentObjectOnlyView: View {
+    @EnvironmentObject var obj: TestEnvObj
+    var body: some View { Text(obj.value) }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct ColorSchemeView: View {
+    @Environment(\.colorScheme) var colorScheme
+    var body: some View { Text(colorScheme == .dark ? "dark" : "light") }
+}
+
+// MARK: - Custom EnvironmentKey
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct TestStringKey: EnvironmentKey {
+    static let defaultValue = "default"
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension EnvironmentValues {
+    var testString: String {
+        get { self[TestStringKey.self] }
+        set { self[TestStringKey.self] = newValue }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct CustomKeyView: View {
+    @Environment(\.testString) var testString
+    var body: some View { Text(testString) }
+}

--- a/ViewInspector.xcodeproj/project.pbxproj
+++ b/ViewInspector.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		520E916226E69E540090BD1F /* PopupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520E916126E69E540090BD1F /* PopupPresenter.swift */; };
 		520F8C13266D0E600026BC57 /* CustomViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520F8C12266D0E600026BC57 /* CustomViewModifier.swift */; };
 		5214800325F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5214800225F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift */; };
+		77315AF38AB5D351033E996D /* EnvironmentInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3B1D96EDC6349C9F90F650 /* EnvironmentInjectionTests.swift */; };
 		5214802B25F803B7002D974D /* CustomStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5214802A25F803B7002D974D /* CustomStyleModifiers.swift */; };
 		5214803A25F803DC002D974D /* CustomStyleModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5214803025F803D5002D974D /* CustomStyleModifiersTests.swift */; };
 		5220903E27748CAD001A899A /* NavigationBarModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5220903D27748CAD001A899A /* NavigationBarModifiers.swift */; };
@@ -327,6 +328,7 @@
 		520E916126E69E540090BD1F /* PopupPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPresenter.swift; sourceTree = "<group>"; };
 		520F8C12266D0E600026BC57 /* CustomViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomViewModifier.swift; sourceTree = "<group>"; };
 		5214800225F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentObjectInjectionTests.swift; sourceTree = "<group>"; };
+		5C3B1D96EDC6349C9F90F650 /* EnvironmentInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentInjectionTests.swift; sourceTree = "<group>"; };
 		5214802A25F803B7002D974D /* CustomStyleModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomStyleModifiers.swift; sourceTree = "<group>"; };
 		5214803025F803D5002D974D /* CustomStyleModifiersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomStyleModifiersTests.swift; sourceTree = "<group>"; };
 		5220903D27748CAD001A899A /* NavigationBarModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifiers.swift; sourceTree = "<group>"; };
@@ -844,6 +846,7 @@
 				DD421B5E26FA6648008EFE05 /* EllipticalGradientTests.swift */,
 				F6D933A82385E9F700358E0E /* EquatableViewTests.swift */,
 				F64057F0238DBB120029D9BA /* EmptyViewTests.swift */,
+				5C3B1D96EDC6349C9F90F650 /* EnvironmentInjectionTests.swift */,
 				5214800225F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift */,
 				F60EEBED2382F004007DB53A /* ForEachTests.swift */,
 				F60EEBEB2382F004007DB53A /* FormTests.swift */,
@@ -1346,6 +1349,7 @@
 				F60EEC032382F004007DB53A /* VStackTests.swift in Sources */,
 				F6C15A17254A0BB5000240F1 /* LazyHStackTests.swift in Sources */,
 				CDA8449B262B723D00C56C98 /* SimultaneousGestureModifierTests.swift in Sources */,
+				77315AF38AB5D351033E996D /* EnvironmentInjectionTests.swift in Sources */,
 				5214800325F4EA4F002D974D /* EnvironmentObjectInjectionTests.swift in Sources */,
 				5214803A25F803DC002D974D /* CustomStyleModifiersTests.swift in Sources */,
 				F6DFD88623830EB80028E84D /* ListTests.swift in Sources */,


### PR DESCRIPTION
## Problem

When ViewInspector evaluates a custom view's `body`, any `@Environment` properties still in their `.keyPath` state trigger:

> Accessing Environment\<T\>'s value outside of being installed on a View. This will always read the default value and will not update.

In large test suites this can produce thousands of warnings (e.g. ~4,000 in ours), making it difficult to spot real issues in test output.

**Related issues:** #131, #167, #338

## Solution

This PR adds **opt-in** `@Environment` resolution that transitions fields from `.keyPath` to `.value` state before `body` evaluation, eliminating the warnings entirely.

### Enabling

```swift
// Per-test
override func setUp() {
    ViewInspectorConfig.resolveEnvironmentValues = true
}

// Or via environment variable (e.g. in your test scheme/CI)
VIEWINSPECTOR_RESOLVE_ENVIRONMENT=1
```

### Custom environment values

Test code using `.environment()` modifiers is automatically honored during resolution — both standard SwiftUI keys and custom `EnvironmentKey` types:

```swift
// Standard key override
let sut = MyView().environment(\.colorScheme, .dark)
let text = try sut.inspect().find(ViewType.Text.self).string()
XCTAssertEqual(text, "dark") // ✅ Uses the override, not the default

// Custom EnvironmentKey
let sut = MyView().environment(\.myCustomKey, "custom_value")
let text = try sut.inspect().find(ViewType.Text.self).string()
XCTAssertEqual(text, "custom_value") // ✅ Custom keys work too
```

## Technical approach

- **`EnvironmentResolvable` protocol** — conformance on `Environment<Value>` enables type-erased generic resolution via `_resolve(using:)`
- **`AnyWritableEnvironmentKeyPath` protocol** — conformance on `WritableKeyPath<EnvironmentValues, T>` enables type-erased application of `.environment()` modifier overrides
- **Raw byte manipulation** of `@frozen` `@Environment<Value>` enum layout (`.keyPath` → `.value` state transition)
- **Keypath-pointer-only matching** — when `sizeof(Value) > sizeof(KeyPath)`, Mirror-extracted copies have divergent spare payload bytes; matching only the keypath pointer (which is unique per field) avoids false negatives
- **ARC safety** — action/closure-based environment values are skipped; `buildValueStateBytes` uses raw memory allocation to avoid corrupting reference-counted keypath fields
- **Thread safety** — environment values flow through the call chain as parameters, no mutable static state

## ⚠️ Experimental — caveats

This is an **experimental** approach that relies on `@Environment`'s `@frozen` ABI-stable layout. It works reliably in our test suite but should be considered carefully before broader adoption:

1. **`@frozen` dependency** — the implementation assumes `@Environment<Value>` uses a two-case enum (`keyPath`/`value`) with a specific byte layout. This is ABI-stable but not a public API contract.

2. **Value types only** — resolution is skipped for `@Environment` values that contain reference types (closures, classes). Action-type environments like `\.dismiss` and `\.openURL` are safely ignored.

3. **Resolved values are defaults unless overridden** — without `.environment()` modifiers, values come from `EnvironmentValues()` (SwiftUI defaults). Custom keys use their `EnvironmentKey.defaultValue`.

## Files changed

| File | Description |
|------|-------------|
| `EnvironmentInjection.swift` | Core resolution logic, `ViewInspectorConfig`, `EnvironmentResolvable`, `AnyWritableEnvironmentKeyPath` |
| `ContentExtraction.swift` | Hook points: resolve before `copy.body` / `copy.body()`, thread `environmentModifiers` parameter |
| `CustomView.swift` | Pass `medium.environmentModifiers` through to `extractContent` |
| `EnvironmentInjectionTests.swift` | 16 test cases covering protocol, resolution, integration, custom keys, and regression |

## Test coverage

- ✅ Bool, enum, action environment types
- ✅ Resolution enabled/disabled (opt-in flag)
- ✅ Single and multiple `@Environment` fields
- ✅ Mixed `@Environment` + `@EnvironmentObject`
- ✅ ViewModifier with `@Environment`
- ✅ Standard key override via `.environment()` modifier
- ✅ Custom `EnvironmentKey` override via `.environment()` modifier
- ✅ Default values when no override present
- ✅ Existing `@EnvironmentObject` injection unaffected
- ✅ All 1,480 existing ViewInspector tests pass