### PR TITLE
Support the native sheet and fullScreenCover modifiers

### DIFF
--- a/Sources/ViewInspector/PopupPresenter.swift
+++ b/Sources/ViewInspector/PopupPresenter.swift
@@ -183,12 +183,16 @@ internal extension Content {
                 type: BasePopupPresenter.self, call: "", index: index ?? 0)
         else {
             _ = try standardPredicate(name)
-            throw InspectionError.notSupported(
-                """
-                Please refer to the Guide for inspecting the \(name): \
-                https://github.com/nalexn/ViewInspector/blob/master/guide_popups.md#\(name.lowercased())
-                """)
+            throw popupNotSupportedError(name)
         }
+        return try popup(parent: parent, index: index, name: name, popupPresenter: popupPresenter)
+    }
+
+    func popup<Popup: KnownViewType>(
+        parent: UnwrappedView, index: Int?,
+        name: String = Inspector.typeName(type: Popup.self),
+        popupPresenter: BasePopupPresenter
+    ) throws -> InspectableView<Popup> {
         #if swift(>=6.0)
         let popup = try build(popupPresenter: popupPresenter, name: name)
         #else
@@ -202,6 +206,14 @@ internal extension Content {
         let call = ViewType.inspectionCall(
             base: Popup.inspectionCall(typeName: name), index: index)
         return try .init(content, parent: parent, call: call, index: index)
+    }
+
+    func popupNotSupportedError(_ name: String) -> InspectionError {
+        return .notSupported(
+            """
+            Please refer to the Guide for inspecting the \(name): \
+            https://github.com/nalexn/ViewInspector/blob/master/guide_popups.md#\(name.lowercased())
+            """)
     }
 
     @MainActor

--- a/Sources/ViewInspector/SwiftUI/Sheet.swift
+++ b/Sources/ViewInspector/SwiftUI/Sheet.swift
@@ -61,9 +61,15 @@ public extension InspectableView {
 internal extension Content {
     
     func sheet(parent: UnwrappedView, index: Int?, name: String = "Sheet") throws -> InspectableView<ViewType.Sheet> {
-        return try popup(parent: parent, index: index, name: name,
-                         modifierPredicate: isSheetBuilder(modifier:),
-                         standardPredicate: standardSheetModifier)
+        guard let modifier = try? self.modifier(
+            isSheetBuilder(modifier:), call: name.firstLetterLowercased, index: index ?? 0)
+        else {
+            // The native modifier is either absent or opaque for the reflection
+            _ = try standardSheetModifier(name)
+            throw popupNotSupportedError(name)
+        }
+        let popupPresenter = try sheetPresenter(modifier: modifier, name: name)
+        return try popup(parent: parent, index: index, name: name, popupPresenter: popupPresenter)
     }
     
     func standardSheetModifier(_ name: String = "Sheet") throws -> Any {
@@ -85,11 +91,112 @@ internal extension Content {
         }
     }
 
+    private func sheetPresenter(modifier: Any, name: String) throws -> BasePopupPresenter {
+        if let presenter = try? Inspector.attribute(
+            label: "modifier", value: modifier, type: BasePopupPresenter.self) {
+            return presenter
+        }
+        let nativeModifier = try Inspector.attribute(label: "modifier", value: modifier)
+        return ViewType.Sheet.NativePresenter(modifier: nativeModifier, name: name)
+    }
+
     @MainActor
     private func isSheetBuilder(modifier: Any) -> Bool {
-        let presenter = try? Inspector.attribute(
-            label: "modifier", value: modifier, type: BasePopupPresenter.self)
-        return presenter?.isSheetPresenter == true
+        if let presenter = try? Inspector.attribute(
+            label: "modifier", value: modifier, type: BasePopupPresenter.self) {
+            return presenter.isSheetPresenter
+        }
+        guard let provider = modifier as? ModifierNameProvider,
+              provider.modifierType.contains("SheetPresentationModifier"),
+              let nativeModifier = try? Inspector.attribute(label: "modifier", value: modifier),
+              ViewType.Sheet.NativePresenter.isInspectable(modifier: nativeModifier),
+              let content = try? Inspector.attribute(label: "content", value: modifier)
+        else { return false }
+        // The modifiers extracted from a custom modifier's body are not reported here:
+        // a `PopupPresenter` is reported through its own presenter, and any other
+        // custom modifier hides the sheet behind its own `body`.
+        return Inspector.typeName(value: content, generics: .remove) != "_ViewModifier_Content"
+    }
+}
+
+// MARK: - Native modifier presenter
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension ViewType.Sheet {
+
+    /// Adapts the native `.sheet` and `.fullScreenCover` modifiers to the `BasePopupPresenter` interface.
+    ///
+    /// The modifier's `body` assembles the sheet's content into an optional `AnyView`,
+    /// which stays `nil` while the sheet is not presented.
+    struct NativePresenter: BasePopupPresenter {
+
+        let modifier: Any
+        let name: String
+
+        // The memberwise init is isolated to the MainActor via `BasePopupPresenter`
+        nonisolated init(modifier: Any, name: String) {
+            self.modifier = modifier
+            self.name = name
+        }
+
+        /// The modifiers of the older SwiftUI versions don't expose the sheet's content.
+        static func isInspectable(modifier: Any) -> Bool {
+            return (try? ContentExtractor(source: modifier)) != nil
+        }
+
+        func buildPopup() throws -> Any {
+            guard let view = try? Inspector.attribute(path: "modifier|content|some", value: body())
+            else { throw InspectionError.viewNotFound(parent: name) }
+            return try Self.unwrapPopupContent(view)
+        }
+
+        func dismissPopup() {
+            if let isPresented = try? Inspector.attribute(
+                label: "_isPresented", value: modifier, type: Binding<Bool>.self) {
+                isPresented.wrappedValue = false
+            } else if let item = try? Inspector.attribute(label: "_item", value: modifier) as? NilAssignable {
+                item.assignNil()
+            } else {
+                assertionFailure(
+                    "\(Inspector.typeName(value: modifier)) does not have a presentation binding")
+                return
+            }
+            if let onDismiss = try? Inspector.attribute(
+                path: "onDismiss|some", value: modifier) as? () -> Void {
+                onDismiss()
+            }
+        }
+
+        func content() throws -> Content {
+            return try Inspector.unwrap(view: body(), medium: .empty)
+        }
+
+        var isSheetPresenter: Bool { true }
+
+        private func body() throws -> Any {
+            return try ContentExtractor(source: modifier).extractContent(environmentObjects: [])
+        }
+
+        /// Unwraps the `AnyView` and `SheetContent` wrappers SwiftUI puts around the user's view.
+        @MainActor
+        private static func unwrapPopupContent(_ view: Any) throws -> Any {
+            let content = try ViewType.AnyView.child(Content(view))
+            guard Inspector.typeName(value: content.view, generics: .remove) == "SheetContent"
+            else { return content.view }
+            return try Inspector.attribute(label: "content", value: content.view)
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private protocol NilAssignable {
+    func assignNil()
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension Binding: NilAssignable where Value: ExpressibleByNilLiteral {
+    func assignNil() {
+        wrappedValue = nil
     }
 }
 

--- a/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/FullScreenCoverTests.swift
@@ -22,16 +22,65 @@ final class FullScreenCoverTests: XCTestCase {
                         "EmptyView does not have 'fullScreenCover' modifier")
     }
 
-    func testInspectionErrorCustomModifierRequired() throws {
+    func testNativeFullScreenCoverNotPresented() throws {
+        guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: false)
+        let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("abc") }
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+                        "View for FullScreenCover is absent")
+    }
+
+    func testNativeFullScreenCoverContentInspection() throws {
         guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
         else { throw XCTSkip() }
         let binding = Binding(wrappedValue: true)
-        let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("") }
+        let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("abc") }
+        let title = try sut.inspect().emptyView().fullScreenCover().text()
+        XCTAssertEqual(try title.string(), "abc")
+        XCTAssertEqual(title.pathToRoot, "emptyView().fullScreenCover().text()")
+    }
+
+    func testNativeFullScreenCoverContentInteraction() throws {
+        guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover(isPresented: binding) {
+            Text("abc")
+            Button("xyz", action: { binding.wrappedValue = false })
+        }
+        let button = try sut.inspect().emptyView().fullScreenCover().button(1)
+        try button.tap()
+        XCTAssertFalse(binding.wrappedValue)
+        XCTAssertEqual(button.pathToRoot, "emptyView().fullScreenCover().button(1)")
+    }
+
+    func testNativeFullScreenCoverDismiss() throws {
+        guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let exp = XCTestExpectation(description: #function)
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().fullScreenCover(isPresented: binding, onDismiss: {
+            exp.fulfill()
+        }, content: { Text("") })
+        try sut.inspect().emptyView().fullScreenCover().dismiss()
+        XCTAssertFalse(binding.wrappedValue)
         XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
-            """
-            Please refer to the Guide for inspecting the FullScreenCover: \
-            https://github.com/nalexn/ViewInspector/blob/master/guide_popups.md#fullscreencover
-            """)
+                        "View for FullScreenCover is absent")
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testNativeFullScreenCoverWithItemDismiss() throws {
+        guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding<Int?>(wrappedValue: 6)
+        let sut = EmptyView().fullScreenCover(item: binding) { Text("\($0)") }
+        let cover = try sut.inspect().emptyView().fullScreenCover()
+        XCTAssertEqual(try cover.text().string(), "6")
+        try cover.dismiss()
+        XCTAssertNil(binding.wrappedValue)
+        XCTAssertThrows(try sut.inspect().emptyView().fullScreenCover(),
+                        "View for FullScreenCover is absent")
     }
 
     func testInspectionErrorFullScreenCoverNotPresented() throws {
@@ -144,18 +193,28 @@ final class FullScreenCoverTests: XCTestCase {
         #endif
         #if compiler(<6) || compiler(>=6.1)
         let title2 = try sut.inspect().implicitAnyView().hStack().emptyView(0).fullScreenCover(1).text(0)
-        XCTAssertEqual(try title2.string(), "title_3")
+        XCTAssertEqual(try title2.string(), "title_2")
         XCTAssertEqual(title2.pathToRoot,
             "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover(1).text(0)")
+        let title3 = try sut.inspect().implicitAnyView().hStack().emptyView(0).fullScreenCover(2).text(0)
+        XCTAssertEqual(try title3.string(), "title_3")
+        XCTAssertEqual(title3.pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).fullScreenCover(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self).text(0).string(), "title_1")
         #else
-        let title2 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().fullScreenCover().text(0)
-        XCTAssertEqual(try title2.string(), "title_3")
+        let title2 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().fullScreenCover(1).text(0)
+        XCTAssertEqual(try title2.string(), "title_2")
         XCTAssertEqual(title2.pathToRoot,
-            "view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0).anyView().fullScreenCover().text(0)")
+            "view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0).anyView().fullScreenCover(1).text(0)")
+        let title3 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().fullScreenCover(2).text(0)
+        XCTAssertEqual(try title3.string(), "title_3")
+        XCTAssertEqual(title3.pathToRoot,
+            "view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0).anyView().fullScreenCover(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self, skipFound: 1).text(0).string(), "title_1")
         #endif
         binding1.wrappedValue = false
+        XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self).text(0).string(), "title_2")
+        binding2.wrappedValue = false
         XCTAssertEqual(try sut.inspect().find(ViewType.FullScreenCover.self).text(0).string(), "title_3")
         binding3.wrappedValue = false
         XCTAssertThrows(try sut.inspect().find(ViewType.FullScreenCover.self),
@@ -191,27 +250,42 @@ final class FullScreenCoverTests: XCTestCase {
             """)
         #endif
         // 2
-        XCTAssertThrows(try sut.inspect().find(text: "title_2").pathToRoot,
-            "Search did not find a match")
+        #if compiler(<6) || compiler(>=6.1)
+        XCTAssertEqual(try sut.inspect().find(text: "title_2").pathToRoot,
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).sheet(1).text()")
+        #else
+        XCTAssertEqual(try sut.inspect().find(text: "title_2").pathToRoot,
+            """
+            view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0)\
+            .anyView().sheet(1).text()
+            """)
+        #endif
+    }
 
-        // 3
+    func testFindAndPathToRootsForThirdCover() throws {
+        guard #available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let binding = Binding(wrappedValue: true)
+        let sut = FullScreenCoverFindTestView(
+            fullScreenCover1: binding, fullScreenCover2: binding, fullScreenCover3: binding)
+
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
             "Search did not find a match")
         #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
-            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).sheet(1).text(0)")
+            "view(FullScreenCoverFindTestView.self).hStack().emptyView(0).sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,
             """
             view(FullScreenCoverFindTestView.self).hStack().emptyView(0)\
-            .sheet(1).button(1).labelView().text()
+            .sheet(2).button(1).labelView().text()
             """)
         #else
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
-            "view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0).anyView().sheet().text(0)")
+            "view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0).anyView().sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,
             """
             view(FullScreenCoverFindTestView.self).anyView().hStack().anyView(0)\
-            .anyView().sheet().button(1).labelView().text()
+            .anyView().sheet(2).button(1).labelView().text()
             """)
         #endif
     }

--- a/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/SheetTests.swift
@@ -18,14 +18,86 @@ final class SheetTests: XCTestCase {
                         "EmptyView does not have 'sheet' modifier")
     }
     
-    func testInspectionErrorCustomModifierRequired() throws {
+    func testInspectionErrorSheetInsideCustomModifier() throws {
         let binding = Binding(wrappedValue: true)
-        let sut = EmptyView().sheet(isPresented: binding) { Text("") }
+        let sut = EmptyView().modifier(NonInspectableSheetModifier(isPresented: binding))
         XCTAssertThrows(try sut.inspect().emptyView().sheet(),
             """
             Please refer to the Guide for inspecting the Sheet: \
             https://github.com/nalexn/ViewInspector/blob/master/guide_popups.md#sheet
             """)
+    }
+
+    func testNativeSheetNotPresented() throws {
+        let binding = Binding(wrappedValue: false)
+        let sut = EmptyView().sheet(isPresented: binding) { Text("abc") }
+        XCTAssertThrows(try sut.inspect().emptyView().sheet(),
+                        "View for Sheet is absent")
+    }
+
+    func testNativeSheetWithItemNotPresented() throws {
+        let binding = Binding<Int?>(wrappedValue: nil)
+        let sut = EmptyView().sheet(item: binding) { Text("\($0)") }
+        XCTAssertThrows(try sut.inspect().emptyView().sheet(),
+                        "View for Sheet is absent")
+    }
+
+    func testNativeSheetContentInspection() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().sheet(isPresented: binding) { Text("abc") }
+        let title = try sut.inspect().emptyView().sheet().text()
+        XCTAssertEqual(try title.string(), "abc")
+        XCTAssertEqual(title.pathToRoot, "emptyView().sheet().text()")
+    }
+
+    func testNativeSheetMultipleContentInspection() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().sheet(isPresented: binding) {
+            Text("abc")
+            Button("xyz", action: { binding.wrappedValue = false })
+        }
+        let button = try sut.inspect().emptyView().sheet().button(1)
+        try button.tap()
+        XCTAssertFalse(binding.wrappedValue)
+        XCTAssertEqual(button.pathToRoot, "emptyView().sheet().button(1)")
+    }
+
+    func testNativeSheetWithItemContentInspection() throws {
+        let binding = Binding<Int?>(wrappedValue: 6)
+        let sut = EmptyView().sheet(item: binding) { Text("\($0)") }
+        XCTAssertEqual(try sut.inspect().emptyView().sheet().text().string(), "6")
+    }
+
+    func testNativeSheetDismiss() throws {
+        let exp = XCTestExpectation(description: #function)
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().sheet(isPresented: binding, onDismiss: {
+            exp.fulfill()
+        }, content: { Text("") })
+        try sut.inspect().emptyView().sheet().dismiss()
+        XCTAssertFalse(binding.wrappedValue)
+        XCTAssertThrows(try sut.inspect().emptyView().sheet(), "View for Sheet is absent")
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testNativeSheetWithItemDismiss() throws {
+        let exp = XCTestExpectation(description: #function)
+        let binding = Binding<Int?>(wrappedValue: 6)
+        let sut = EmptyView().sheet(item: binding, onDismiss: {
+            exp.fulfill()
+        }, content: { Text("\($0)") })
+        try sut.inspect().emptyView().sheet().dismiss()
+        XCTAssertNil(binding.wrappedValue)
+        XCTAssertThrows(try sut.inspect().emptyView().sheet(), "View for Sheet is absent")
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testNativeSheetSearch() throws {
+        let binding = Binding(wrappedValue: true)
+        let sut = EmptyView().sheet(isPresented: binding) { Text("abc") }
+        XCTAssertEqual(try sut.inspect().find(ViewType.Sheet.self).text().string(), "abc")
+        XCTAssertEqual(try sut.inspect().find(text: "abc").pathToRoot,
+                       "emptyView().sheet().text()")
     }
 
     func testInspectionErrorSheetNotPresented() throws {
@@ -113,22 +185,32 @@ final class SheetTests: XCTestCase {
         XCTAssertEqual(title1.pathToRoot,
             "view(SheetFindTestView.self).hStack().emptyView(0).sheet().text(0)")
         let title2 = try sut.inspect().hStack().emptyView(0).sheet(1).text(0)
-        XCTAssertEqual(try title2.string(), "title_3")
+        XCTAssertEqual(try title2.string(), "title_2")
         XCTAssertEqual(title2.pathToRoot,
             "view(SheetFindTestView.self).hStack().emptyView(0).sheet(1).text(0)")
+        let title3 = try sut.inspect().hStack().emptyView(0).sheet(2).text(0)
+        XCTAssertEqual(try title3.string(), "title_3")
+        XCTAssertEqual(title3.pathToRoot,
+            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.Sheet.self).text(0).string(), "title_1")
         #else
         let title1 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().emptyView(0).sheet().text(0)
         XCTAssertEqual(try title1.string(), "title_1")
         XCTAssertEqual(title1.pathToRoot,
             "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().emptyView(0).sheet().text(0)")
-        let title2 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().sheet().text(0)
-        XCTAssertEqual(try title2.string(), "title_3")
+        let title2 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().sheet(1).text(0)
+        XCTAssertEqual(try title2.string(), "title_2")
         XCTAssertEqual(title2.pathToRoot,
-            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet().text(0)")
+            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet(1).text(0)")
+        let title3 = try sut.inspect().implicitAnyView().hStack().anyView(0).anyView().sheet(2).text(0)
+        XCTAssertEqual(try title3.string(), "title_3")
+        XCTAssertEqual(title3.pathToRoot,
+            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(ViewType.Sheet.self, skipFound: 1).text(0).string(), "title_1")
         #endif
         binding1.wrappedValue = false
+        XCTAssertEqual(try sut.inspect().find(ViewType.Sheet.self).text(0).string(), "title_2")
+        binding2.wrappedValue = false
         XCTAssertEqual(try sut.inspect().find(ViewType.Sheet.self).text(0).string(), "title_3")
         binding3.wrappedValue = false
         XCTAssertThrows(try sut.inspect().find(ViewType.Sheet.self),
@@ -155,22 +237,30 @@ final class SheetTests: XCTestCase {
             """)
         #endif
         // 2
