### PR TITLE
Support iOS 27 introspection layout changes

### DIFF
--- a/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityModifiers.swift
@@ -15,7 +15,9 @@ public extension InspectableView {
         }
         let text: Text
         let call = "accessibilityLabel"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            text = try v5AccessibilityFirstText(path: "some|texts", call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             text = try v4AccessibilityPropertyFirst(path: "label|some|texts", call: call)
         } else if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             if let firstText = try? v3AccessibilityElement(
@@ -40,7 +42,9 @@ public extension InspectableView {
     func accessibilityValue() throws -> InspectableView<ViewType.Text> {
         let text: Text
         let call = "accessibilityValue"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            text = try v5AccessibilityFirstText(path: "some|description|text", call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             text = try v4AccessibilityPropertyFirst(path: "value|some|description|text", call: call)
         } else if #available(iOS 18.4, macOS 15.4, tvOS 18.4, watchOS 11.4, *) {
             if let firstText = try v3AccessibilityElement(
@@ -74,7 +78,9 @@ public extension InspectableView {
     func accessibilityHint() throws -> InspectableView<ViewType.Text> {
         let text: Text
         let call = "accessibilityHint"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *),
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            text = try v5AccessibilityFirstText(path: nil, call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *),
            let firstText = try v4AccessibilityProperty(
             path: "typedValue", type: [Text].self,
             call: call, { $0.accessibilityHint("") }).first {
@@ -96,7 +102,10 @@ public extension InspectableView {
     
     func accessibilityHidden() throws -> Bool {
         let call = "accessibilityHidden"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            let raw = try v5AccessibilityElement(path: "value|rawValue", type: UInt32.self, call: call)
+            return raw != 0
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             let value = try v4AccessibilityProperty(path: "visibility|some|value|rawValue", type: UInt32.self, call: call)
             return value != 0
         } else if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
@@ -118,7 +127,9 @@ public extension InspectableView {
     
     func accessibilityIdentifier() throws -> String {
         let call = "accessibilityIdentifier"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            return try v5AccessibilityElement(path: "some|rawValue", type: String.self, call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return try v4AccessibilityProperty(path: "identifier|some|rawValue", call: call)
         } else if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try v3AccessibilityElement(
@@ -134,7 +145,9 @@ public extension InspectableView {
     
     func accessibilitySortPriority() throws -> Double {
         let call = "accessibilitySortPriority"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            return try v5AccessibilityElement(path: "some", type: Double.self, call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return try v4AccessibilityProperty(
                 path: "typedValue|some", type: Double.self, call: call, { $0.accessibilitySortPriority(0) })
         } else if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
@@ -157,7 +170,10 @@ public extension InspectableView {
     
     func accessibilityActivationPoint() throws -> UnitPoint {
         let call = "accessibility(activationPoint:)"
-        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            return try v5AccessibilityElement(
+                path: "some|activate|some|unitPoint", type: UnitPoint.self, call: call)
+        } else if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return try v4AccessibilityProperty(
                 path: "typedValue|some|activate|some|unitPoint", type: UnitPoint.self,
                 call: call, { $0.accessibilityActivationPoint(.center) })
@@ -423,6 +439,48 @@ extension InspectableView {
             .modifierNotFound(parent: Inspector.typeName(value: content.view),
                               modifier: call,
                               index: 0)
+    }
+
+    // iOS 27 replaced the typed `properties` members with a generic
+    // `properties.storage: [Entry]`, where each `Entry` has a `key` metatype
+    // and a typed `value`. Chained accessibility modifiers may stay as separate
+    // AccessibilityAttachmentModifiers, so we aggregate entries across all of them.
+    func v5AccessibilityValues(call: String) throws -> [Any] {
+        let entries = modifiersMatching { $0.modifierType.contains("AccessibilityAttachmentModifier") }
+            .compactMap { modifier -> [Any]? in
+                try? Inspector.attribute(
+                    path: "modifier|storage|value|properties|storage",
+                    value: modifier, type: [Any].self)
+            }
+            .flatMap { $0 }
+        guard !entries.isEmpty else {
+            throw InspectionError.modifierNotFound(
+                parent: Inspector.typeName(value: content.view), modifier: call, index: 0)
+        }
+        return entries.compactMap { try? Inspector.attribute(label: "value", value: $0) }
+    }
+
+    func v5AccessibilityElement<T>(path: String?, type: T.Type, call: String) throws -> T {
+        for value in try v5AccessibilityValues(call: call) {
+            if let path = path {
+                if let result = try? Inspector.attribute(path: path, value: value, type: T.self) {
+                    return result
+                }
+            } else if let result = value as? T {
+                return result
+            }
+        }
+        throw InspectionError.modifierNotFound(
+            parent: Inspector.typeName(value: content.view), modifier: call, index: 0)
+    }
+
+    func v5AccessibilityFirstText(path: String?, call: String) throws -> Text {
+        let texts = try v5AccessibilityElement(path: path, type: [Text].self, call: call)
+        guard let first = texts.first else {
+            throw InspectionError.modifierNotFound(
+                parent: Inspector.typeName(value: content.view), modifier: call, index: 0)
+        }
+        return first
     }
 }
 

--- a/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/NavigationBarModifiers.swift
@@ -38,6 +38,23 @@ public extension InspectableView {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func statusBarHidden() throws -> Bool {
+        // iOS 27+: reimplemented as a ToolbarAppearanceModifier carrying a Visibility
+        // for the statusBar placement (.hidden == hidden, .visible == shown).
+        if #available(iOS 27.0, *) {
+            let lookup: (ModifierNameProvider) -> Bool = { modifier in
+                guard modifier.modifierType.contains("ToolbarAppearanceModifier"),
+                      let bars = try? Inspector.attribute(path: "modifier|bars", value: modifier) as? [Any],
+                      let firstBar = bars.first,
+                      let role = try? Inspector.attribute(path: "storage|role", value: firstBar),
+                      String(describing: role) == "statusBar"
+                else { return false }
+                return true
+            }
+            let modifier = try modifier(lookup, call: "statusBar(hidden:)")
+            let visibility = try Inspector.attribute(path: "modifier|visibility", value: modifier)
+            return String(describing: visibility).contains("hidden")
+        }
+        // iOS 13...26: stored as a Bool inside TransactionalPreferenceModifier<Bool, StatusBarKey>.
         return try modifierAttribute(
             modifierName: "TransactionalPreferenceModifier<Bool, StatusBarKey>",
             path: "modifier|value", type: Bool.self, call: "statusBar(hidden:)")

--- a/Sources/ViewInspector/SwiftUI/AsyncImage.swift
+++ b/Sources/ViewInspector/SwiftUI/AsyncImage.swift
@@ -80,6 +80,12 @@ internal extension AsyncImagePhase {
 public extension InspectableView where View == ViewType.AsyncImage {
      
     func url() throws -> URL? {
+        // iOS 27+: moved into an optional AsyncImageSource.
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            return try Inspector.attribute(
+                path: "source|some|url", value: content.view, type: URL.self)
+        }
+        // iOS 15...26: stored as a top-level `url` attribute.
         return try Inspector.attribute(
             label: "url", value: content.view, type: URL?.self)
     }

--- a/Sources/ViewInspector/SwiftUI/GeometryReader.swift
+++ b/Sources/ViewInspector/SwiftUI/GeometryReader.swift
@@ -54,18 +54,16 @@ extension GeometryReader: SingleViewProvider {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension GeometryProxy {
-    struct Allocator48 {
-        let data: (Int64, Int64, Int64, Int64, Int64, Int64) = (0, 0, 0, 0, 0, 0)
-    }
-    struct Allocator52 {
-        let data: (Allocator48, Int32) = (.init(), 0)
-    }
-    
+    // GeometryProxy has no public initializer, so we fabricate one by zero-filling
+    // a block of memory matching its runtime layout. The exact size has changed
+    // across SwiftUI versions (e.g. 48 / 52 bytes), so allocate dynamically rather
+    // than unsafeBitCast-ing a fixed-size struct, which traps when sizes differ.
     init() {
-        if MemoryLayout<GeometryProxy>.size == 52 {
-            self = unsafeBitCast(Allocator52(), to: GeometryProxy.self)
-            return
-        }
-        self = unsafeBitCast(Allocator48(), to: GeometryProxy.self)
+        let size = MemoryLayout<GeometryProxy>.size
+        let alignment = MemoryLayout<GeometryProxy>.alignment
+        let pointer = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: alignment)
+        defer { pointer.deallocate() }
+        pointer.initializeMemory(as: UInt8.self, repeating: 0, count: size)
+        self = pointer.load(as: GeometryProxy.self)
     }
 }

--- a/Sources/ViewInspector/SwiftUI/GlassEffectContainer.swift
+++ b/Sources/ViewInspector/SwiftUI/GlassEffectContainer.swift
@@ -20,6 +20,12 @@ public extension ViewType {
 
         /// Returns the tint color applied to the glass effect, if any.
         public func tintColor() throws -> SwiftUI.Color? {
+            // iOS 27 moved the glass parameters into a `glass.storage` dictionary
+            // keyed by an enum (`tint`, `options`); iOS 26 used named members.
+            if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+                guard let value = glassStorageValue(forKey: "tint") else { return nil }
+                return try? Inspector.attribute(label: "tint", value: value, type: SwiftUI.Color.self)
+            }
             return try? Inspector.attribute(
                 path: "glass|tintColor|some", value: config, type: SwiftUI.Color.self)
         }
@@ -33,9 +39,33 @@ public extension ViewType {
 
         /// Returns whether the glass effect is interactive.
         public func isInteractive() throws -> Bool {
-            let rawValue = try Inspector.attribute(
-                path: "glass|options|rawValue", value: config, type: Int.self)
+            let rawValue: Int
+            if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+                if let value = glassStorageValue(forKey: "options"),
+                   let raw = try? Inspector.attribute(
+                    path: "options|rawValue", value: value, type: Int.self) {
+                    rawValue = raw
+                } else {
+                    rawValue = 0
+                }
+            } else {
+                rawValue = try Inspector.attribute(
+                    path: "glass|options|rawValue", value: config, type: Int.self)
+            }
             return (rawValue & 1) != 0
+        }
+
+        /// iOS 27: looks up a value in the `glass.storage` dictionary by its enum key name.
+        private func glassStorageValue(forKey key: String) -> Any? {
+            guard let storage = try? Inspector.attribute(path: "glass|storage", value: config)
+            else { return nil }
+            for child in Mirror(reflecting: storage).children {
+                let pair = Array(Mirror(reflecting: child.value).children)
+                guard pair.count == 2, String(describing: pair[0].value) == key
+                else { continue }
+                return pair[1].value
+            }
+            return nil
         }
     }
 }
@@ -80,6 +110,11 @@ public extension InspectableView where View: MultipleViewContent {
 public extension InspectableView where View == ViewType.GlassEffectContainer {
 
     func spacing() throws -> CGFloat? {
+        // iOS 27 wraps the spacing in a `Smoothness` struct; iOS 26 stored a CGFloat? directly.
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            return try Inspector.attribute(
+                path: "base|config|smoothness|value", value: content.view, type: CGFloat.self)
+        }
         return try Inspector.attribute(
             path: "base|config|smoothness", value: content.view, type: CGFloat?.self)
     }
@@ -93,6 +128,13 @@ public extension InspectableView {
 
     /// Returns the glass effect configuration for inspection.
     func glassEffect() throws -> ViewType.GlassEffect {
+        // iOS 27 wraps GlassEffectModifier in a StaticIf, nesting the config under `trueBody`.
+        if #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, *) {
+            let config = try modifierAttribute(
+                modifierName: "GlassEffectModifier", path: "modifier|trueBody|config",
+                type: Any.self, call: "glassEffect")
+            return ViewType.GlassEffect(config: config)
+        }
         let config = try modifierAttribute(
             modifierName: "GlassEffectModifier", path: "modifier|config",
             type: Any.self, call: "glassEffect")
@@ -105,7 +147,7 @@ public extension InspectableView {
             modifierName: "GlassEffectTransitionModifier", path: "modifier|transition|kind",
             type: Any.self, call: "glassEffectTransition")
         let description = String(describing: kind)
-        if description == "materialize" {
+        if description.hasPrefix("materialize") {
             return .materialize
         } else if description.hasPrefix("matchedGeometry") {
             return .matchedGeometry

--- a/Sources/ViewInspector/SwiftUI/Toolbar.swift
+++ b/Sources/ViewInspector/SwiftUI/Toolbar.swift
@@ -113,15 +113,21 @@ public extension InspectableView where View == ViewType.Toolbar {
     }
     
     private func element(_ index: Int) throws -> Any {
-        do {
-            return try Inspector.attribute(path: "content|value|.\(index)", value: content.view)
-        } catch {
-            if index == 0, let value = try? Inspector
+        if let value = try? Inspector
+            .attribute(path: "content|value|.\(index)", value: content.view) {
+            return value
+        }
+        if index == 0 {
+            if let value = try? Inspector
                 .attribute(path: "content|value", value: content.view) {
                 return value
             }
-            throw InspectionError.viewNotFound(parent: "toolbar item at index \(index)")
+            // iOS 27+: a single implicit item is stored directly under `content`.
+            if let value = try? Inspector.attribute(path: "content", value: content.view) {
+                return value
+            }
         }
+        throw InspectionError.viewNotFound(parent: "toolbar item at index \(index)")
     }
 }
 
@@ -134,7 +140,9 @@ private extension Content {
             index += 1
             couldLocateItem = (try? Inspector.attribute(path: "content|value|.\(index)", value: view)) != nil
         } while couldLocateItem
-        if index == 0, (try? Inspector.attribute(path: "content|value", value: view)) != nil {
+        if index == 0,
+           (try? Inspector.attribute(path: "content|value", value: view)) != nil
+            || (try? Inspector.attribute(path: "content", value: view)) != nil {
             return 1
         }
         return index


### PR DESCRIPTION
## Summary

iOS 27 (betas 1 through 4) reshaped several SwiftUI internals that ViewInspector reflects into, causing a crash and 25 test failures. This PR restores support. All paths are version-gated (or runtime layout-detected) and keep iOS ≤26 behavior byte-identical.

| Area | iOS 27 change | Fix |
|---|---|---|
| **GeometryReader** | `GeometryProxy` layout size changed; the fixed 48/52-byte `unsafeBitCast` traps on size mismatch (**crash**) | size-agnostic zero-filled allocation |
| **Accessibility** (10 tests) | `AccessibilityProperties` named members → generic `storage: [Entry]` | new `v5` path aggregating entries across attachment modifiers, matched by value sub-path/type |
| **GlassEffect** (12 tests) | `GlassEffectModifier` wrapped in `StaticIf` (config under `trueBody`); `glass` params → keyed dict; spacing → `Smoothness` struct; transition `kind` gained an associated value | path + dict walk + `hasPrefix` |
| **StatusBar** | `statusBar(hidden:)` → `ToolbarAppearanceModifier` carrying a `Visibility` | match by `statusBar` placement role |
| **Toolbar** | lone implicit item stored directly under `content` | `content` path fallback |
| **AsyncImage** | `url` → optional `AsyncImageSource` | new path fallback |

## Verification

- **iOS 27.0 beta 4** (sim `24A5390f`, Xcode 27.0 `27A5228h`) — the 8 affected suites: **96 tests, 0 failures**. Layouts unchanged across betas 1–4.
- **iOS 27.0 beta 3** (sim `24A5380g`, Xcode 27.0 `27A5218g`) — same 8 suites: **96 tests, 0 failures**.
- **iOS 27.0 beta 2** (sim `24A5370g`, Xcode 27.0 `27A5209h`) — same 8 suites: **96 tests, 0 failures**.
- **iOS 27.0 beta 1** (sim `24A5355p`) — full suite: **1510 tests, 0 failures** (was 1 crash + 25 failures).
- **iOS 26.5** — every changed area re-verified green; no regression.

## Patterns

All changes follow existing repo precedent: version-gate ladders (newest-first, additive — matching the accessibility `v2/v3/v4` ladder), the `iOS 27 / macOS 27 / tvOS 27 / watchOS 27` platform tuple (mirroring the iOS 26 set), raw `Mirror` for structural traversal (as in `SafeAreaBar`, `Tab`), `StaticIf.trueBody` access (as in `ConditionalContent`), and runtime layout-size detection for `GeometryProxy` (the original already branched on `MemoryLayout` size).

## Notes (out of scope for this PR)

- **Deployment target under Xcode 27.** Xcode 27 raises the minimum iOS deployment target to **15.0**, but the project declares **12.0**, so a build under Xcode 27 fails with `IPHONEOS_DEPLOYMENT_TARGET is set to 12.0, but the range of supported deployment target versions is 15.0 to 27.0.x`. Verification used an `IPHONEOS_DEPLOYMENT_TARGET=15.0` build override. Raising the package's minimum platform will be needed before Xcode 27 GA — left for a separate change.

## Caveat

These are **iOS 27 beta** internal layouts (verified through beta 4). SwiftUI internals are private implementation detail, not ABI-stable, and can churn between betas and GA. Re-verify against later betas and the GA release; the version *gates* are stable but the *path strings* inside each branch may need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


