### PR TITLE
#363: Fix crash when search traverses a Charts `Chart` view

### DIFF
--- a/Sources/ViewInspector/SwiftUI/Chart.swift
+++ b/Sources/ViewInspector/SwiftUI/Chart.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+public extension ViewType {
+
+    /// `Chart` is an opaque view: its `body` is built from `GeometryReader` and other
+    /// internals that require a real layout context, so ViewInspector does not descend
+    /// into it. The chart's content is `ChartContent`, not `View`, and is not inspectable.
+    struct Chart: KnownViewType {
+        public static let typePrefix: String = "Chart"
+        public static var namespacedPrefixes: [String] {
+            return ["Charts." + typePrefix]
+        }
+        public static func inspectionCall(typeName: String) -> String {
+            return "chart(\(ViewType.indexPlaceholder))"
+        }
+    }
+}
+
+// MARK: - Extraction from SingleViewContent parent
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+public extension InspectableView where View: SingleViewContent {
+
+    func chart() throws -> InspectableView<ViewType.Chart> {
+        return try .init(try child(), parent: self)
+    }
+}
+
+// MARK: - Extraction from MultipleViewContent parent
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+public extension InspectableView where View: MultipleViewContent {
+
+    func chart(_ index: Int) throws -> InspectableView<ViewType.Chart> {
+        return try .init(try child(at: index), parent: self, index: index)
+    }
+}

--- a/Sources/ViewInspector/ViewSearchIndex.swift
+++ b/Sources/ViewInspector/ViewSearchIndex.swift
@@ -16,6 +16,7 @@ internal extension ViewSearch {
             ViewType.AsyncImage.self,
             ViewType.Button.self,
             ViewType.Canvas.self,
+            ViewType.Chart.self,
             ViewType.Color.self,
             ViewType.ColorPicker.self,
             ViewType.ConfirmationDialog.self,

--- a/Tests/ViewInspectorTests/SwiftUI/ChartTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ChartTests.swift
@@ -1,0 +1,59 @@
+#if canImport(Charts)
+import XCTest
+import SwiftUI
+import Charts
+@testable import ViewInspector
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+final class ChartTests: XCTestCase {
+
+    @MainActor
+    func testExtractionFromSingleViewContainer() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let view = AnyView(Chart { BarMark(x: .value("a", 1), y: .value("b", 2)) })
+        XCTAssertNoThrow(try view.inspect().anyView().chart())
+    }
+
+    @MainActor
+    func testExtractionFromMultipleViewContainer() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let view = HStack {
+            Chart { }
+            Chart { }
+        }
+        XCTAssertNoThrow(try view.inspect().hStack().chart(0))
+        XCTAssertNoThrow(try view.inspect().hStack().chart(1))
+    }
+
+    @MainActor
+    func testSearch() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let view = HStack { Chart { } }
+        XCTAssertEqual(try view.inspect().find(ViewType.Chart.self).pathToRoot,
+                       "hStack().chart(0)")
+    }
+
+    /// The `Chart` internals require a real layout context, so the search must not
+    /// descend into the chart's body.
+    @MainActor
+    func testSearchDoesNotDescendIntoChart() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+        else { throw XCTSkip() }
+        let view = VStack {
+            Chart {
+                BarMark(x: .value("a", 1), y: .value("b", 2))
+            }
+            .chartXAxis(.hidden)
+            .id("chart")
+        }
+        XCTAssertNoThrow(try view.inspect().find(viewWithId: "chart"))
+        XCTAssertThrows(try view.inspect().find(viewWithId: "unknown"),
+                        "Search did not find a match")
+        XCTAssertThrows(try view.inspect().find(text: "a"),
+                        "Search did not find a match")
+    }
+}
+#endif

--- a/Tests/ViewInspectorTests/SwiftUI/ChartTests.swift
+++ b/Tests/ViewInspectorTests/SwiftUI/ChartTests.swift
@@ -20,8 +20,8 @@ final class ChartTests: XCTestCase {
         guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
         else { throw XCTSkip() }
         let view = HStack {
-            Chart { }
-            Chart { }
+            Chart { BarMark(x: .value("a", 1), y: .value("b", 2)) }
+            Chart { BarMark(x: .value("a", 2), y: .value("b", 3)) }
         }
         XCTAssertNoThrow(try view.inspect().hStack().chart(0))
         XCTAssertNoThrow(try view.inspect().hStack().chart(1))
@@ -31,7 +31,7 @@ final class ChartTests: XCTestCase {
     func testSearch() throws {
         guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
         else { throw XCTSkip() }
-        let view = HStack { Chart { } }
+        let view = HStack { Chart { BarMark(x: .value("a", 1), y: .value("b", 2)) } }
         XCTAssertEqual(try view.inspect().find(ViewType.Chart.self).pathToRoot,
                        "hStack().chart(0)")
     }

--- a/readiness.md
+++ b/readiness.md
@@ -27,7 +27,7 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:white_check_mark:| ButtonStyleConfiguration.Label | |
 |:technologist:| CameraView | |
 |:white_check_mark:| Canvas | `symbols view`, `colorMode: ColorRenderingMode`, `opaque: Bool`, `rendersAsynchronously: Bool` |
-|:technologist:| Chart | |
+|:white_check_mark:| Chart | opaque view: the contents are `ChartContent`, not `View`, so there is nothing to inspect inside |
 |:white_check_mark:| Color | `value: Color`, `rgba: (Float, Float, Float, Float)`, `name: String` |
 |:white_check_mark:| ColorPicker | `label view`, `select(color: Color)` |
 |:white_check_mark:| ControlGroup | |


### PR DESCRIPTION
Fixes #363

## What

Registers `Chart` as a known leaf view type so the view search identifies it and stops there, instead of unwrapping its body.

## Why

`Chart`'s body is built from a `GeometryReader` whose content closure requires a real layout context. ViewInspector feeds every `GeometryReader` a zero-filled `GeometryProxy`, and Charts then traps on an implicitly unwrapped nil inside its private `RenderBasedChartView`, taking down the whole test process.

Any `find` that has to walk *past* a chart crashes; a `find` that matches before reaching the chart happens to survive, which is why the failure looks intermittent:

```swift
struct ChartView: View {
    var body: some View {
        VStack {
            Chart { BarMark(x: .value("a", 1), y: .value("b", 2)) }.id("chart")
        }
    }
}

let sut = try ChartView().inspect()
try? sut.find(viewWithId: "chart")   // fine — matched before descending
try? sut.find(viewWithId: "text")    // crashed — walked into the chart's body
```

Backtrace of the crash: `Charts` frame called directly from `GeometryReader.view()` (`GeometryReader.swift:51`), where the fabricated `GeometryProxy` is passed to the content builder.

## Notes for the reviewer

- Nothing is lost by not descending: a chart's contents are `ChartContent`, not `View`, so they were never inspectable.
- No `import Charts` is needed — the type is matched by its namespaced name (`Charts.Chart`), so the code compiles and behaves the same on platforms without the framework.
- Adds `chart()` / `chart(_ index:)` extraction, matching the `Map` / `VideoPlayer` pattern for opaque framework views.
- `readiness.md` updated.
- Verified on Xcode 27.0 (27A266a): the crash still reproduces without this change, and the full suite passes with it — 1605 tests, 7 skipped, 0 failures.
- The tests deliberately use charts containing a `BarMark`. An empty `Chart { }` segfaults inside the Charts framework at construction time on this SDK, with no ViewInspector involved:
  ```swift
  let c = Chart { }   // EXC_BAD_ACCESS
  ```
  That looks like a separate Apple bug and is out of scope here.