-        XCTAssertThrows(try sut.inspect().find(text: "title_2").pathToRoot,
-            "Search did not find a match")
+        #if compiler(<6) || compiler(>=6.1)
+        XCTAssertEqual(try sut.inspect().find(text: "title_2").pathToRoot,
+            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(1).text()")
+        #else
+        XCTAssertEqual(try sut.inspect().find(text: "title_2").pathToRoot,
+            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet(1).text()")
+        #endif
         
         // 3
         XCTAssertThrows(try sut.inspect().find(text: "message_3").pathToRoot,
             "Search did not find a match")
         #if compiler(<6) || compiler(>=6.1)
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
-            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(1).text(0)")
+            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,
-            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(1).button(1).labelView().text()")
+            "view(SheetFindTestView.self).hStack().emptyView(0).sheet(2).button(1).labelView().text()")
         #else
         XCTAssertEqual(try sut.inspect().find(text: "title_3").pathToRoot,
-            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet().text(0)")
+            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet(2).text(0)")
         XCTAssertEqual(try sut.inspect().find(text: "button_3").pathToRoot,
-            "view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView().sheet().button(1).labelView().text()")
+            """
+            view(SheetFindTestView.self).anyView().hStack().anyView(0).anyView()\
+            .sheet(2).button(1).labelView().text()
+            """)
         #endif
     }
 }
