### PR TITLE
Support iOS 27 LazyVStack and LazyHStack introspection

### DIFF
--- a/Sources/ViewInspector/SwiftUI/LazyHStack.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyHStack.swift
@@ -34,7 +34,15 @@ public extension InspectableView where View: MultipleViewContent {
 extension ViewType.LazyHStack: MultipleViewContent {
 
     public static func children(_ content: Content) throws -> LazyGroup<Content> {
-        let view = try Inspector.attribute(path: "tree|content", value: content.view)
+        // iOS 27 flattened LazyVStack and LazyHStack: the content sits directly on the view,
+        // and there is no longer a `tree` wrapper. LazyVGrid and LazyHGrid delegate here and
+        // kept the earlier layout, so `tree|content` is attempted first.
+        let view: Any
+        if let tree = try? Inspector.attribute(path: "tree|content", value: content.view) {
+            view = tree
+        } else {
+            view = try Inspector.attribute(label: "content", value: content.view)
+        }
         return try Inspector.viewsInContainer(view: view, medium: content.medium)
     }
 }
@@ -45,20 +53,34 @@ extension ViewType.LazyHStack: MultipleViewContent {
 public extension InspectableView where View == ViewType.LazyHStack {
     
     func alignment() throws -> VerticalAlignment {
+        guard let layout = try? lazyHStackLayout() else {
+            return try Inspector.attribute(
+                label: "alignment", value: content.view, type: VerticalAlignment.self)
+        }
         return try Inspector.attribute(
-            path: "base|alignment", value: lazyHStackLayout(), type: VerticalAlignment.self)
+            path: "base|alignment", value: layout, type: VerticalAlignment.self)
     }
-    
+
     func spacing() throws -> CGFloat? {
+        guard let layout = try? lazyHStackLayout() else {
+            return try Inspector.attribute(
+                label: "spacing", value: content.view, type: CGFloat?.self)
+        }
         return try Inspector.attribute(
-            path: "base|spacing", value: lazyHStackLayout(), type: CGFloat?.self)
+            path: "base|spacing", value: layout, type: CGFloat?.self)
     }
-    
+
     func pinnedViews() throws -> PinnedScrollableViews {
+        guard let layout = try? lazyHStackLayout() else {
+            return try Inspector.attribute(
+                label: "pinnedViews", value: content.view, type: PinnedScrollableViews.self)
+        }
         return try Inspector.attribute(
-            label: "pinnedViews", value: lazyHStackLayout(), type: PinnedScrollableViews.self)
+            label: "pinnedViews", value: layout, type: PinnedScrollableViews.self)
     }
-    
+
+    // Absent on iOS 27, where these values live directly on the view.
+
     private func lazyHStackLayout() throws -> Any {
         if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
             return layout

--- a/Sources/ViewInspector/SwiftUI/LazyVStack.swift
+++ b/Sources/ViewInspector/SwiftUI/LazyVStack.swift
@@ -44,20 +44,34 @@ extension ViewType.LazyVStack: MultipleViewContent {
 public extension InspectableView where View == ViewType.LazyVStack {
     
     func alignment() throws -> HorizontalAlignment {
+        guard let layout = try? lazyVStackLayout() else {
+            return try Inspector.attribute(
+                label: "alignment", value: content.view, type: HorizontalAlignment.self)
+        }
         return try Inspector.attribute(
-            path: "base|alignment", value: lazyVStackLayout(), type: HorizontalAlignment.self)
+            path: "base|alignment", value: layout, type: HorizontalAlignment.self)
     }
-    
+
     func spacing() throws -> CGFloat? {
+        guard let layout = try? lazyVStackLayout() else {
+            return try Inspector.attribute(
+                label: "spacing", value: content.view, type: CGFloat?.self)
+        }
         return try Inspector.attribute(
-            path: "base|spacing", value: lazyVStackLayout(), type: CGFloat?.self)
+            path: "base|spacing", value: layout, type: CGFloat?.self)
     }
-    
+
     func pinnedViews() throws -> PinnedScrollableViews {
+        guard let layout = try? lazyVStackLayout() else {
+            return try Inspector.attribute(
+                label: "pinnedViews", value: content.view, type: PinnedScrollableViews.self)
+        }
         return try Inspector.attribute(
-            label: "pinnedViews", value: lazyVStackLayout(), type: PinnedScrollableViews.self)
+            label: "pinnedViews", value: layout, type: PinnedScrollableViews.self)
     }
-    
+
+    // Absent on iOS 27, where these values live directly on the view.
+
     private func lazyVStackLayout() throws -> Any {
         if let layout = try? Inspector.attribute(path: "tree|content|root", value: content.view) {
             return layout


### PR DESCRIPTION
## The problem

On iOS 27, `find(...)` cannot reach any view inside a `LazyVStack` or `LazyHStack`. This already fails **10 tests in the existing suites** on the iOS 27 simulator — `testSearch`, `testContentViewInspection`, `testAlignmentInspection`, `testSpacingInspection` and `testPinnedViewsInspection`, in both `LazyVStackTests` and `LazyHStackTests`.

iOS 27 flattened both types. The `tree` wrapper is gone and the content sits directly on the view:

```
LazyVStack (iOS 27):  .alignment  .spacing  .pinnedViews  .content
                      tree|content THREW: LazyVStack<Text> does not have 'tree' attribute

LazyVGrid  (iOS 27):  .tree = ResettableLazyLayoutRoot -> tree.content = Tree   (unchanged)
```

`LazyVGrid` and `LazyHGrid` delegate to the same `LazyHStack.children(_:)` but kept the earlier layout, which is why only the stacks broke — `LazyVGridTests` and `LazyHGridTests` pass on iOS 27 today.

## The fix

`children(_:)` attempts `tree|content` first and falls back to the flat `content`, so every shape that works today takes the identical path. The three custom attributes get the same treatment: when there is no `tree` they read `alignment` / `spacing` / `pinnedViews` directly off the view, composing with the existing `tree|content|root` fallback rather than replacing it.

## Verification

Existing `LazyVStackTests`, `LazyHStackTests`, `LazyVGridTests` and `LazyHGridTests`:

| | iOS 27.0 sim (`24A5390f`, Xcode 27.0 beta 4) | iOS 26.5 (Xcode 26.5) |
|---|---|---|
| before | 34 tests, **10 failures** | 34 tests, 0 failures |
| after | 34 tests, **0 failures** | 34 tests, 0 failures |

No new tests: the existing suites already cover both `children(_:)` and all three attributes, and they exercise whichever internal shape the running OS provides, so they now pass on both.

Also validated in a large private codebase, where this silently hid the entire content subtree of every scrolling screen — traversal reached 104 views on iOS 27 versus 270 on iOS 26.5, and found zero `Text` anywhere.

One note: `IPHONEOS_DEPLOYMENT_TARGET` is 12.0 in `ViewInspector.xcodeproj`, below Xcode 27's floor of 15.0, so running the suite under Xcode 27 needs `IPHONEOS_DEPLOYMENT_TARGET=15.0` on the command line. I left the project alone since raising it is your call, but it may be worth doing so iOS 27 is testable out of the box.

Related: #422 reports the `GeometryProxy` crash, which is the same family of moved internals, and #421 fixes it.