### PR TITLE
#401: Support Group/ForEach subviews and sections

### DIFF
--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -442,6 +442,10 @@ internal extension Inspector {
             return try ViewType.PopoverContent.child(content)
         case "WrappedContent":
             return try ViewType.WrappedContent.child(content)
+        case "GroupElementsOfContent":
+            return try ViewType.GroupElementsOfContent.child(content)
+        case "GroupSectionsOfContent":
+            return try ViewType.GroupSectionsOfContent.child(content)
         default:
             return content
         }

--- a/Sources/ViewInspector/SwiftUI/ForEach.swift
+++ b/Sources/ViewInspector/SwiftUI/ForEach.swift
@@ -92,6 +92,26 @@ extension ForEach: MultipleViewProvider {
         typealias Builder = (Data.Element) -> Content
         let data = try Inspector
             .attribute(label: "data", value: self, type: Data.self)
+
+        // `ForEach(subviews:)` and `ForEach(sections:)` store a collection that only the
+        // SwiftUI rendering engine can enumerate - touching it here would crash. Both keep
+        // a substitute view, `Group(subviews:)` or `Group(sections:)`, that is inspected instead.
+        switch Inspector.typeName(value: data, generics: .remove) {
+        case "ForEachSubviewCollection", "ForEachSectionCollection":
+            // The substitute view is boxed in an `AnyView` that no one wrote in the
+            // view hierarchy, so it is skipped to keep the inspection paths clean.
+            let substituteView = try {
+                if let unboxed = try? Inspector.attribute(
+                    path: "substituteView|storage|view", value: data) {
+                    return unboxed
+                }
+                return try Inspector.attribute(label: "substituteView", value: data)
+            }()
+            return LazyGroup(count: 1) { _ in substituteView }
+        default:
+            break
+        }
+
         let builder = try Inspector
             .attribute(label: "content", value: self, type: Builder.self)
         

--- a/Sources/ViewInspector/SwiftUI/GroupElementsOfContent.swift
+++ b/Sources/ViewInspector/SwiftUI/GroupElementsOfContent.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension ViewType {
+    /// The view produced by `Group(subviews:transform:)` and used as the substitute
+    /// view of `ForEach(subviews:content:)`.
+    struct GroupElementsOfContent { }
+}
+
+// MARK: - Content Extraction
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.GroupElementsOfContent: SingleViewContent {
+
+    static func child(_ content: Content) throws -> Content {
+        // The `transform` closure takes a `SubviewsCollection`, which only the SwiftUI
+        // rendering engine can produce, so the closure cannot be called during inspection.
+        // The original view is inspected instead: the views it contains are the subviews
+        // the closure would receive, just without the transformation applied.
+        let view: Any = try {
+            if let stored = try? Inspector.attribute(path: "storage|view", value: content.view) {
+                return stored
+            }
+            return try Inspector.attribute(label: "view", value: content.view)
+        }()
+        return try Inspector.unwrap(view: view, medium: content.medium)
+    }
+}

--- a/Sources/ViewInspector/SwiftUI/GroupSectionsOfContent.swift
+++ b/Sources/ViewInspector/SwiftUI/GroupSectionsOfContent.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension ViewType {
+    /// The view produced by `Group(sections:transform:)` and used as the substitute
+    /// view of `ForEach(sections:content:)`.
+    struct GroupSectionsOfContent { }
+}
+
+// MARK: - Content Extraction
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.GroupSectionsOfContent: SingleViewContent {
+
+    static func child(_ content: Content) throws -> Content {
+        // The `transform` closure takes a `SectionCollection`, which only the SwiftUI
+        // rendering engine can produce, so the closure cannot be called during inspection.
+        // The original view is inspected instead: the sections it contains are the ones
+        // the closure would receive, just without the transformation applied.
+        let view = try Inspector.attribute(label: "sections", value: content.view)
+        return try Inspector.unwrap(view: view, medium: content.medium)
+    }
+}

--- a/Tests/ViewInspectorTests/SwiftUI/SubviewsTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SubviewsTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import SwiftUI
+@testable import ViewInspector
+
+@MainActor
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+final class SubviewsTests: XCTestCase {
+
+    // MARK: - Group(subviews:)
+
+    func testGroupSubviewsSingleSubview() throws {
+        let view = Group(subviews: HStack { Text("First"); Text("Second") }) { subviews in
+            ForEach(Array(subviews.enumerated()), id: \.offset) { _, subview in subview }
+        }
+        let sut = try view.inspect().group()
+        // The HStack is a single subview of the inspected view
+        XCTAssertEqual(sut.count, 1)
+        XCTAssertEqual(try sut.hStack(0).text(0).string(), "First")
+        XCTAssertEqual(try sut.hStack(0).text(1).string(), "Second")
+    }
+
+    func testGroupSubviewsMultipleSubviews() throws {
+        let view = SubviewsContainer { Text("First"); Text("Second"); Text("Third") }
+        let sut = try view.inspect().view(SubviewsContainer<TupleView<(Text, Text, Text)>>.self).group()
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(try sut.text(0).string(), "First")
+        XCTAssertEqual(try sut.text(2).string(), "Third")
+    }
+
+    func testGroupSubviewsSearch() throws {
+        let view = AnyView(Group(subviews: VStack { Text("First") }) { $0 })
+        XCTAssertEqual(try view.inspect().find(text: "First").pathToRoot,
+                       "anyView().group().vStack(0).text(0)")
+    }
+
+    func testGroupSubviewsTransformIsNotApplied() throws {
+        let view = Group(subviews: VStack { Text("First") }) { subviews in
+            ForEach(Array(subviews.enumerated()), id: \.offset) { index, subview in
+                subview.accessibilityIdentifier("subview-\(index)")
+            }
+        }
+        // The transform closure takes a `SubviewsCollection` that only the SwiftUI
+        // rendering engine can produce, so the transformation is not visible for inspection
+        XCTAssertThrows(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "subview-0"),
+            "Search did not find a match")
+    }
+
+    // MARK: - Group(sections:)
+
+    func testGroupSectionsContent() throws {
+        let view = Group(sections: VStack {
+            Section { Text("Content 1") } header: { Text("Header 1") }
+            Section { Text("Content 2") } header: { Text("Header 2") }
+        }) { sections in
+            ForEach(Array(sections.enumerated()), id: \.offset) { index, _ in
+                Text("Section \(index)")
+            }
+        }
+        let sut = try view.inspect().group().vStack(0)
+        XCTAssertEqual(sut.count, 2)
+        XCTAssertEqual(try sut.section(0).header().text().string(), "Header 1")
+        XCTAssertEqual(try sut.section(1).text(0).string(), "Content 2")
+    }
+
+    func testGroupSectionsSearch() throws {
+        let view = AnyView(Group(sections: VStack { Section { Text("First") } }) { _ in EmptyView() })
+        XCTAssertEqual(try view.inspect().find(text: "First").pathToRoot,
+                       "anyView().group().vStack(0).section(0).text(0)")
+    }
+
+    // MARK: - ForEach(subviews:)
+
+    func testForEachSubviews() throws {
+        let view = ForEach(subviews: HStack { Text("First"); Text("Second") }) { subview in
+            subview.border(Color.red)
+        }
+        let sut = try view.inspect().forEach()
+        XCTAssertEqual(sut.count, 1)
+        XCTAssertEqual(try sut.hStack(0).text(1).string(), "Second")
+    }
+
+    func testForEachSubviewsSearch() throws {
+        let view = ForEach(subviews: VStack { Text("First") }) { $0 }
+        XCTAssertEqual(try view.inspect().find(text: "First").pathToRoot,
+                       "forEach().vStack(0).text(0)")
+    }
+
+    // MARK: - ForEach(sections:)
+
+    func testForEachSections() throws {
+        let view = ForEach(sections: VStack {
+            Section { Text("Content 1") } header: { Text("Header 1") }
+        }) { section in
+            Text("Section")
+        }
+        let sut = try view.inspect().forEach().group(0).vStack(0)
+        XCTAssertEqual(try sut.section(0).header().text().string(), "Header 1")
+        XCTAssertEqual(try sut.section(0).text(0).string(), "Content 1")
+    }
+
+    func testForEachSectionsSearch() throws {
+        let view = ForEach(sections: VStack { Section { Text("First") } }) { _ in EmptyView() }
+        XCTAssertEqual(try view.inspect().find(text: "First").pathToRoot,
+                       "forEach().group(0).vStack(0).section(0).text(0)")
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct SubviewsContainer<Content: View>: View {
+
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        Group(subviews: content) { subviews in
+            ForEach(Array(subviews.enumerated()), id: \.offset) { _, subview in subview }
+        }
+    }
+}

--- a/readiness.md
+++ b/readiness.md
@@ -49,7 +49,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| EquatableView | `contained view` |
 |:technologist:| FamilyActivityPicker | |
 |:white_check_mark:| Font (*) | `size: CGFloat`, `isFixedSize: Bool`, `name: String`, `weight: Font.Weight`, `design: Font.Design`, `style: Font.TextStyle` |
-|:white_check_mark:| ForEach | `contained view`, `callOnDelete`, `callOnMove`, `callOnInsert` |
+|:white_check_mark:| ForEach | `contained view`, `callOnDelete`, `callOnMove`, `callOnInsert`, `ForEach(subviews:)`, `ForEach(sections:)` |
 |:white_check_mark:| Form | `contained view` |
 |:technologist:| Gauge | |
 |:white_check_mark:| FullScreenCover | `dismiss()` |
@@ -57,7 +57,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| GlassEffectContainer | `contained view`, `spacing: CGFloat?` |
 |:white_check_mark:| Grid | `alignment: Alignment`, `horizontalSpacing: CGFloat?`, `verticalSpacing: CGFloat?` |
 |:white_check_mark:| GridRow | `alignment: VerticalAlignment?` |
-|:white_check_mark:| Group | `contained view` |
+|:white_check_mark:| Group | `contained view`, `Group(subviews:)`, `Group(sections:)` |
 |:white_check_mark:| GroupBox | `contained view`, `label view` |
 |:white_check_mark:| HSplitView | `contained view` |
 |:white_check_mark:| HStack | `contained view`, `alignment: VerticalAlignment`, `spacing: CGFloat?` |

--- a/unsupported_swiftui_apis.md
+++ b/unsupported_swiftui_apis.md
@@ -102,23 +102,20 @@ QuickLookPreview
 
 These views have basic support but are missing specific initializers or APIs.
 
-### Group
+### Group / ForEach subviews and sections
 
 ```
 Group(subviews:transform:)
 Group(sections:transform:)
+ForEach(subviews:content:)
+ForEach(sections:content:)
 ```
 
-Current support: Basic `Group(@ViewBuilder content:)` only.
-
-### ForEach
-
-```
-ForEach(subviewOf:content:)
-ForEach(sectionOf:content:)
-```
-
-Current support: Basic collection-based ForEach.
+Current support: the views are traversable, exposing the subviews (or sections) of the
+view they were given. The `transform` / `content` closure is not called: it takes a
+`SubviewsCollection` or a `SectionCollection`, which only the SwiftUI rendering engine
+can produce, so anything the closure adds around a subview (modifiers, wrapping
+containers) is not visible for inspection.
 
 ### ScrollView
 
@@ -580,7 +577,6 @@ Below are prioritized items that can be directly used with the skill:
 ### Partial Support Improvements
 
 ```
-/new-api-support "Group(subviews:)"
 /new-api-support "ScrollView scrollPosition"
 /new-api-support "List swipeActions"
 /new-api-support "NavigationStack navigationDestination"


### PR DESCRIPTION
Closes #401

## What

Adds inspection support for the iOS 18 view-decomposition APIs:

| API | Before | After |
|---|---|---|
| `Group(subviews:transform:)` | not inspectable | traversable |
| `Group(sections:transform:)` | not inspectable | traversable |
| `ForEach(subviews:content:)` | **crashed the test process** | traversable |
| `ForEach(sections:content:)` | **crashed the test process** | traversable |

The two `ForEach` variants store their data in an opaque collection
(`ForEachSubviewCollection` / `ForEachSectionCollection`) that traps inside
SwiftUICore (`ForEach+Subviews.swift:144`) when enumerated outside the rendering
engine, so `ForEach.views()` crashed rather than throwing.

## How

`Group(subviews:)` and `Group(sections:)` produce `GroupElementsOfContent` and
`GroupSectionsOfContent`, each keeping the original view (`storage.view` /
`sections`) next to the transform closure. Both are now unwrapped transparently
in `Inspector.unwrap`, the same way `Tree`, `_UnaryViewAdaptor` and friends are,
so inspection continues into the view whose subviews the closure would receive.

The `ForEach` variants keep a substitute view - the matching `Group(subviews:)` /
`Group(sections:)` - so `ForEach.views()` detects the two collection types by
name and returns that substitute instead of touching the collection. This both
removes the crash and routes them through the code path above. The substitute is
boxed in an `AnyView` nobody wrote in the view hierarchy, so it is unboxed to
keep inspection paths clean.

Resulting paths:

```
group().hStack(0).text(0)                        // Group(subviews:)
group().vStack(0).section(1).header().text()     // Group(sections:)
forEach().vStack(0).text(0)                      // ForEach(subviews:)
forEach().group(0).vStack(0).section(0).text(0)  // ForEach(sections:)
```

Subview counts follow SwiftUI semantics: `Group(subviews: HStack { a; b })` has
one subview (the stack), while a `@ViewBuilder` tuple content has one per view.

## Known limitation

The transform closure is not called, so anything it adds around a subview
(modifiers, wrapping containers) is invisible to inspection.

The closure takes a `SubviewsCollection` / `SectionCollection`. Capturing a real
one at render time shows it is a `_VariadicView_Children` holding a
`BaseViewList` of AttributeGraph attributes plus an `AGSubgraph` reference - it
only exists inside the render graph, and the views it points at are graph
attributes rather than reachable structs. Fabricating one by zero-filling, the
trick used for `GeometryProxy`, yields an empty or trapping collection. So the
closure cannot be invoked during inspection, and the pre-transform content is
the best available answer.

`testGroupSubviewsTransformIsNotApplied` pins this behaviour, and
`unsupported_swiftui_apis.md` documents it.

## Testing

- `Tests/ViewInspectorTests/SwiftUI/SubviewsTests.swift`: 10 new tests covering
  content extraction, search paths and the limitation above.
- `swift test`: the new tests pass; the 12 failing tests on this machine
  (`TextTests` localization, `ViewSearchTests`, all reporting "Failed to load
  test Bundle") fail identically without this change.
- `xcodebuild test` on an iOS 26 simulator: all 10 new tests pass.
- SwiftLint clean apart from the pre-existing `ViewHosting.swift:21` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)