### PR TITLE
Fix toolbar item inspection when wrapped by availability-gated ToolbarContent modifiers

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Toolbar.swift
+++ b/Sources/ViewInspector/SwiftUI/Toolbar.swift
@@ -103,12 +103,12 @@ public extension InspectableView where View == ViewType.Toolbar {
     }
 
     func item(_ index: Int = 0) throws -> InspectableView<ViewType.Toolbar.Item> {
-        let element = try self.element(index)
+        let element = try Inspector.resolveTransparentToolbarWrapper(self.element(index))
         return try .init(Content(element, medium: content.medium), parent: self, index: index)
     }
-    
+
     func itemGroup(_ index: Int = 0) throws -> InspectableView<ViewType.Toolbar.ItemGroup> {
-        let element = try self.element(index)
+        let element = try Inspector.resolveTransparentToolbarWrapper(self.element(index))
         return try .init(Content(element, medium: content.medium), parent: self, index: index)
     }
     
@@ -128,6 +128,72 @@ public extension InspectableView where View == ViewType.Toolbar {
             }
         }
         throw InspectionError.viewNotFound(parent: "toolbar item at index \(index)")
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension Inspector {
+
+    /// Peels away compiler-synthesized wrappers that a `#available`-gated `ToolbarContent`
+    /// modifier (e.g. `.sharedBackgroundVisibility(_:)`, introduced in iOS 26) inserts around
+    /// a `ToolbarItem`/`ToolbarItemGroup`, so `item(_:)`/`itemGroup(_:)` can hand a real
+    /// `ToolbarItem`/`ToolbarItemGroup` value to `guardType`.
+    ///
+    /// `if #available { ... } else { ... }` inside a `@ToolbarContentBuilder` compiles to
+    /// `_ConditionalContent<TrueBranch, FalseBranch>`. When the true branch calls an
+    /// availability-limited API (as `sharedBackgroundVisibility` does), the compiler further
+    /// wraps it in `LimitedAvailabilityToolbarContent`, whose payload is boxed inside a
+    /// single-element `TupleToolbarContent` and then a `ToolbarModifiedContent` pairing the
+    /// original `ToolbarItem` with the applied modifier. None of these three types are
+    /// `ToolbarItem`/`ToolbarItemGroup` themselves, so `guardType` rejects them outright
+    /// (see https://github.com/nalexn/ViewInspector/issues/409) unless resolved first.
+    ///
+    /// Resolution is best-effort: if a hop's expected shape isn't found (e.g. a future SDK
+    /// changes the internal layout), the value from before that hop is returned as-is so
+    /// existing behavior for plain `ToolbarItem`/`ToolbarItemGroup` values is unaffected.
+    static func resolveTransparentToolbarWrapper(_ value: Any) throws -> Any {
+        var current = value
+        for _ in 0..<10 {
+            switch Inspector.typeName(value: current, generics: .remove) {
+            case "TupleToolbarContent":
+                // Only the single-element shape (wrapping one of the other transparent
+                // wrappers below) is transparent here; the general multi-element tuple case
+                // is already handled positionally by `element(_:)` above.
+                guard let next = try? resolveSingleElementTupleToolbarContent(current) else { return current }
+                current = next
+            case "_ConditionalContent":
+                guard let next = try? resolveConditionalToolbarContent(current) else { return current }
+                current = next
+            case "LimitedAvailabilityToolbarContent":
+                guard let storage = try? Inspector.attribute(label: "storage", value: current),
+                      let boxedContent = try? Inspector.attribute(label: "content", value: storage),
+                      let next = try? resolveSingleElementTupleToolbarContent(boxedContent) else {
+                    return current
+                }
+                current = next
+            case "ToolbarModifiedContent":
+                guard let next = try? Inspector.attribute(label: "content", value: current) else { return current }
+                current = next
+            default:
+                return current
+            }
+        }
+        return current
+    }
+
+    private static func resolveConditionalToolbarContent(_ value: Any) throws -> Any {
+        let storage = try Inspector.attribute(label: "storage", value: value)
+        if let trueContent = try? Inspector.attribute(label: "trueContent", value: storage) {
+            return trueContent
+        }
+        return try Inspector.attribute(label: "falseContent", value: storage)
+    }
+
+    /// `TupleToolbarContent` wrapping a single element stores it directly under `value`
+    /// rather than as a Swift tuple needing positional (`.0`) access — mirrors the
+    /// single-item fallback already used by `element(_:)` above.
+    private static func resolveSingleElementTupleToolbarContent(_ value: Any) throws -> Any {
+        return try Inspector.attribute(label: "value", value: value)
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/ToolbarTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ToolbarTests.swift
@@ -2,10 +2,22 @@ import XCTest
 import SwiftUI
 @testable import ViewInspector
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private extension ToolbarContent {
+    @ToolbarContentBuilder
+    func vi_conditionallyHideSharedBackground() -> some ToolbarContent {
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
+            sharedBackgroundVisibility(.hidden)
+        } else {
+            self
+        }
+    }
+}
+
 @MainActor
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class ToolbarTests: XCTestCase {
-    
+
     func testToolbarItemPlacementEquatable() throws {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
@@ -96,6 +108,48 @@ final class ToolbarTests: XCTestCase {
                         "View for toolbar item at index 2 is absent")
     }
     
+    // https://github.com/nalexn/ViewInspector/issues/409
+    // `if #available { ... } else { ... }` inside a `@ToolbarContentBuilder` compiles to
+    // `_ConditionalContent<TrueBranch, FalseBranch>`. When the true branch calls an
+    // availability-limited API (like `sharedBackgroundVisibility`, iOS 26+), the compiler
+    // further wraps it in `LimitedAvailabilityToolbarContent`. Previously `item(_:)`/
+    // `itemGroup(_:)` handed this wrapper straight to `guardType`, which rejected it because
+    // it isn't literally `ToolbarItem`/`ToolbarItemGroup`, regardless of what the caller was
+    // searching for downstream.
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
+    func testToolbarItemWrappedByAvailabilityGatedModifier() throws {
+        let sut = EmptyView()
+            .toolbar {
+                ToolbarItem { Text("abc") }
+                    .sharedBackgroundVisibility(.hidden)
+            }
+        let text = try sut.inspect().toolbar().item().text().string()
+        XCTAssertEqual(text, "abc")
+    }
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
+    func testToolbarItemGroupWrappedByAvailabilityGatedModifier() throws {
+        let sut = EmptyView()
+            .toolbar {
+                ToolbarItemGroup { Text("abc") }
+                    .sharedBackgroundVisibility(.hidden)
+            }
+        let text = try sut.inspect().toolbar().itemGroup().text().string()
+        XCTAssertEqual(text, "abc")
+    }
+
+    // Reproduces the exact shape from #409: the availability check lives in a helper
+    // extension the caller applies inline, rather than at the `.toolbar { }` call site.
+    func testToolbarItemWrappedByConditionallyCompiledModifier() throws {
+        let sut = EmptyView()
+            .toolbar {
+                ToolbarItem { Text("abc") }
+                    .vi_conditionallyHideSharedBackground()
+            }
+        let text = try sut.inspect().toolbar().item().text().string()
+        XCTAssertEqual(text, "abc")
+    }
+
     func testImplicitToolbarItemGroup() throws {
         guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }


### PR DESCRIPTION
Fixes #409

## Problem

`if #available { ... } else { ... }` inside a `@ToolbarContentBuilder` compiles to `_ConditionalContent<TrueBranch, FalseBranch>`. When the true branch calls an availability-limited API (e.g. `sharedBackgroundVisibility`, introduced in iOS 26), the compiler further wraps it in `LimitedAvailabilityToolbarContent`, whose payload is boxed inside a single-element `TupleToolbarContent` and then a `ToolbarModifiedContent` pairing the original `ToolbarItem` with the applied modifier.

`toolbar().item(_:)`/`itemGroup(_:)` handed these wrapper values straight to `guardType`, which rejected them outright since none of them are literally `ToolbarItem`/`ToolbarItemGroup` — regardless of what the caller was searching for downstream. `find(ViewType.Button.self)`, `find(viewWithId:)`, and even `find(ViewType.Toolbar.ItemGroup.self)` directly all failed identically with `"Search did not find a match"`, matching every access pattern reported in #409.

## Fix

Adds `Inspector.resolveTransparentToolbarWrapper(_:)`, called from `item(_:)`/`itemGroup(_:)` before constructing the `InspectableView`, which peels through:
- `TupleToolbarContent` (single-element case)
- `_ConditionalContent`
- `LimitedAvailabilityToolbarContent`
- `ToolbarModifiedContent`

...to reach the real `ToolbarItem`/`ToolbarItemGroup`.

Resolution is best-effort: if an expected shape isn't found at any hop, the pre-hop value is returned as-is, so existing behavior for plain `ToolbarItem`/`ToolbarItemGroup` values is unaffected.

## Testing

Added 3 tests to `ToolbarTests.swift`:
- `.sharedBackgroundVisibility` applied directly to a `ToolbarItem`
- `.sharedBackgroundVisibility` applied directly to a `ToolbarItemGroup`
- The exact shape from #409 — the availability check lives in a separate `@ToolbarContentBuilder` helper extension applied inline, rather than at the `.toolbar { }` call site

Ran the full suite before and after this change: 92 pre-existing failures in both runs (unrelated to toolbars), confirming no regressions.