### PR TITLE
#413: Support accessibilityTraits inspection

### DIFF
--- a/Sources/ViewInspector/Modifiers/AccessibilityTraitsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityTraitsModifiers.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+// MARK: - Accessibility traits
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension InspectableView {
+
+    /**
+     The accessibility traits applied to the view with `accessibilityAddTraits`
+     and `accessibilityRemoveTraits`. Traits that are unknown to ViewInspector
+     are omitted from the resulting set.
+     */
+    func accessibilityTraits() throws -> AccessibilityTraits {
+        let call = "accessibilityAddTraits"
+        let traitSets = accessibilityTraitSets()
+        guard !traitSets.isEmpty else {
+            throw InspectionError
+                .modifierNotFound(parent: Inspector.typeName(value: content.view),
+                                  modifier: call, index: 0)
+        }
+        let rawValue = traitSets.reduce(UInt64(0)) { result, traitSet in
+            (result & ~traitSet.mask) | (traitSet.value & traitSet.mask)
+        }
+        return AccessibilityTraits(rawTraitsValue: rawValue)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal struct AccessibilityTraitSetValue {
+    
+    /// The bits of the traits that are turned on
+    let value: UInt64
+    /// The bits of the traits the modifier has an opinion about
+    let mask: UInt64
+    
+    /**
+     The traits are stored differently depending on the OS version: as a pair of
+     `value` and `mask` option sets, or as a standalone option set. The layout of
+     the enclosing `AccessibilityAttachmentModifier` changed a few times as well,
+     so instead of hardcoding the paths we look the values up by their type.
+     */
+    init?(anyValue: Any) {
+        let typeName = Inspector.typeName(value: anyValue)
+        if typeName.contains("NullableOptionSet"),
+           let value = try? Inspector.attribute(
+            path: "value|rawValue", value: anyValue, type: UInt64.self),
+           let mask = try? Inspector.attribute(
+            path: "mask|rawValue", value: anyValue, type: UInt64.self) {
+            self.value = value
+            self.mask = mask
+        } else if typeName.contains("AccessibilityTrait"),
+                  let rawValue = accessibilityTraitsRawValue(of: anyValue) {
+            self.value = rawValue
+            self.mask = rawValue
+        } else {
+            return nil
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private func accessibilityTraitsRawValue(of value: Any) -> UInt64? {
+    if let rawValue = try? Inspector.attribute(
+        path: "traitSet|rawValue", value: value, type: UInt64.self) {
+        return rawValue
+    }
+    return try? Inspector.attribute(label: "rawValue", value: value, type: UInt64.self)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension AccessibilityTraits {
+    
+    static var knownTraits: [AccessibilityTraits] {
+        var traits: [AccessibilityTraits] = [
+            .isButton, .isHeader, .isSelected, .isLink, .isSearchField, .isImage,
+            .playsSound, .isKeyboardKey, .isStaticText, .isSummaryElement,
+            .updatesFrequently, .startsMediaSession, .allowsDirectInteraction,
+            .causesPageTurn, .isModal]
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            traits.append(contentsOf: [.isToggle, .isTabBar])
+        }
+        return traits
+    }
+    
+    init(rawTraitsValue rawValue: UInt64) {
+        self = AccessibilityTraits.knownTraits.reduce(into: AccessibilityTraits()) { result, trait in
+            guard let traitValue = accessibilityTraitsRawValue(of: trait),
+                  traitValue != 0, rawValue & traitValue == traitValue
+            else { return }
+            result.formUnion(trait)
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private extension InspectableView {
+    
+    /// The traits from every `AccessibilityAttachmentModifier`, in the order they were applied
+    func accessibilityTraitSets() -> [AccessibilityTraitSetValue] {
+        return modifiersMatching { $0.modifierType.contains("AccessibilityAttachmentModifier") }
+            .reversed()
+            .flatMap { InspectableView.accessibilityTraitSets(in: $0, depth: 0) }
+    }
+    
+    private static func accessibilityTraitSets(in value: Any, depth: Int) -> [AccessibilityTraitSetValue] {
+        if let traitSet = AccessibilityTraitSetValue(anyValue: value) {
+            return [traitSet]
+        }
+        guard depth < 8 else { return [] }
+        return Mirror(reflecting: value).children.flatMap {
+            accessibilityTraitSets(in: $0.value, depth: depth + 1)
+        }
+    }
+}

--- a/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
@@ -289,6 +289,58 @@ final class ViewAccessibilityActionTests: XCTestCase {
         XCTAssertNoThrow(try sut.inspect().emptyView())
     }
     
+    func testAccessibilityTraitsInspection() throws {
+        let sut1 = try EmptyView().accessibility(addTraits: .isHeader)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertTrue(sut1.contains(.isHeader))
+        XCTAssertFalse(sut1.contains(.isButton))
+        XCTAssertEqual(sut1, .isHeader)
+        if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+            let sut2 = try Text("abc").accessibilityAddTraits([.isHeader, .isImage])
+                .inspect().text().accessibilityTraits()
+            XCTAssertEqual(sut2, [.isHeader, .isImage])
+        }
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            let sut3 = try EmptyView().accessibilityAddTraits(.isToggle)
+                .inspect().emptyView().accessibilityTraits()
+            XCTAssertEqual(sut3, .isToggle)
+        }
+    }
+    
+    func testAccessibilityTraitsRemovalInspection() throws {
+        let sut1 = try EmptyView()
+            .accessibility(addTraits: [.isHeader, .isButton])
+            .accessibility(removeTraits: .isButton)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut1, .isHeader)
+        let sut2 = try EmptyView()
+            .accessibility(removeTraits: .isButton)
+            .accessibility(addTraits: .isButton)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut2, .isButton)
+        let sut3 = try EmptyView().accessibility(removeTraits: .isButton)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut3, AccessibilityTraits())
+    }
+    
+    func testAccessibilityTraitsInspectionAmongOtherModifiers() throws {
+        let sut = try EmptyView()
+            .accessibility(label: Text("abc"))
+            .accessibility(addTraits: .isImage)
+            .padding()
+            .accessibility(hint: Text("xyz"))
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut, .isImage)
+    }
+    
+    func testMissingAccessibilityTraits() throws {
+        let sut = try EmptyView().accessibility(label: Text("abc"))
+            .inspect().emptyView()
+        XCTAssertThrows(
+            try sut.accessibilityTraits(),
+            "EmptyView does not have 'accessibilityAddTraits' modifier")
+    }
+    
     func testAccessibilitySortPriority() throws {
         let sut = EmptyView().accessibility(sortPriority: 5)
         XCTAssertNoThrow(try sut.inspect().emptyView())
@@ -311,6 +363,7 @@ final class ViewAccessibilityActionTests: XCTestCase {
 
         XCTAssertEqual(try sut.accessibilityLabel().string(), label)
         XCTAssertEqual(try sut.accessibilityValue().string(), value)
+        XCTAssertEqual(try sut.accessibilityTraits(), .isImage)
     }
     
     func testMissingAccessibilityAttribute() throws {

--- a/readiness.md
+++ b/readiness.md
@@ -609,8 +609,8 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:technologist:| `func accessibilityElement(children: AccessibilityChildBehavior) -> some View` |
 |:technologist:| `func accessibilityChildren<V>(children: () -> V) -> some View` |
 |:technologist:| `func accessibilityInputLabels(...) -> some View` |
-|:technologist:| `func accessibilityAddTraits(AccessibilityTraits) -> some View` |
-|:technologist:| `func accessibilityRemoveTraits(AccessibilityTraits) -> some View` |
+|:white_check_mark:| `func accessibilityAddTraits(AccessibilityTraits) -> some View` |
+|:white_check_mark:| `func accessibilityRemoveTraits(AccessibilityTraits) -> some View` |
 |:technologist:| `func accessibilityLinkedGroup<ID>(id: ID, in: Namespace.ID) -> some View` |
 |:technologist:| `func accessibilityShowsLargeContentViewer(...) -> some View` |
 |:technologist:| `func speechAdjustedPitch(_ value: Double) -> some View` |


### PR DESCRIPTION
Closes #413

## What

Adds `accessibilityTraits()` on `InspectableView`, so tests can assert which accessibility traits a view carries:

```swift
let text = try sut.inspect().text()
XCTAssertTrue(try text.accessibilityTraits().contains(.isHeader))
XCTAssertEqual(try text.accessibilityTraits(), [.isHeader, .isImage])
```

Throws `modifierNotFound("accessibilityAddTraits")` when the view has no traits, consistent with the neighboring accessibility getters.

## How

SwiftUI stores the traits inside `AccessibilityAttachmentModifier` as a `value` / `mask` pair, where `mask` marks the bits the modifier has an opinion about. Folding the modifiers in the order they were applied with `(result & ~mask) | (value & mask)` handles `accessibilityAddTraits` and `accessibilityRemoveTraits` in any order, including add-after-remove.

The storage layout differs between OS versions — iOS 26 keeps a typed `properties.traits`, iOS 27 a generic `properties.storage` of key-value entries — so the values are looked up **by their type** rather than by a hardcoded key path. That keeps one code path for every version instead of the usual v2/v3/v4/v5 ladder, which matters here because the pre-26 layouts cannot be verified locally (see below).

Raw bits are converted back into `AccessibilityTraits` by unioning the known trait constants (15 base + `isToggle` / `isTabBar` on 17+). Bits with no matching constant are omitted; this is stated in the doc comment. The alternative — `unsafeBitCast` of the raw `UInt64` — would preserve unknown bits but relies on undocumented layout, so it seemed the wrong trade for a testing library.

The code lives in a new file rather than in `AccessibilityModifiers.swift` because appending it there crossed the SwiftLint `file_length` warning threshold of 600.

## Testing

| Toolchain | SDK | Target | Result |
|---|---|---|---|
| Xcode 26.6 | macOS 26 | macOS 26.6 | full suite, failures identical to baseline with the change stashed |
| Xcode 26.6 | iPhoneSimulator 26.5 | iOS 27.0 sim | 1524 tests, 0 failures |
| Xcode 26.6 | iPhoneSimulator 26.5 | iOS 26.5 sim | 35 accessibility tests, 0 failures |
| Xcode-beta 27.0 | macOS 27 | macOS 26.6 | build clean, 35 accessibility tests, 0 failures |
| Xcode-beta 27.0 | iPhoneSimulator 27.0 | iOS 27.0 sim | 1524 tests, 0 failures |

The pre-existing macOS `swift test` failures are localization / test-bundle-loading ones under the SwiftPM CLI; count is unchanged by this PR.

## Reviewer notes

- **Pre-iOS-26 paths are untested.** No pre-26 simulator runtimes are installed on my machine, so iOS 13–25 rest on the type-based search rather than on verified key paths. If you have older runtimes available, those are the runs worth doing before merge.
- `readiness.md` marks `accessibilityAddTraits` / `accessibilityRemoveTraits` as supported.
- No search predicate (`find(viewWithAccessibilityTrait:)`) was added — outside the scope of the issue, happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)