### PR TITLE
Support arbitrary type injection for @Environment

### DIFF
--- a/Sources/ViewInspector/BaseTypes.swift
+++ b/Sources/ViewInspector/BaseTypes.swift
@@ -171,6 +171,20 @@ internal extension Content {
         let environmentModifiers: [EnvironmentModifier]
         let environmentObjects: [AnyObject]
         
+        /// The values of the enclosing `.environment(keyPath, value)` modifiers,
+        /// in the order of their application, for injecting in the `@Environment` properties.
+        #if swift(>=6.0)
+        @MainActor
+        #endif
+        var environmentValues: [EnvironmentValueInjection] {
+            return environmentModifiers.compactMap { modifier in
+                guard let keyPath = (try? modifier.keyPath()) as? AnyKeyPath,
+                      let value = try? modifier.value()
+                else { return nil }
+                return (keyPath, value)
+            }
+        }
+
         static var empty: Medium {
             return .init(viewModifiers: [],
                          transitiveViewModifiers: [],

--- a/Sources/ViewInspector/ContentExtraction.swift
+++ b/Sources/ViewInspector/ContentExtraction.swift
@@ -10,24 +10,28 @@ internal struct ContentExtractor {
         self.contentSource = try Self.contentSource(from: source)
     }
 
-    internal func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+    internal func extractContent(medium: Content.Medium) throws -> Any {
         #if swift(>=6.0)
-        return try isolatedExtractContent(environmentObjects: environmentObjects)
+        return try isolatedExtractContent(medium: medium)
         #else
         return try MainActor.assumeIsolated {
-            try isolatedExtractContent(environmentObjects: environmentObjects)
+            try isolatedExtractContent(medium: medium)
         }
         #endif
     }
 
     @MainActor
-    private func isolatedExtractContent(environmentObjects: [AnyObject]) throws -> Any {
+    private func isolatedExtractContent(medium: Content.Medium) throws -> Any {
         try validateSourceBeforeExtraction()
+        let environmentObjects = medium.environmentObjects
+        let environmentValues = medium.environmentValues
         switch contentSource {
         case .view(let view):
-            return try view.extractContent(environmentObjects: environmentObjects)
+            return try view.extractContent(environmentObjects: environmentObjects,
+                                           environmentValues: environmentValues)
         case .viewModifier(let viewModifier):
-            return try viewModifier.extractContent(environmentObjects: environmentObjects)
+            return try viewModifier.extractContent(environmentObjects: environmentObjects,
+                                                   environmentValues: environmentValues)
         case .gesture(let gesture):
             return try gesture.extractContent(environmentObjects: environmentObjects)
         }
@@ -130,9 +134,11 @@ private extension ViewModifier {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension View {
     @MainActor
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+    func extractContent(environmentObjects: [AnyObject],
+                        environmentValues: [(keyPath: AnyKeyPath, value: Any)] = []) throws -> Any {
         var copy = self
         environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        copy = EnvironmentInjection.inject(environmentValues: environmentValues, into: copy)
         let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
         if missingObjects.count > 0 {
             let view = Inspector.typeName(value: self)
@@ -146,9 +152,11 @@ public extension View {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public extension ViewModifier {
     @MainActor
-    func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+    func extractContent(environmentObjects: [AnyObject],
+                        environmentValues: [(keyPath: AnyKeyPath, value: Any)] = []) throws -> Any {
         var copy = self
         environmentObjects.forEach { copy = EnvironmentInjection.inject(environmentObject: $0, into: copy) }
+        copy = EnvironmentInjection.inject(environmentValues: environmentValues, into: copy)
         let missingObjects = EnvironmentInjection.missingEnvironmentObjects(for: copy)
         if missingObjects.count > 0 {
             let view = Inspector.typeName(value: self)
@@ -157,7 +165,8 @@ public extension ViewModifier {
         }
         if let envModifier = copy as? (any EnvironmentalModifier) {
             let resolved = envModifier.resolve(in: EnvironmentValues())
-            return try resolved.extractContent(environmentObjects: environmentObjects)
+            return try resolved.extractContent(environmentObjects: environmentObjects,
+                                               environmentValues: environmentValues)
         }
         guard copy.hasBody else {
             return "<Never>"

--- a/Sources/ViewInspector/EnvironmentInjection.swift
+++ b/Sources/ViewInspector/EnvironmentInjection.swift
@@ -22,7 +22,11 @@ internal enum EnvironmentInjection {
     }
     static func inject<T>(environmentObject: AnyObject, into entity: T) -> T {
         let entity = injectEnvironmentObject(environmentObject, into: entity)
-        return injectEnvironment(object: environmentObject, into: entity)
+        // An `Observable` object is injected the same way as any other environment value,
+        // using the key paths SwiftUI assigns to `@Environment(Type.self)`.
+        let values = environmentKeyPaths(for: environmentObject)
+            .map { (keyPath: $0, value: environmentObject as Any) }
+        return inject(environmentValues: values, into: entity)
     }
 
     private static func injectEnvironmentObject<T>(_ environmentObject: AnyObject, into entity: T) -> T {
@@ -65,39 +69,33 @@ internal enum EnvironmentInjection {
         }
     }
 
-    /// Injects an `Observable` object in the `@Environment(Type.self)` properties of the view.
-    ///
-    /// Such property stores either a `KeyPath` to a private `EnvironmentValues` entry,
-    /// or the resolved value. SwiftUI crashes when it reads the unresolved `KeyPath`
-    /// outside a hosted view, so the injection replaces `keyPath` with the `value` case.
-    private static func injectEnvironment<T>(object: AnyObject, into entity: T) -> T {
-        let keyPaths = environmentKeyPaths(for: object)
-        guard keyPaths.count > 0 else { return entity }
-        return Mirror(reflecting: entity).children.reduce(entity) { entity, child in
-            guard let label = child.label,
-                  let keyPath = try? Inspector.attribute(path: "content|keyPath", value: child.value,
-                                                         type: AnyKeyPath.self),
-                  keyPaths.contains(keyPath)
-            else { return entity }
-            return withUnsafeBytes(of: Unmanaged.passUnretained(keyPath).toOpaque()) { reference in
-                var offset = 0
-                while offset + EnvValue.structSize <= MemoryLayout<T>.size {
-                    var copy = entity
-                    withUnsafeMutableBytes(of: &copy) { bytes in
-                        guard bytes[offset..<offset + reference.count].elementsEqual(reference),
-                              bytes[offset + reference.count] == EnvValue.keyPathCase
-                        else { return }
-                        let rawPointer = bytes.baseAddress! + offset
-                        rawPointer.assumingMemoryBound(to: EnvValue.Forgery.self).pointee = .init(object: object)
-                    }
-                    if (try? Inspector.attribute(path: label + "|content|value", value: copy)) != nil {
-                        return copy
-                    }
-                    offset += MemoryLayout<UnsafeRawPointer>.alignment
-                }
-                return entity
+    /// Injects the values of the enclosing `.environment(keyPath, value)` modifiers in the
+    /// `@Environment(keyPath)` properties of the view, so that the view's `body` reads
+    /// the injected value instead of the `EnvironmentKey`'s default one.
+    static func inject<T>(environmentValues: [EnvironmentValueInjection], into entity: T) -> T {
+        guard !environmentValues.isEmpty else { return entity }
+        let wrappers = Mirror(reflecting: entity).children
+            .compactMap { child -> (keyPath: AnyKeyPath, wrapper: EnvironmentPropertyWrapper)? in
+                guard let wrapper = child.value as? EnvironmentPropertyWrapper,
+                      let keyPath = wrapper.injectionKeyPath
+                else { return nil }
+                return (keyPath, wrapper)
+            }
+        guard !wrappers.isEmpty else { return entity }
+        var copy = entity
+        var injectedKeyPaths: [AnyKeyPath] = []
+        for (keyPath, wrapper) in wrappers where !injectedKeyPaths.contains(keyPath) {
+            injectedKeyPaths.append(keyPath)
+            let candidates = environmentValues.filter { $0.keyPath == keyPath }.map { $0.value }
+            guard !candidates.isEmpty else { continue }
+            // Properties declared with the same key path share the byte pattern
+            // and are all expected to receive the value.
+            let expectedMatches = wrappers.filter { $0.keyPath == keyPath }.count
+            withUnsafeMutableBytes(of: &copy) { bytes in
+                wrapper.injectValue(candidates: candidates, into: bytes, expectedMatches: expectedMatches)
             }
         }
+        return copy
     }
 
     /// The key paths SwiftUI uses for referencing the object in `EnvironmentValues`, for both
@@ -118,16 +116,95 @@ internal enum EnvironmentInjection {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-internal struct EnvValue {
-    /// `SwiftUI.Environment.Content` is a frozen enum with cases `keyPath` and `value`,
-    /// each holding a pointer-sized payload followed by the case discriminator.
-    static var keyPathCase: UInt8 { 0 }
-    static var structSize: Int { MemoryLayout<UnsafeRawPointer>.size + 1 }
+// MARK: - Environment value injection
 
-    struct Forgery {
-        let object: AnyObject?
-        let valueCase: UInt8 = 1
+internal typealias EnvironmentValueInjection = (keyPath: AnyKeyPath, value: Any)
+
+/// Replica of the private `SwiftUI.Environment.Content` enum.
+///
+/// Swift lays out the cases of two structurally identical enums identically,
+/// which is verified at runtime before the injection takes place.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal enum EnvironmentContent<Value> {
+    case keyPath(KeyPath<EnvironmentValues, Value>)
+    case value(Value)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal protocol EnvironmentPropertyWrapper {
+    /// The key path the property reads the value from,
+    /// or `nil` when it already holds a resolved value.
+    var injectionKeyPath: AnyKeyPath? { get }
+
+    /// Replaces the `keyPath` case of every matching property found in `bytes` with the
+    /// innermost of the `candidates` that matches the property's value type.
+    ///
+    /// The properties are located by the byte pattern of the key path reference and the
+    /// enum's case discriminator. The injection is skipped altogether unless the number of
+    /// the matches is the expected one, or if the layout does not meet the expectations.
+    func injectValue(candidates: [Any], into bytes: UnsafeMutableRawBufferPointer, expectedMatches: Int)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension SwiftUI.Environment: EnvironmentPropertyWrapper {
+
+    var injectionKeyPath: AnyKeyPath? {
+        return try? Inspector.attribute(path: "content|keyPath", value: self, type: AnyKeyPath.self)
+    }
+
+    func injectValue(candidates: [Any], into bytes: UnsafeMutableRawBufferPointer, expectedMatches: Int) {
+        // A `transformEnvironment` modifier provides a transform closure instead of a value,
+        // and is skipped by this type check.
+        guard let value = candidates.reversed().lazy.compactMap({ $0 as? Value }).first,
+              let keyPath = injectionKeyPath as? KeyPath<EnvironmentValues, Value>,
+              let pattern = Pattern(wrapper: self, keyPath: keyPath)
+        else { return }
+        let offsets = pattern.offsets(in: bytes)
+        guard offsets.count == expectedMatches else { return }
+        let source = UnsafeMutablePointer<EnvironmentContent<Value>>.allocate(capacity: 1)
+        defer { source.deallocate() }
+        offsets.forEach { offset in
+            // Every destination receives its own strong reference to the value,
+            // and the replaced key path reference is released.
+            source.initialize(to: .value(value))
+            let destination = (bytes.baseAddress! + offset).assumingMemoryBound(to: Self.self)
+            destination.deinitialize(count: 1)
+            UnsafeMutableRawPointer(destination).copyMemory(from: source, byteCount: pattern.size)
+        }
+    }
+
+    /// The byte signature of an `Environment<Value>` in the `keyPath` case.
+    private struct Pattern {
+        let reference: [UInt8]
+        let discriminator: UInt8
+        let size: Int
+
+        /// Fails unless `EnvironmentContent<Value>` matches the layout of `Environment<Value>`:
+        /// a key path reference at the front, followed by the case discriminator at the back.
+        init?(wrapper: SwiftUI.Environment<Value>, keyPath: KeyPath<EnvironmentValues, Value>) {
+            size = MemoryLayout<SwiftUI.Environment<Value>>.size
+            guard MemoryLayout<EnvironmentContent<Value>>.size == size,
+                  MemoryLayout<EnvironmentContent<Value>>.alignment
+                    == MemoryLayout<SwiftUI.Environment<Value>>.alignment,
+                  size > MemoryLayout<UnsafeRawPointer>.size
+            else { return nil }
+            let wrapperBytes = withUnsafeBytes(of: wrapper) { Array($0) }
+            let replicaBytes = withUnsafeBytes(of: EnvironmentContent<Value>.keyPath(keyPath)) { Array($0) }
+            reference = Array(wrapperBytes.prefix(MemoryLayout<UnsafeRawPointer>.size))
+            discriminator = wrapperBytes[size - 1]
+            guard replicaBytes.prefix(reference.count).elementsEqual(reference),
+                  replicaBytes[size - 1] == discriminator
+            else { return nil }
+        }
+
+        func offsets(in bytes: UnsafeMutableRawBufferPointer) -> [Int] {
+            let step = MemoryLayout<SwiftUI.Environment<Value>>.alignment
+            return stride(from: 0, through: max(0, bytes.count - size), by: step).filter { offset in
+                return offset + size <= bytes.count
+                    && bytes[offset..<offset + reference.count].elementsEqual(reference)
+                    && bytes[offset + size - 1] == discriminator
+            }
+        }
     }
 }
 

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -337,7 +337,7 @@ internal extension Inspector {
             dict[childName + ": " + childType] = value
         }
         if let contentExtractor = try? ContentExtractor(source: value),
-           let content = try? contentExtractor.extractContent(environmentObjects: medium.environmentObjects) {
+           let content = try? contentExtractor.extractContent(medium: medium) {
             let childType = typeName(value: content)
             dict["body: " + childType] = attributesTree(value: content, medium: medium, visited: visited)
         }

--- a/Sources/ViewInspector/SwiftUI/CustomView.swift
+++ b/Sources/ViewInspector/SwiftUI/CustomView.swift
@@ -55,14 +55,14 @@ internal extension Content {
     
     func extractCustomView() throws -> Content {
         let contentExtractor = try ContentExtractor(source: view)
-        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
+        let view = try contentExtractor.extractContent(medium: medium)
         let medium = self.medium.resettingViewModifiers()
         return try Inspector.unwrap(view: view, medium: medium)
     }
     
     func extractCustomViewGroup() throws -> LazyGroup<Content> {
         let contentExtractor = try ContentExtractor(source: view)
-        let view = try contentExtractor.extractContent(environmentObjects: medium.environmentObjects)
+        let view = try contentExtractor.extractContent(medium: medium)
         return try Inspector.viewsInContainer(view: view, medium: medium)
     }
 }
@@ -123,7 +123,7 @@ public extension InspectableView where View: CustomViewType {
         content.medium.environmentObjects.forEach {
             view = EnvironmentInjection.inject(environmentObject: $0, into: view)
         }
-        return view
+        return EnvironmentInjection.inject(environmentValues: content.medium.environmentValues, into: view)
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentObservableInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentObservableInjectionTests.swift
@@ -10,27 +10,6 @@ import Observation
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class EnvironmentObservableInjectionTests: XCTestCase {
 
-    func testEnvironmentMemoryLayout() throws {
-        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-        else { throw XCTSkip() }
-        typealias RealType = Environment<TestObservableObject1>
-        XCTAssertEqual(MemoryLayout<RealType>.size, EnvValue.structSize)
-        let sut = RealType(\.testObservableObject1)
-        try withUnsafeBytes(of: sut, { bytes in
-            let discriminator = try XCTUnwrap(bytes.last)
-            XCTAssertEqual(discriminator, EnvValue.keyPathCase)
-        })
-    }
-
-    func testEnvironmentForgery() throws {
-        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-        else { throw XCTSkip() }
-        let obj = TestObservableObject1()
-        let forgery = EnvValue.Forgery(object: obj)
-        let sut = unsafeBitCast(forgery, to: Environment<TestObservableObject1>.self)
-        XCTAssertIdentical(sut.wrappedValue, obj)
-    }
-
     func testDirectEnvironmentInjection() throws {
         guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
         else { throw XCTSkip() }
@@ -125,17 +104,18 @@ final class EnvironmentObservableInjectionTests: XCTestCase {
         wait(for: [exp], timeout: 0.5)
     }
 
-    func testEnvironmentValueOfTheSameTypeIsUnaffected() throws {
+    func testEnvironmentValueOfTheSameTypeIsInjectedSeparately() throws {
         guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
         else { throw XCTSkip() }
         let injected = TestObservableObject1()
         injected.value1 = "injected"
         let keyed = TestObservableObject1()
+        keyed.value1 = "keyed"
         let sut = ObservableEnvironmentValueView()
             .environment(injected)
             .environment(\.testObservableObject1, keyed)
-        // The keyed property is not injected, thus reading the key's default value:
-        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "env_injected")
+        // The two properties are injected from their respective modifiers:
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "keyed_injected")
         let view = try sut.inspect().find(ObservableEnvironmentValueView.self)
         XCTAssertIdentical(try view.environment(\.testObservableObject1), keyed)
     }

--- a/Tests/ViewInspectorTests/SwiftUI/EnvironmentValueInjectionTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/EnvironmentValueInjectionTests.swift
@@ -1,0 +1,277 @@
+import XCTest
+import SwiftUI
+
+@testable import ViewInspector
+
+@MainActor
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class EnvironmentValueInjectionTests: XCTestCase {
+
+    func testEnvironmentContentMemoryLayout() throws {
+        XCTAssertEqual(MemoryLayout<Environment<Int>>.size, MemoryLayout<EnvironmentContent<Int>>.size)
+        XCTAssertEqual(MemoryLayout<Environment<String>>.size, MemoryLayout<EnvironmentContent<String>>.size)
+        XCTAssertEqual(MemoryLayout<Environment<Payload>>.size, MemoryLayout<EnvironmentContent<Payload>>.size)
+        XCTAssertEqual(MemoryLayout<Environment<Int?>>.size, MemoryLayout<EnvironmentContent<Int?>>.size)
+        let sut = Environment(\EnvironmentValues.injectedString)
+        XCTAssertEqual(sut.injectionKeyPath, \EnvironmentValues.injectedString)
+        let replica = EnvironmentContent<String>.keyPath(\EnvironmentValues.injectedString)
+        let sutBytes = withUnsafeBytes(of: sut) { Array($0) }
+        let replicaBytes = withUnsafeBytes(of: replica) { Array($0) }
+        // The key path reference at the front, the case discriminator at the back:
+        XCTAssertEqual(sutBytes.prefix(MemoryLayout<UnsafeRawPointer>.size),
+                       replicaBytes.prefix(MemoryLayout<UnsafeRawPointer>.size))
+        XCTAssertEqual(sutBytes.last, replicaBytes.last)
+    }
+
+    func testDirectInjectionOfValueTypes() throws {
+        var sut = ValueTypesView()
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "default 0 false none 0.000000")
+        sut = EnvironmentInjection.inject(environmentValues: [
+            (\EnvironmentValues.injectedString, "injected"),
+            (\EnvironmentValues.injectedInt, 42),
+            (\EnvironmentValues.injectedBool, true),
+            (\EnvironmentValues.injectedOptional, Optional("some")),
+            (\EnvironmentValues.injectedStruct, Payload(number: 7.0))
+        ], into: sut)
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "injected 42 true some 7.000000")
+    }
+
+    func testInjectionThroughEnvironmentModifiers() throws {
+        let sut = ValueTypesView()
+            .environment(\.injectedString, "injected")
+            .environment(\.injectedInt, 42)
+            .environment(\.injectedBool, true)
+            .environment(\.injectedOptional, "some")
+            .environment(\.injectedStruct, Payload(number: 7.0))
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "injected 42 true some 7.000000")
+    }
+
+    func testInjectionInNestedCustomView() throws {
+        let sut = OuterView().environment(\.injectedString, "injected")
+        XCTAssertEqual(try sut.inspect().find(InnerView.self).find(ViewType.Text.self).string(),
+                       "injected|injected")
+    }
+
+    func testInjectionInCustomViewModifier() throws {
+        let sut = InnerView().modifier(InjectedModifier()).environment(\.injectedString, "injected")
+        XCTAssertEqual(try sut.inspect().find(text: "modifier: injected").string(), "modifier: injected")
+    }
+
+    func testTheInnermostModifierWins() throws {
+        let sut = InnerView()
+            .environment(\.injectedString, "outer")
+            .padding()
+        XCTAssertEqual(try VStack { sut.environment(\.injectedString, "inner") }
+            .inspect().find(InnerView.self).find(ViewType.Text.self).string(), "outer|outer")
+        XCTAssertEqual(try VStack { InnerView().environment(\.injectedString, "inner") }
+            .environment(\.injectedString, "outer")
+            .inspect().find(InnerView.self).find(ViewType.Text.self).string(), "inner|inner")
+    }
+
+    func testInjectionInActualView() throws {
+        let sut = ValueTypesView().environment(\.injectedInt, 42)
+        let view = try sut.inspect().find(ValueTypesView.self).actualView()
+        XCTAssertEqual(view.number, 42)
+        XCTAssertEqual(view.string, "default")
+    }
+
+    func testUnmodifiedPropertiesKeepTheDefaultValue() throws {
+        let sut = ValueTypesView().environment(\.injectedInt, 42)
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "default 42 false none 0.000000")
+    }
+
+    func testMultiplePropertiesWithTheSameKeyPath() throws {
+        let sut = DuplicatedPropertiesView().environment(\.injectedString, "injected")
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "injected-injected")
+    }
+
+    func testInjectionOfReferenceType() throws {
+        let object = ReferenceValue()
+        object.value = "injected"
+        let sut = ReferenceTypeView().environment(\.injectedObject, object)
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "injected")
+        let view = try sut.inspect().find(ReferenceTypeView.self).actualView()
+        XCTAssertIdentical(view.object, object)
+    }
+
+    func testInjectedReferenceTypeIsRetainedAndReleased() throws {
+        weak var weakObject: ReferenceValue?
+        try {
+            let object = ReferenceValue()
+            weakObject = object
+            var sut = ReferenceTypeView()
+            sut = EnvironmentInjection.inject(
+                environmentValues: [(\EnvironmentValues.injectedObject, object)], into: sut)
+            XCTAssertIdentical(sut.object, object)
+            XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "default")
+        }()
+        XCTAssertNil(weakObject)
+    }
+
+    func testInjectedValueTypeIsNotOverReleased() throws {
+        // A `String` payload does not fit in the `keyPath` reference slot,
+        // verifying the ARC balance for a multi-word value.
+        for _ in 0..<100 {
+            var sut = ValueTypesView()
+            sut = EnvironmentInjection.inject(
+                environmentValues: [(\EnvironmentValues.injectedString, String(repeating: "long", count: 20))],
+                into: sut)
+            XCTAssertTrue(sut.string.hasPrefix("longlong"))
+        }
+    }
+
+    func testEnvironmentModifierReadingIsUnaffected() throws {
+        let sut = ValueTypesView().environment(\.injectedInt, 42)
+        let view = try sut.inspect().find(ValueTypesView.self)
+        XCTAssertEqual(try view.environment(\.injectedInt), 42)
+        XCTAssertThrows(try view.environment(\.injectedBool),
+                        "ValueTypesView does not have 'environment(Bool)' modifier")
+    }
+
+    func testTransformEnvironmentModifierIsIgnored() throws {
+        let sut = ValueTypesView()
+            .transformEnvironment(\.injectedInt, transform: { $0 += 1 })
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "default 0 false none 0.000000")
+    }
+
+    func testTransformEnvironmentModifierDoesNotShadowTheValue() throws {
+        let sut = ValueTypesView()
+            .environment(\.injectedInt, 42)
+            .transformEnvironment(\.injectedInt, transform: { $0 += 1 })
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "default 42 false none 0.000000")
+    }
+
+    func testInjectionOfSystemEnvironmentValue() throws {
+        let sut = SystemValueView().environment(\.layoutDirection, .rightToLeft)
+        XCTAssertEqual(try sut.inspect().find(ViewType.Text.self).string(), "rtl")
+    }
+}
+
+// MARK: - Test data
+
+private struct Payload: Equatable {
+    var number: Double = 0
+    var padding: String = "pad"
+    var flag: Bool = false
+}
+
+private class ReferenceValue {
+    var value = "default"
+}
+
+private struct StringKey: EnvironmentKey { static var defaultValue: String { "default" } }
+private struct IntKey: EnvironmentKey { static var defaultValue: Int { 0 } }
+private struct BoolKey: EnvironmentKey { static var defaultValue: Bool { false } }
+private struct OptionalKey: EnvironmentKey { static var defaultValue: String? { nil } }
+private struct StructKey: EnvironmentKey { static var defaultValue: Payload { .init() } }
+private struct ObjectKey: EnvironmentKey {
+    static var defaultValue: ReferenceValue { .init() }
+}
+
+private extension EnvironmentValues {
+    var injectedString: String {
+        get { self[StringKey.self] } set { self[StringKey.self] = newValue }
+    }
+    var injectedInt: Int {
+        get { self[IntKey.self] } set { self[IntKey.self] = newValue }
+    }
+    var injectedBool: Bool {
+        get { self[BoolKey.self] } set { self[BoolKey.self] = newValue }
+    }
+    var injectedOptional: String? {
+        get { self[OptionalKey.self] } set { self[OptionalKey.self] = newValue }
+    }
+    var injectedStruct: Payload {
+        get { self[StructKey.self] } set { self[StructKey.self] = newValue }
+    }
+    var injectedObject: ReferenceValue {
+        get { self[ObjectKey.self] } set { self[ObjectKey.self] = newValue }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct ValueTypesView: View {
+
+    private var iVar1: Int8 = 0
+    @Environment(\.injectedString) var string
+    private var iVar2: Bool = false
+    @Environment(\.injectedInt) var number
+    @Environment(\.injectedBool) private var flag
+    @State private var state: Int = 0
+    @Environment(\.injectedOptional) private var optional
+    @Environment(\.injectedStruct) private var structure
+    private var iVar3: Int16 = 0
+
+    var body: some View {
+        Text("\(string) \(number) \(flag) \(optional ?? "none") \(structure.number)")
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct InnerView: View {
+
+    @Environment(\.injectedString) private var string
+    @Environment(\.injectedString) private var duplicate
+
+    var body: some View {
+        Text(string + "|" + duplicate)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct OuterView: View {
+
+    @Environment(\.injectedString) private var string
+
+    var body: some View {
+        VStack {
+            Text(string)
+            InnerView()
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct DuplicatedPropertiesView: View {
+
+    @Environment(\.injectedString) private var string1
+    private var iVar: Bool = false
+    @Environment(\.injectedString) private var string2
+
+    var body: some View {
+        Text(string1 + "-" + string2)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct ReferenceTypeView: View {
+
+    @Environment(\.injectedObject) var object
+
+    var body: some View {
+        Text(object.value)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct SystemValueView: View {
+
+    @Environment(\.layoutDirection) private var direction
+
+    var body: some View {
+        Text(direction == .rightToLeft ? "rtl" : "ltr")
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct InjectedModifier: ViewModifier {
+
+    @Environment(\.injectedString) private var string
+
+    func body(content: Self.Content) -> some View {
+        VStack {
+            Text("modifier: " + string)
+            content
+        }
+    }
+}

--- a/guide.md
+++ b/guide.md
@@ -506,6 +506,29 @@ try sut.inspect().find(button: "Login").tap()
 XCTAssertEqual(router.routes, [.dashboard])
 ```
 
+Values of any type provided with `.environment(keyPath, value)` are injected in the `@Environment(keyPath)` properties of the views underneath, so the views' `body` reads the injected value instead of the `EnvironmentKey`'s default one. This works without hosting the view as well:
+
+```swift
+struct ProfileScreen: View {
+
+    @Environment(\.isPremiumUser) private var isPremiumUser
+
+    var body: some View {
+        if isPremiumUser {
+            Text("Premium")
+        } else {
+            Button("Upgrade") { ... }
+        }
+    }
+}
+
+// The test:
+let sut = ProfileScreen().environment(\.isPremiumUser, true)
+XCTAssertNoThrow(try sut.inspect().find(text: "Premium"))
+```
+
+The innermost `.environment(keyPath, value)` modifier takes precedence, just like it does in the running app. Properties not covered by a modifier keep reading the `EnvironmentKey`'s default value.
+
 ## Custom **ViewModifier**
 
 You can inspect custom `ViewModifier` independently, or together with the parent view hierarchy, to which the `ViewModifier` is applied using `.modifier(...)`. Consider an example:

--- a/readiness.md
+++ b/readiness.md
@@ -421,7 +421,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:---:|---|
 |:white_check_mark:| `func environmentObject<B>(B) -> some View` |
 |:white_check_mark:| `func environment<T>(T?) -> some View where T: AnyObject, T: Observable` |
-|:technologist:| `func environment<V>(WritableKeyPath<EnvironmentValues, V>, V) -> some View` |
+|:white_check_mark:| `func environment<V>(WritableKeyPath<EnvironmentValues, V>, V) -> some View` |
 |:technologist:| `func transformEnvironment<V>(WritableKeyPath<EnvironmentValues, V>, transform: (inout V) -> Void) -> some View` |
 
 ### Setting View Colors


### PR DESCRIPTION
Follow-up to #426, per the suggestion to explore using that approach for arbitrary type injection, not just `@Observable`.

## What this does

`.environment(keyPath, value)` was collected in the inspection medium for reading back with `try view.environment(keyPath)`, but the value never reached the `@Environment(keyPath)` properties of the views underneath — their `body` kept reading the `EnvironmentKey`'s default value. Now it does, for any value type, without hosting the view:

```swift
struct ProfileScreen: View {

    @Environment(\.isPremiumUser) private var isPremiumUser

    var body: some View {
        if isPremiumUser { Text("Premium") } else { Button("Upgrade") { ... } }
    }
}

let sut = ProfileScreen().environment(\.isPremiumUser, true)
XCTAssertNoThrow(try sut.inspect().find(text: "Premium"))
```

The innermost modifier wins, as in the running app. Properties not covered by a modifier keep reading the key's default value.

## How

Same trick as #426 — replace the property wrapper's `keyPath` case with the `value` case — with two generalizations:

- **Layout.** #426 assumed a pointer-sized payload plus the case discriminator, which only holds for a class. `Environment<T>` is `max(8, sizeof(T)) + 1` bytes, so the layout now comes from a replica of the private `SwiftUI.Environment.Content` enum, validated against the real one before every injection. A mismatch skips the injection rather than corrupting the view, so a future SwiftUI layout change degrades to a no-op.
- **ARC.** Byte-copying a forged wrapper under-retains a multi-word payload such as `String`, freeing it prematurely. The value is now moved into the property: the destination is deinitialized (releasing the replaced key path) and receives its own strong reference.

With that in place, the `Observable` injection is a special case of the generic one — it just passes the key paths SwiftUI assigns to `@Environment(Type.self)` — so its dedicated code path from #426 is deleted. Net effect is ~110 lines on top of the object-only case, with one mechanism instead of two.

## Notes for review

- **This changes behavior of existing tests, not just adds capability.** A custom view branching on an `@Environment` value now sees ancestor `.environment(...)` values, including ones set by system modifiers that lower to `_EnvironmentKeyWritingModifier` (`.font`, `.foregroundStyle`, …). Tests asserting the old default-value behavior can flip. One in-repo test did: `testEnvironmentValueOfTheSameTypeIsUnaffected` became `testEnvironmentValueOfTheSameTypeIsInjectedSeparately`, since `@Environment(\.key)` and `@Environment(Type.self)` for the same class type are now each injected from their own modifier.
- **Known limitation, deliberate.** Properties are located by the byte pattern of the key path reference and the case discriminator, and the injection is skipped unless the match count equals the number of properties declaring that key path. A view that stores another view reading the same key path therefore keeps the default value in its own property (the stored view still gets injected when the inspection reaches it). Relaxing the count check would fix that but reopens the case it guards: a view storing a bare `KeyPath<EnvironmentValues, V>` field, where a false positive would write 9+ bytes over an 8-byte field. Chose never-corrupt over never-miss.
- **`transformEnvironment` stays unsupported.** It provides a transform closure instead of a value, which fails the type check, and it cannot shadow a value set for the same key path. A natural follow-up is resolving a value by seeding from `EnvironmentValues()[keyPath:]` and folding all matching modifiers in order, which would cover transforms too.
- `extractContent(environmentObjects:)` on `View` and `ViewModifier` gained a defaulted `environmentValues:` parameter — source-compatible for existing callers.
- `readiness.md`: `environment<V>(WritableKeyPath, V)` flipped :technologist: → :white_check_mark:.

## Testing

16 new tests in `EnvironmentValueInjectionTests` covering `Int`, `String`, `Bool`, `Optional`, a multi-field struct, a class, a system key (`\.layoutDirection`), custom `ViewModifier` properties, `actualView()`, nested custom views, duplicate key paths, innermost-wins, ARC balance in both directions, and `transformEnvironment` neither injecting nor shadowing.

Full suite is unchanged against the base: 92 pre-existing failures, all in `ViewSearchTests`/`TextTests` from test-bundle localization lookups under `swift test`. SwiftLint clean. Also verified the replica enum compiles at the package's iOS 12 deployment target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
