### PR TITLE
Support @Observable objects in @Environment

### DIFF
--- a/Sources/ViewInspector/EnvironmentInjection.swift
+++ b/Sources/ViewInspector/EnvironmentInjection.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Observation
 
 // MARK: - EnvironmentObject injection
 
@@ -20,6 +21,11 @@ internal enum EnvironmentInjection {
         }
     }
     static func inject<T>(environmentObject: AnyObject, into entity: T) -> T {
+        let entity = injectEnvironmentObject(environmentObject, into: entity)
+        return injectEnvironment(object: environmentObject, into: entity)
+    }
+
+    private static func injectEnvironmentObject<T>(_ environmentObject: AnyObject, into entity: T) -> T {
         let type = "SwiftUI.EnvironmentObject<\(Inspector.typeName(value: environmentObject, namespaced: true))>"
         let mirror = Mirror(reflecting: entity)
         guard let label = mirror.children
@@ -57,6 +63,71 @@ internal enum EnvironmentInjection {
             }
             return entity
         }
+    }
+
+    /// Injects an `Observable` object in the `@Environment(Type.self)` properties of the view.
+    ///
+    /// Such property stores either a `KeyPath` to a private `EnvironmentValues` entry,
+    /// or the resolved value. SwiftUI crashes when it reads the unresolved `KeyPath`
+    /// outside a hosted view, so the injection replaces `keyPath` with the `value` case.
+    private static func injectEnvironment<T>(object: AnyObject, into entity: T) -> T {
+        let keyPaths = environmentKeyPaths(for: object)
+        guard keyPaths.count > 0 else { return entity }
+        return Mirror(reflecting: entity).children.reduce(entity) { entity, child in
+            guard let label = child.label,
+                  let keyPath = try? Inspector.attribute(path: "content|keyPath", value: child.value,
+                                                         type: AnyKeyPath.self),
+                  keyPaths.contains(keyPath)
+            else { return entity }
+            return withUnsafeBytes(of: Unmanaged.passUnretained(keyPath).toOpaque()) { reference in
+                var offset = 0
+                while offset + EnvValue.structSize <= MemoryLayout<T>.size {
+                    var copy = entity
+                    withUnsafeMutableBytes(of: &copy) { bytes in
+                        guard bytes[offset..<offset + reference.count].elementsEqual(reference),
+                              bytes[offset + reference.count] == EnvValue.keyPathCase
+                        else { return }
+                        let rawPointer = bytes.baseAddress! + offset
+                        rawPointer.assumingMemoryBound(to: EnvValue.Forgery.self).pointee = .init(object: object)
+                    }
+                    if (try? Inspector.attribute(path: label + "|content|value", value: copy)) != nil {
+                        return copy
+                    }
+                    offset += MemoryLayout<UnsafeRawPointer>.alignment
+                }
+                return entity
+            }
+        }
+    }
+
+    /// The key paths SwiftUI uses for referencing the object in `EnvironmentValues`, for both
+    /// the plain and the optional `@Environment(Type.self)`. Empty for non-`Observable` objects.
+    static func environmentKeyPaths(for object: AnyObject) -> [AnyKeyPath] {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *),
+              let object = object as? any Observable & AnyObject
+        else { return [] }
+        return environmentKeyPaths(of: object)
+    }
+
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+    private static func environmentKeyPaths<T>(of object: T) -> [AnyKeyPath]
+    where T: Observable & AnyObject {
+        return [Environment(T.self) as Any, Environment<T?>(T.self) as Any].compactMap {
+            try? Inspector.attribute(path: "content|keyPath", value: $0, type: AnyKeyPath.self)
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal struct EnvValue {
+    /// `SwiftUI.Environment.Content` is a frozen enum with cases `keyPath` and `value`,
+    /// each holding a pointer-sized payload followed by the case discriminator.
+    static var keyPathCase: UInt8 { 0 }
+    static var structSize: Int { MemoryLayout<UnsafeRawPointer>.size + 1 }
+
+    struct Forgery {
+        let object: AnyObject?
+        let valueCase: UInt8 = 1
     }
 }
 

--- a/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomViewModifier.swift
@@ -70,7 +70,8 @@ internal extension Content {
            modifier.qualifiesAsEnvironmentModifier() {
             if let value = try? modifier.value(),
                let object = try? Inspector.attribute(label: "some", value: value, type: AnyObject.self),
-               object is any ObservableObject {
+               object is any ObservableObject
+                || EnvironmentInjection.environmentKeyPaths(for: object).count > 0 {
                 medium = self.medium.appending(environmentObject: object)
             } else {
                 medium = self.medium.appending(environmentModifier: modifier)

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObservableInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObservableInjectionTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+import SwiftUI
+#if canImport(Observation)
+import Observation
+#endif
+
+@testable import ViewInspector
+
+@MainActor
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class EnvironmentObservableInjectionTests: XCTestCase {
+
+    func testEnvironmentMemoryLayout() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        typealias RealType = Environment<TestObservableObject1>
+        XCTAssertEqual(MemoryLayout<RealType>.size, EnvValue.structSize)
+        let sut = RealType(\.testObservableObject1)
+        try withUnsafeBytes(of: sut, { bytes in
+            let discriminator = try XCTUnwrap(bytes.last)
+            XCTAssertEqual(discriminator, EnvValue.keyPathCase)
+        })
+    }
+
+    func testEnvironmentForgery() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj = TestObservableObject1()
+        let forgery = EnvValue.Forgery(object: obj)
+        let sut = unsafeBitCast(forgery, to: Environment<TestObservableObject1>.self)
+        XCTAssertIdentical(sut.wrappedValue, obj)
+    }
+
+    func testDirectEnvironmentInjection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let obj2 = TestObservableObject2()
+        var sut = ObservableInnerView()
+        sut = EnvironmentInjection.inject(environmentObject: obj1, into: sut)
+        sut = EnvironmentInjection.inject(environmentObject: obj2, into: sut)
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "env_true")
+    }
+
+    func testEnvironmentInjectionDuringSyncInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let obj2 = TestObservableObject2()
+        let sut = ObservableOuterView()
+            .environment(obj1)
+            .environment(obj2)
+        XCTAssertNoThrow(try sut.inspect().find(text: "env_true"))
+        try sut.inspect().find(button: "Flag").tap()
+        XCTAssertNoThrow(try sut.inspect().find(text: "env_false"))
+        XCTAssertEqual(try sut.inspect().findAll(ViewType.Text.self).first?.string(), "env_false")
+    }
+
+    func testOptionalEnvironmentInjection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let sut = ObservableOptionalView()
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "none")
+        XCTAssertEqual(try sut.environment(obj1).inspect().find(ViewType.Text.self).string(), "env")
+    }
+
+    func testInjectedObjectIsRetainedAndReleased() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        weak var weakObject: TestObservableObject1?
+        try {
+            let object = TestObservableObject1()
+            weakObject = object
+            var sut = ObservableOptionalView()
+            sut = EnvironmentInjection.inject(environmentObject: object, into: sut)
+            XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "env")
+        }()
+        XCTAssertNil(weakObject)
+    }
+
+    func testEnvironmentInjectionInActualView() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let obj2 = TestObservableObject2()
+        let sut = ObservableInnerView().environment(obj1).environment(obj2)
+        let view = try sut.inspect().find(ObservableInnerView.self).actualView()
+        XCTAssertIdentical(view.obj1, obj1)
+        XCTAssertIdentical(view.obj2, obj2)
+    }
+
+    func testEnvironmentInjectionOnDidAppearInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let obj2 = TestObservableObject2()
+        var sut = ObservableOuterView()
+        let exp = sut.on(\.didAppear) { view in
+            XCTAssertNoThrow(try view.find(text: "env_true"))
+            try view.find(button: "Flag").tap()
+            XCTAssertNoThrow(try view.find(text: "env_false"))
+        }
+        ViewHosting.host(view: sut.environment(obj1).environment(obj2))
+        defer { ViewHosting.expel() }
+        wait(for: [exp], timeout: 0.5)
+    }
+
+    func testEnvironmentInjectionDuringAsyncInspection() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let obj1 = TestObservableObject1()
+        let obj2 = TestObservableObject2()
+        let sut = ObservableOuterView()
+        // Note: unlike with `@EnvironmentObject`, only one inspection of the hosted
+        // view is possible: SwiftUI drops the `Observable` objects from the
+        // environment once it re-renders the hierarchy.
+        let exp = sut.inspection.inspect { view in
+            XCTAssertNoThrow(try view.find(text: "env_true"))
+            try view.find(button: "Flag").tap()
+            XCTAssertNoThrow(try view.find(text: "env_false"))
+        }
+        ViewHosting.host(view: sut.environment(obj1).environment(obj2))
+        defer { ViewHosting.expel() }
+        wait(for: [exp], timeout: 0.5)
+    }
+
+    func testEnvironmentValueOfTheSameTypeIsUnaffected() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+        else { throw XCTSkip() }
+        let injected = TestObservableObject1()
+        injected.value1 = "injected"
+        let keyed = TestObservableObject1()
+        let sut = ObservableEnvironmentValueView()
+            .environment(injected)
+            .environment(\.testObservableObject1, keyed)
+        // The keyed property is not injected, thus reading the key's default value:
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "env_injected")
+        let view = try sut.inspect().find(ObservableEnvironmentValueView.self)
+        XCTAssertIdentical(try view.environment(\.testObservableObject1), keyed)
+    }
+}
+
+// MARK: -
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+@Observable
+private class TestObservableObject1 {
+    var value1 = "env"
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+@Observable
+private class TestObservableObject2 {
+    var value2 = true
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private extension EnvironmentValues {
+    var testObservableObject1: TestObservableObject1 {
+        get { self[TestObservableObject1Key.self] }
+        set { self[TestObservableObject1Key.self] = newValue }
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct TestObservableObject1Key: EnvironmentKey {
+    static var defaultValue: TestObservableObject1 { .init() }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct ObservableInnerView: View {
+
+    private var iVar1: Int8 = 0
+    private var iVar2: Int16 = 0
+    @Environment(TestObservableObject2.self) var obj2
+    private var iVar3: Int32 = 0
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(TestObservableObject1.self) var obj1
+    @State var flag: Bool = false
+    private var iVar4: Bool = false
+
+    var body: some View {
+        VStack {
+            Text(obj1.value1 + "_\(obj2.value2)")
+            Button("Flag", action: { self.obj2.value2.toggle() })
+        }
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct ObservableOuterView: View {
+
+    private var iVar1: Bool = false
+    @Environment(TestObservableObject1.self) var obj1
+    private var iVar2: Int8 = 0
+    @Environment(TestObservableObject2.self) var obj2
+    var didAppear: ((Self) -> Void)?
+    let inspection = Inspection<Self>()
+
+    var body: some View {
+        ObservableInnerView()
+            .modifier(ObservableViewModifier())
+            .onAppear { self.didAppear?(self) }
+            .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct ObservableOptionalView: View {
+
+    @Environment(TestObservableObject1.self) private var obj1: TestObservableObject1?
+
+    var body: some View {
+        Text(obj1?.value1 ?? "none")
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct ObservableEnvironmentValueView: View {
+
+    @Environment(\.testObservableObject1) private var keyed
+    @Environment(TestObservableObject1.self) private var obj1
+
+    var body: some View {
+        Text(keyed.value1 + "_" + obj1.value1)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+private struct ObservableViewModifier: ViewModifier {
+    private var iVar1: Bool = false
+    @Environment(TestObservableObject2.self) var obj2
+    @Environment(TestObservableObject1.self) var obj1
+    private var iVar2: Int8 = 0
+
+    func body(content: Self.Content) -> some View {
+        VStack {
+            Text(obj1.value1 + "+\(obj2.value2)")
+            content
+        }
+    }
+}

--- a/guide.md
+++ b/guide.md
@@ -483,6 +483,29 @@ For the case of `@Environment` or `@EnvironmentObject`, you can perform the inje
 ViewHosting.host(view: sut.environmentObject(...))
 ```
 
+Objects taken from the environment with the `@Observable` macro are supported as well, and they don't require hosting the view: the injection works with synchronous inspection:
+
+```swift
+@Observable class Router {
+    var routes: [Route] = []
+}
+
+struct LoginScreen: View {
+
+    @Environment(Router.self) private var router
+
+    var body: some View {
+        Button("Login") { router.navigate(to: .dashboard) }
+    }
+}
+
+// The test:
+let router = Router()
+let sut = LoginScreen().environment(router)
+try sut.inspect().find(button: "Login").tap()
+XCTAssertEqual(router.routes, [.dashboard])
+```
+
 ## Custom **ViewModifier**
 
 You can inspect custom `ViewModifier` independently, or together with the parent view hierarchy, to which the `ViewModifier` is applied using `.modifier(...)`. Consider an example:

--- a/readiness.md
+++ b/readiness.md
@@ -420,6 +420,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 | Status | Modifier |
 |:---:|---|
 |:white_check_mark:| `func environmentObject<B>(B) -> some View` |
+|:white_check_mark:| `func environment<T>(T?) -> some View where T: AnyObject, T: Observable` |
 |:technologist:| `func environment<V>(WritableKeyPath<EnvironmentValues, V>, V) -> some View` |
 |:technologist:| `func transformEnvironment<V>(WritableKeyPath<EnvironmentValues, V>, transform: (inout V) -> Void) -> some View` |
 


### PR DESCRIPTION
Fixes #423

## Problem

A view that takes an `@Observable` object from the environment crashes during inspection:

```swift
@Observable class Router { var routes: [Route] = [] }

struct LoginScreen: View {
    @Environment(Router.self) private var router
    var body: some View {
        Button("Login") { router.navigate(to: .dashboard) }
    }
}

let sut = LoginScreen().environment(Router())
try sut.inspect().find(button: "Login") // 💥
```

```
SwiftUICore/Environment+Objects.swift:34: Fatal error: No Observable object of type Router
found. A View.environmentObject(_:) for Router may be missing as an ancestor of this view.
```

Two causes:

1. `Content.unwrappedModifiedContent()` collected the object supplied with `.environment(_:)` only when it was an `ObservableObject`. Types using the `@Observable` macro conform to `Observable` instead, so the object never reached `Medium.environmentObjects`.
2. Even when collected, `EnvironmentInjection` only knew how to inject `@EnvironmentObject`. `@Environment(Type.self)` is a different property wrapper: `SwiftUI.Environment<T>` stores either a `KeyPath` into `EnvironmentValues` or the already resolved value. Reading the unresolved `KeyPath` outside a hosted view hierarchy is what makes SwiftUI trap above.

## Solution

Inject such objects by replacing the `keyPath` case of the property wrapper's storage with the `value` case, in the same spirit as the existing `@EnvironmentObject` forgery.

The properties to inject are found by comparing their key path with the ones SwiftUI uses for the plain and the optional `@Environment(Type.self)` declarations, instead of matching on type names. This keeps an `@Environment(\.someKey)` value of the same class type untouched.

Supported for iOS 17 / macOS 14 / tvOS 17 / watchOS 10 and above; earlier OS versions are unaffected.

## Notes

- Both `@Environment(Router.self) var router` and `@Environment(Router.self) var router: Router?` are handled, in views and in custom `ViewModifier`s.
- The existing `@EnvironmentObject` injection is unchanged: the original function body was only renamed to `injectEnvironmentObject(_:into:)`, and the new code returns early for objects that are not `Observable`.
- When a hosted view mutates an `Observable` object taken from the environment, SwiftUI drops those objects from the environment on the following re-render, so only one inspection per hosting is possible in that case. This reproduces without ViewInspector taking part in the render, so it is left as is and noted in the tests.
- Forgetting `.environment(object)` still results in SwiftUI's own fatal error rather than an `InspectionError`: object-keyed `Environment` properties cannot be told apart from `@Environment(\.someKey)` ones without knowing the object type upfront.

## Testing

New `EnvironmentObservableInjectionTests` with 10 tests, mirroring `EnvironmentObjectInjectionTests`: memory layout and forgery assumptions, direct injection, synchronous inspection with a tap, the optional declaration, `actualView()`, `didAppear` and async inspection, non-interference with an `@Environment` value of the same type, and retain/release of the injected object.

The full suite was run with `xcodebuild test` on macOS before and after the change: 1548 test cases passed before, 1558 after, no failures in either run, and no pre-existing test changed its result.