@@ -216,6 +306,16 @@ where Item: Identifiable, Sheet: View {
     
     func body(content: Self.Content) -> some View {
         content.sheet(item: item, onDismiss: onDismiss, content: popupBuilder)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct NonInspectableSheetModifier: ViewModifier {
+
+    let isPresented: Binding<Bool>
+
+    func body(content: Self.Content) -> some View {
+        content.sheet(isPresented: isPresented) { Text("abc") }
     }
 }
 

--- a/guide_popups.md
+++ b/guide_popups.md
@@ -6,11 +6,11 @@
 - [FullScreenCover](#fullscreencover)
 - [Popover](#popover)
 
-These five types of views have many in common, so is their inspection mechanism. Due to limited capabilities of what can be achieved in reflection, the native SwiftUI modifiers for presenting these views (`.alert`, `.actionSheet`, `.sheet`, `.fullScreenCover`, `.popover`) cannot be inspected as-is by the ViewInspector.
+These five types of views have many in common, so is their inspection mechanism. Due to limited capabilities of what can be achieved in reflection, some of the native SwiftUI modifiers for presenting these views (`.alert`, `.actionSheet`, `.popover`) cannot be inspected as-is by the ViewInspector.
 
 This section discusses how you still can gain the full access to the internals of these views by adding a couple of code snippets to your source code while not making ViewInspector a dependency for the main target.
 
-*Note*: ViewInspector fully supports `confirmationDialog` inspection without any code tweaking.
+*Note*: ViewInspector fully supports `confirmationDialog`, `sheet` and `fullScreenCover` inspection without any code tweaking.
 
 ## `Alert`
 
@@ -156,9 +156,29 @@ Make sure to use `actionSheet2` in your view's body (or a different name of your
 
 ## `Sheet`
 
-Similarly to the `Alert` and `ActionSheet`, there are two APIs for presenting the `Sheet` thus two sets of snippets to add to the project, depending on your needs.
+Both the `isPresented: Binding<Bool>` and the `item: Binding<Item?>` variants of the native `.sheet` modifier are supported as-is - no changes in the main target are needed:
 
-#### Variant with `isPresented: Binding<Bool>` - main target snippet:
+```swift
+func testSheetExample() throws {
+    let binding = Binding(wrappedValue: true)
+    let sut = EmptyView().sheet(isPresented: binding) {
+        Text("Sheet content")
+        Button("Close", action: { binding.wrappedValue = false })
+    }
+    let sheet = try sut.inspect().emptyView().sheet()
+    XCTAssertEqual(try sheet.text(0).string(), "Sheet content")
+    try sheet.button(1).tap()
+    XCTAssertFalse(binding.wrappedValue)
+}
+```
+
+Calling `sheet()` throws an error when the sheet is not presented, and `dismiss()` unpresents it, calling the `onDismiss` closure:
+
+```swift
+try sut.inspect().emptyView().sheet().dismiss()
+```
+
+If you're targeting a SwiftUI version that does not expose the sheet's content to the reflection, use the following snippet in the main target and `sheet2` in place of `sheet` in your views:
 
 ```swift
 extension View {
@@ -186,7 +206,7 @@ Test target:
 extension InspectableSheet: PopupPresenter { }
 ```
 
-#### Variant with `item: Binding<Item?>` - main target snippet:
+And the corresponding snippet for the `item: Binding<Item?>` variant - main target:
 
 ```swift
 extension View {
@@ -214,13 +234,19 @@ Test target:
 extension InspectableSheetWithItem: ItemPopupPresenter { }
 ```
 
-Don't forget that you'll need to use `sheet2` in place of `sheet` in your views.
-
 ## `FullScreenCover`
 
-Similarly to the `Alert` and `Sheet`, there are two APIs for presenting the `FullScreenCover` thus two sets of snippets to add to the project, depending on your needs.
+The native `.fullScreenCover` modifier is supported as-is, just like the `.sheet` - use the `fullScreenCover()` inspection call:
 
-#### Variant with `isPresented: Binding<Bool>` - main target snippet:
+```swift
+func testFullScreenCoverExample() throws {
+    let binding = Binding(wrappedValue: true)
+    let sut = EmptyView().fullScreenCover(isPresented: binding) { Text("Cover content") }
+    XCTAssertEqual(try sut.inspect().emptyView().fullScreenCover().text().string(), "Cover content")
+}
+```
+
+For the SwiftUI versions that don't expose the content to the reflection, use the `fullScreenCover2` snippets - main target:
 
 ```swift
 extension View {
@@ -248,7 +274,7 @@ Test target:
 extension InspectableFullScreenCover: PopupPresenter { }
 ```
 
-#### Variant with `item: Binding<Item?>` - main target snippet:
+And for the `item: Binding<Item?>` variant - main target:
 
 ```swift
 extension View {
@@ -275,8 +301,6 @@ Test target:
 ```swift
 extension InspectableFullScreenCoverWithItem: ItemPopupPresenter { }
 ```
-
-Don't forget that you'll need to use `fullScreenCover2` in place of `fullScreenCover` in your views.
 
 ## `Popover`
 


### PR DESCRIPTION
This PR adds full support for the native `.sheet` and `.fullScreenCover` modifiers, along with the `sheet2` / `fullScreenCover2` shims from [guide_popups.md](guide_popups.md), which keep working exactly as before.

The shims were needed because the native modifiers were thought to be opaque to the reflection. They aren't: `SheetPresentationModifier` (and `ItemSheetPresentationModifier` on macOS) builds the popup's content into an optional `AnyView` inside its `body`. It stays `nil` while the sheet is not presented, which gives the presented/absent check for free.

### Approach

`ViewType.Sheet.NativePresenter` adapts the native modifier to the existing `BasePopupPresenter` interface, so `PopupContainer`, `child()`/`children()`, `sheet()`, `fullScreenCover()`, `dismiss()` and `find` are all unchanged:

* `buildPopup()` reads `modifier|content|some` from the modifier's body, then unwraps the `AnyView` and `SheetContent` wrappers via `ViewType.AnyView.child`.
* `dismissPopup()` writes `false` to `_isPresented`, or `nil` to `_item` (through a private `NilAssignable` conformance on `Binding`, since `Item` isn't known statically), then calls `onDismiss`.

`isSheetBuilder(modifier:)` gained the native branch as a fallback after the existing presenter check, so shim and native modifiers share one indexed list and keep source order when mixed.

`popup(parent:index:name:popupPresenter:)` was split out of `popup(…modifierPredicate:standardPredicate:)` so the container assembly isn't duplicated.

### Backwards compatibility

The shim path is untouched and stays documented as the fallback for SwiftUI versions that don't expose the content. `NativePresenter.isInspectable` checks the modifier actually has a `body`, so those versions still get the "refer to the Guide" error rather than a misleading "absent".

No public API change.

**Behavior changes visible to existing test suites:**

1. Native `.sheet` modifiers now count in `sheet(index)`, so a view mixing `sheet2` and `.sheet` renumbers.
2. `find` descends into native sheets, so assertions of "Search did not find a match" for that content now resolve.
3. Inspecting a native `.sheet` no longer throws `notSupported`; unpresented throws `viewNotFound` instead.
4. `pathToRoot` gains `.sheet()` segments for previously unreachable content.

A `.sheet` applied inside a custom `ViewModifier`'s body is still not reported at the outer level, as before.

### Known limitation

The presentation's `_EnvironmentKeyWritingModifier<Binding<PresentationMode>>` is discarded, so `@Environment(\.presentationMode)` / `\.dismiss` inside the content won't resolve. The cause is `PopupContainer` storing only `popup: Any` with no medium. This is pre-existing for every popup type, and left for a separate change.

### Tests

13 added, 4 updated, 2 replaced. The replaced ones are `testInspectionErrorCustomModifierRequired` in both files, since that path is dead for native sheets; a new `testInspectionErrorSheetInsideCustomModifier` covers the remaining guide-error branch.

| Toolchain | Destination | Result |
|---|---|---|
| Xcode 26.6 | macOS 26.6 | 1573 tests, 0 failures |
| Xcode 26.6 | iOS 27.0 sim | 1533 tests, 0 failures |
| Xcode 26.6 | iOS 26.5 sim | 1533 tests, 0 failures |
| Xcode-beta 27.0 | macOS / iOS 26.5 / iOS 27.0 | 0 failures |

Not verified on tvOS, watchOS or visionOS. SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
