### PR TITLE
#425: Support TupleContent produced by ViewBuilder on iOS 27

### DIFF
--- a/Sources/ViewInspector/InspectableView.swift
+++ b/Sources/ViewInspector/InspectableView.swift
@@ -28,8 +28,9 @@ public struct InspectableView<View> where View: BaseViewType {
     
     private static func build(content: Content, parent: UnwrappedView?, call: String, index: Int?) throws -> Self {
         if !View.typePrefix.isEmpty,
-           Inspector.isTupleView(content.view),
-           View.self != ViewType.TupleView.self {
+           Inspector.isViewTuple(content.view),
+           View.self != ViewType.TupleView.self,
+           View.self != ViewType.TupleContentView.self {
             throw InspectionError.notSupported(
                 "Unable to extract \(View.typePrefix): please specify its index inside parent view")
         }
@@ -204,10 +205,11 @@ internal extension InspectableView where View: MultipleViewContent {
             throw InspectionError.viewIndexOutOfBounds(index: index, count: viewes.count)
         }
         let child = try viewes.element(at: index)
-        if !isTupleExtraction && Inspector.isTupleView(child.view) {
+        if !isTupleExtraction && Inspector.isViewTuple(child.view) {
+            let call = Inspector.isTupleContentView(child.view) ? "tupleContentView" : "tupleView"
             throw InspectionError.notSupported(
                 // swiftlint:disable:next line_length
-                "Please insert .tupleView(\(index)) after \(Inspector.typeName(type: View.self)) for inspecting its children at index \(index)")
+                "Please insert .\(call)(\(index)) after \(Inspector.typeName(type: View.self)) for inspecting its children at index \(index)")
         }
         return child
     }

--- a/Sources/ViewInspector/Inspector.swift
+++ b/Sources/ViewInspector/Inspector.swift
@@ -389,14 +389,26 @@ internal extension Inspector {
     #endif
     static func viewsInContainer(view: Any, medium: Content.Medium) throws -> LazyGroup<Content> {
         let unwrappedContainer = try Inspector.unwrap(content: Content(view, medium: medium.resettingViewModifiers()))
-        guard Inspector.isTupleView(unwrappedContainer.view) else {
-            return LazyGroup(count: 1) { _ in unwrappedContainer }
+        if Inspector.isTupleView(unwrappedContainer.view) {
+            return try ViewType.TupleView.children(unwrappedContainer)
         }
-        return try ViewType.TupleView.children(unwrappedContainer)
+        if Inspector.isTupleContentView(unwrappedContainer.view) {
+            return try ViewType.TupleContentView.children(unwrappedContainer)
+        }
+        return LazyGroup(count: 1) { _ in unwrappedContainer }
     }
 
     static func isTupleView(_ view: Any) -> Bool {
         return Inspector.typeName(value: view, generics: .remove) == ViewType.TupleView.typePrefix
+    }
+
+    static func isTupleContentView(_ view: Any) -> Bool {
+        return Inspector.typeName(value: view, generics: .remove) == ViewType.TupleContentView.typePrefix
+    }
+
+    /// `ViewBuilder` wraps multiple children in `TupleView`, or in `TupleContent` since iOS 27
+    static func isViewTuple(_ view: Any) -> Bool {
+        return isTupleView(view) || isTupleContentView(view)
     }
 
     #if swift(>=6.0)

--- a/Sources/ViewInspector/SwiftUI/Toolbar.swift
+++ b/Sources/ViewInspector/SwiftUI/Toolbar.swift
@@ -114,7 +114,7 @@ public extension InspectableView where View == ViewType.Toolbar {
     
     private func element(_ index: Int) throws -> Any {
         if let value = try? Inspector
-            .attribute(path: "content|value|.\(index)", value: content.view) {
+            .attribute(path: "\(content.toolbarElementsPath)|.\(index)", value: content.view) {
             return value
         }
         if index == 0 {
@@ -133,12 +133,22 @@ public extension InspectableView where View == ViewType.Toolbar {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private extension Content {
+    /// Multiple toolbar elements are stored in a tuple, which since iOS 27
+    /// is `TupleContent` (keeping the tuple under `content`) instead of
+    /// `TupleView` (keeping it under `value`)
+    var toolbarElementsPath: String {
+        guard let root = try? Inspector.attribute(label: "content", value: view),
+              Inspector.isTupleContentView(root)
+        else { return "content|value" }
+        return "content|content"
+    }
+
     func toolbarElementsCount() -> Int {
         var index: Int = -1
         var couldLocateItem = false
         repeat {
             index += 1
-            couldLocateItem = (try? Inspector.attribute(path: "content|value|.\(index)", value: view)) != nil
+            couldLocateItem = (try? Inspector.attribute(path: "\(toolbarElementsPath)|.\(index)", value: view)) != nil
         } while couldLocateItem
         if index == 0,
            (try? Inspector.attribute(path: "content|value", value: view)) != nil

--- a/Sources/ViewInspector/SwiftUI/TupleView.swift
+++ b/Sources/ViewInspector/SwiftUI/TupleView.swift
@@ -6,6 +6,15 @@ public extension ViewType {
     struct TupleView: KnownViewType {
         public static let typePrefix: String = "TupleView"
     }
+
+    /// Starting with iOS 27, `ViewBuilder` assembles multiple children
+    /// into `TupleContent` instead of `TupleView`
+    struct TupleContentView: KnownViewType {
+        public static let typePrefix: String = "TupleContent"
+        public static func inspectionCall(typeName: String) -> String {
+            return "tupleContentView(\(ViewType.indexPlaceholder))"
+        }
+    }
 }
 
 // MARK: - Content Extraction
@@ -14,7 +23,23 @@ public extension ViewType {
 extension ViewType.TupleView: MultipleViewContent {
     
     public static func children(_ content: Content) throws -> LazyGroup<Content> {
-        let tupleViews = try Inspector.attribute(label: "value", value: content.view)
+        return try ViewType.tupleChildren(content, label: "value")
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension ViewType.TupleContentView: MultipleViewContent {
+
+    public static func children(_ content: Content) throws -> LazyGroup<Content> {
+        return try ViewType.tupleChildren(content, label: "content")
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+internal extension ViewType {
+
+    static func tupleChildren(_ content: Content, label: String) throws -> LazyGroup<Content> {
+        let tupleViews = try Inspector.attribute(label: label, value: content.view)
         let childrenCount = Mirror(reflecting: tupleViews).children.count
         return LazyGroup(count: childrenCount) { index in
             let child = try Inspector.attribute(label: ".\(index)", value: tupleViews)
@@ -30,6 +55,10 @@ extension ViewType.TupleView: MultipleViewContent {
 public extension InspectableView where View: MultipleViewContent {
     
     func tupleView(_ index: Int) throws -> InspectableView<ViewType.TupleView> {
+        return try .init(try child(at: index, isTupleExtraction: true), parent: self, index: index)
+    }
+
+    func tupleContentView(_ index: Int) throws -> InspectableView<ViewType.TupleContentView> {
         return try .init(try child(at: index, isTupleExtraction: true), parent: self, index: index)
     }
 }

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -89,6 +89,7 @@ internal extension ViewSearch {
             ViewType.Toggle.self,
             ViewType.TouchBar.self,
             ViewType.TupleView.self,
+            ViewType.TupleContentView.self,
             ViewType.Toolbar.self,
             ViewType.Toolbar.Item.self,
             ViewType.Toolbar.ItemGroup.self,
@@ -215,7 +216,7 @@ internal extension ViewSearch {
                 let descendants = try supplementary(parent)
                 return .init(count: descendants.count) { index -> UnwrappedView in
                     var view = try descendants.element(at: index)
-                    if Inspector.isTupleView(view.content.view) ||
+                    if Inspector.isViewTuple(view.content.view) ||
                         !(view is InspectableView<ViewType.ClassifiedView>) {
                         view.isUnwrappedSupplementaryChild = true
                         return view

--- a/Tests/ViewInspectorTests/InspectorTests.swift
+++ b/Tests/ViewInspectorTests/InspectorTests.swift
@@ -168,8 +168,9 @@ final class InspectorTests: XCTestCase {
     func testTupleView() throws {
         let view = HStack { Text(""); Text("") }
         let content = try Inspector.attribute(path: "_tree|content", value: view)
-        XCTAssertTrue(Inspector.isTupleView(content))
-        XCTAssertFalse(Inspector.isTupleView((0, 2)))
+        // ViewBuilder produces `TupleContent` instead of `TupleView` since iOS 27
+        XCTAssertTrue(Inspector.isViewTuple(content))
+        XCTAssertFalse(Inspector.isViewTuple((0, 2)))
     }
     
     func testGuardType() throws {

--- a/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/TupleViewTests.swift
@@ -17,13 +17,14 @@ final class TupleViewTests: XCTestCase {
     
     func testTupleInsideTupleView() throws {
         let view = TupleInsideTupleView(flag: true)
-        let string1 = try view.inspect().implicitAnyView().hStack().text(0).string()
+        let sut = try view.inspect().implicitAnyView().hStack()
+        let string1 = try sut.text(0).string()
         XCTAssertEqual(string1, "xyz")
-        XCTAssertThrows(try view.inspect().implicitAnyView().hStack().text(1),
-                        "Please insert .tupleView(1) after HStack for inspecting its children at index 1")
-        let string2 = try view.inspect().implicitAnyView().hStack().tupleView(1).text(0).string()
+        XCTAssertThrows(try sut.text(1),
+                        "Please insert .\(tupleCall)(1) after HStack for inspecting its children at index 1")
+        let string2 = try nestedTupleText(sut, tuple: 1, text: 0).string()
         XCTAssertEqual(string2, "abc")
-        let string3 = try view.inspect().implicitAnyView().hStack().tupleView(1).text(1).string()
+        let string3 = try nestedTupleText(sut, tuple: 1, text: 1).string()
         XCTAssertEqual(string3, "def")
     }
     
@@ -34,18 +35,18 @@ final class TupleViewTests: XCTestCase {
         XCTAssertEqual(try view1.inspect().find(text: "xyz").pathToRoot,
                        "view(TupleInsideTupleView.self).hStack().text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "abc").pathToRoot,
-                       "view(TupleInsideTupleView.self).hStack().tupleView(1).text(0)")
+                       "view(TupleInsideTupleView.self).hStack().\(tupleCall)(1).text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "def").pathToRoot,
-                       "view(TupleInsideTupleView.self).hStack().tupleView(1).text(1)")
+                       "view(TupleInsideTupleView.self).hStack().\(tupleCall)(1).text(1)")
         XCTAssertEqual(try view2.inspect().find(text: "xyz").pathToRoot,
                        "view(TupleInsideTupleView.self).hStack().text(0)")
         #else
         XCTAssertEqual(try view1.inspect().find(text: "xyz").pathToRoot,
                        "view(TupleInsideTupleView.self).anyView().hStack().text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "abc").pathToRoot,
-                       "view(TupleInsideTupleView.self).anyView().hStack().tupleView(1).text(0)")
+                       "view(TupleInsideTupleView.self).anyView().hStack().\(tupleCall)(1).text(0)")
         XCTAssertEqual(try view1.inspect().find(text: "def").pathToRoot,
-                       "view(TupleInsideTupleView.self).anyView().hStack().tupleView(1).text(1)")
+                       "view(TupleInsideTupleView.self).anyView().hStack().\(tupleCall)(1).text(1)")
         XCTAssertEqual(try view2.inspect().find(text: "xyz").pathToRoot,
                        "view(TupleInsideTupleView.self).anyView().hStack().text(0)")
         #endif
@@ -53,12 +54,139 @@ final class TupleViewTests: XCTestCase {
         XCTAssertThrows(try view2.inspect().find(text: "def"), "Search did not find a match")
     }
     
+    func testMultipleChildrenInContainer() throws {
+        let view = VStack { Text("A"); Text("B") }
+        XCTAssertEqual(try view.inspect().vStack().text(0).string(), "A")
+        XCTAssertEqual(try view.inspect().vStack().text(1).string(), "B")
+        XCTAssertEqual(try view.inspect().find(text: "B").pathToRoot, "vStack().text(1)")
+    }
+
+    func testMultipleModifiedChildrenInContainer() throws {
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+        else { throw XCTSkip() }
+        let view = DecoratedFieldsView()
+        XCTAssertEqual(try view.inspect().find(text: "Label").string(), "Label")
+        XCTAssertEqual(try view.inspect().find(ViewType.TextField.self).labelView().text().string(),
+                       "Placeholder")
+        XCTAssertEqual(try view.inspect().find(text: "Footer").string(), "Footer")
+    }
+
     func testResetsModifiers() throws {
         let view = TupleInsideTupleView(flag: true)
-        let sut = try view.inspect().implicitAnyView().hStack().tupleView(1).text(0)
+        let hStack = try view.inspect().implicitAnyView().hStack()
+        let sut = try nestedTupleText(hStack, tuple: 1, text: 0)
         XCTAssertEqual(sut.content.medium.viewModifiers.count, 2)
     }
 }
+
+// MARK: - Deployment target differences
+
+/// `ViewBuilder` assembles multiple children into `TupleContent` instead of
+/// `TupleView` when the deployment target is iOS 27 or above. The two are
+/// inspected with `tupleContentView(_:)` and `tupleView(_:)` respectively.
+@MainActor
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private var tupleCall: String {
+    return Inspector.isTupleContentView(TupleProbeView().body) ? "tupleContentView" : "tupleView"
+}
+
+@MainActor
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private func nestedTupleText(_ sut: InspectableView<ViewType.HStack>,
+                             tuple: Int, text: Int) throws -> InspectableView<ViewType.Text> {
+    if Inspector.isTupleContentView(TupleProbeView().body) {
+        return try sut.tupleContentView(tuple).text(text)
+    }
+    return try sut.tupleView(tuple).text(text)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+private struct TupleProbeView: View {
+    var body: some View {
+        Text("1")
+        Text("2")
+    }
+}
+
+// MARK: - TupleContent
+
+#if compiler(>=6.4)
+
+/// Since iOS 27 `ViewBuilder` assembles multiple children into `TupleContent`
+/// instead of `TupleView`
+@MainActor
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class TupleContentTests: XCTestCase {
+
+    func testTupleContentInsideTupleContent() throws {
+        guard #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+        else { throw XCTSkip() }
+        let sut = try TupleContentView(flag: true).inspect().implicitAnyView().hStack()
+        XCTAssertEqual(try sut.text(0).string(), "xyz")
+        XCTAssertThrows(try sut.text(1),
+                        "Please insert .tupleContentView(1) after HStack for inspecting its children at index 1")
+        XCTAssertEqual(try sut.tupleContentView(1).text(0).string(), "abc")
+        XCTAssertEqual(try sut.tupleContentView(1).text(1).string(), "def")
+    }
+
+    func testSearch() throws {
+        guard #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+        else { throw XCTSkip() }
+        let view = TupleContentView(flag: true)
+        XCTAssertEqual(try view.inspect().find(text: "xyz").pathToRoot,
+                       "view(TupleContentView.self).hStack().text(0)")
+        XCTAssertEqual(try view.inspect().find(text: "abc").pathToRoot,
+                       "view(TupleContentView.self).hStack().tupleContentView(1).text(0)")
+        XCTAssertEqual(try view.inspect().find(text: "def").pathToRoot,
+                       "view(TupleContentView.self).hStack().tupleContentView(1).text(1)")
+    }
+
+    func testResetsModifiers() throws {
+        guard #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+        else { throw XCTSkip() }
+        let view = TupleContentView(flag: true)
+        let sut = try view.inspect().implicitAnyView().hStack().tupleContentView(1).text(0)
+        XCTAssertEqual(sut.content.medium.viewModifiers.count, 2)
+    }
+
+    func testToolbarItemsExtraction() throws {
+        guard #available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+        else { throw XCTSkip() }
+        let sut = try ToolbarTupleContentView().inspect().implicitAnyView().emptyView()
+        XCTAssertEqual(try sut.toolbar().item(0).text().string(), "abc")
+        XCTAssertEqual(try sut.toolbar().item(1).text().string(), "def")
+    }
+}
+
+/// The `@available` attribute raises the availability context, so `ViewBuilder`
+/// picks the `TupleContent` overload no matter what the deployment target is
+@available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+private struct TupleContentView: View {
+
+    let flag: Bool
+    var body: some View {
+        HStack {
+            Text("xyz")
+            if flag {
+                Text("abc").offset().blur(radius: 1)
+                Text("def")
+            }
+        }.padding()
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
+private struct ToolbarTupleContentView: View {
+    var body: some View {
+        EmptyView()
+            .toolbar {
+                ToolbarItem { Text("abc") }
+                ToolbarItem { Text("def") }
+            }
+    }
+}
+
+#endif
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 private struct SimpleTupleView: View {
@@ -80,5 +208,24 @@ private struct TupleInsideTupleView: View {
                 Text("def")
             }
         }.padding()
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+private struct DecoratedFieldsView: View {
+
+    @State private var value: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Label")
+                .padding(4)
+                .accessibilityLabel(Text("label"))
+            TextField("Placeholder", text: $value)
+                .padding()
+                .onAppear { }
+            Text("Footer")
+                .opacity(0.5)
+        }
     }
 }


### PR DESCRIPTION
Fixes #425

## Problem

With the iOS 27 SDK and a deployment target of iOS 27, inspection fails on any
container with two or more children:

    Search did not find a match. Possible blockers: TupleContent<Pack{Text, Text}>

## Cause

The iOS 27 SDK adds a `ViewBuilder.buildBlock` overload:

    @available(iOS 27.0, macOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0, *)
    public static func buildBlock<each Content>(_ content: repeat each Content)
        -> TupleContent<repeat each Content>

The pre-existing overload returning `TupleView` is `@_disfavoredOverload`, so in
an iOS 27 availability context `VStack { Text("A"); Text("B") }` is built as
`VStack<TupleContent<Pack{Text, Text}>>` instead of
`VStack<TupleView<(Text, Text)>>`. The children move from the `value` attribute
to `content`, and `Inspector.isTupleView` matched only `TupleView`, so
containers stopped decomposing. `ToolbarContentBuilder` changed the same way,
moving toolbar elements from `content|value|.N` to `content|content|.N`.

## Changes

* `ViewType.TupleContentView` — a distinct view type for `TupleContent`,
  inspected with `tupleContentView(_:)`, alongside `TupleView`/`tupleView(_:)`.
  Both share the extraction logic, differing only in the storage label.
* `Inspector.isViewTuple` for the checks that care about tuple-ness, with
  `isTupleView`/`isTupleContentView` for the specific types.
* The "please specify its index" blocker now names the matching call, so the
  suggestion is accurate on both SDKs.
* `Toolbar` picks the element path based on the container type.

## Testing

`TupleContentTests` mirror `TupleViewTests` and cover extraction, search,
modifier resetting and toolbar items. The fixtures are marked
`@available(iOS 27.0, ...)`, which raises the availability context so
`ViewBuilder` selects the `TupleContent` overload regardless of the deployment
target — they run on an iOS 27 simulator in a normal build, and skip below
iOS 27. They compile only under the Xcode 27 SDK (`#if compiler(>=6.4)`).

Existing tests that assert `.tupleView` in paths and error messages now derive
the expected call from the tuple type the builder actually produced, so they
pass under either deployment target.

Full suite, 0 failures:

| Toolchain | Destination |
| --- | --- |
| Xcode 26.6 | iOS 26.5, iOS 27.0, macOS |
| Xcode 27 | iOS 26.5, iOS 27.0, macOS |
| Xcode 27 | iOS 27.0 with `IPHONEOS_DEPLOYMENT_TARGET=27.0` |

Without the fix, that last configuration fails 278 tests; with the default
deployment target the SDK bump alone stays green, which is why the new tests
raise the availability context instead of relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)