### PR TITLE
feat: Support onScrollVisibilityChange(threshold:_:)

### DIFF
--- a/Sources/ViewInspector/Modifiers/EventsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/EventsModifiers.swift
@@ -127,3 +127,34 @@ public extension InspectableView {
         }
     }
 }
+
+// MARK: - ViewScrollEvents
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public extension InspectableView {
+
+    func callOnScrollVisibilityChange(_ isVisible: Bool, index: Int = 0) throws {
+        let action = try modifierAttribute(
+            modifierName: "OnScrollVisibilityChangeModifier", path: "modifier|action",
+            type: Any.self, call: "onScrollVisibilityChange", index: index)
+        // SwiftUI stores the callback with the concrete `(Bool) -> Void` calling convention.
+        // Casting it to that closure type reabstracts it and corrupts the argument, so the
+        // callback is rebound to a container that preserves the original convention.
+        guard type(of: action) == ((Bool) -> Void).self,
+              let container = withUnsafeBytes(of: action, {
+                  $0.bindMemory(to: BoolActionContainer.self).first
+              })
+        else { throw InspectionError.typeMismatch(action, ((Bool) -> Void).self) }
+        container.action(isVisible)
+    }
+
+    func onScrollVisibilityChangeThreshold(index: Int = 0) throws -> Double {
+        return try modifierAttribute(
+            modifierName: "OnScrollVisibilityChangeModifier", path: "modifier|threshold",
+            type: Double.self, call: "onScrollVisibilityChange", index: index)
+    }
+}
+
+private struct BoolActionContainer {
+    let action: (Bool) -> Void
+}

--- a/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/EventsModifiersTests.swift
@@ -286,6 +286,76 @@ final class ViewEventsTests: XCTestCase {
     }
 }
 
+// MARK: - ViewScrollEventsTests
+
+@MainActor
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+final class ViewScrollEventsTests: XCTestCase {
+
+    func testOnScrollVisibilityChange() throws {
+        let sut = EmptyView().onScrollVisibilityChange { _ in }
+        XCTAssertNoThrow(try sut.inspect().emptyView())
+    }
+
+    func testOnScrollVisibilityChangeInspection() throws {
+        let exp1 = XCTestExpectation(description: "\(#function)_visible")
+        let exp2 = XCTestExpectation(description: "\(#function)_hidden")
+        let sut = ScrollView {
+            VStack {
+                Text("abc")
+                    .onScrollVisibilityChange { isVisible in
+                        if isVisible {
+                            exp1.fulfill()
+                        } else {
+                            exp2.fulfill()
+                        }
+                    }
+            }
+        }
+        let text = try sut.inspect().find(text: "abc")
+        try text.callOnScrollVisibilityChange(true)
+        try text.callOnScrollVisibilityChange(false)
+        wait(for: [exp1, exp2], timeout: 0.1)
+    }
+
+    func testOnScrollVisibilityChangeArgumentDelivery() throws {
+        var received: [Bool] = []
+        let sut = EmptyView().onScrollVisibilityChange { received.append($0) }
+        let view = try sut.inspect().emptyView()
+        try view.callOnScrollVisibilityChange(false)
+        try view.callOnScrollVisibilityChange(true)
+        try view.callOnScrollVisibilityChange(false)
+        XCTAssertEqual(received, [false, true, false])
+    }
+
+    func testOnScrollVisibilityChangeMultipleModifiers() throws {
+        var received: [String] = []
+        let sut = EmptyView()
+            .onScrollVisibilityChange(threshold: 0.1) { received.append("first: \($0)") }
+            .onScrollVisibilityChange(threshold: 0.9) { received.append("second: \($0)") }
+        let view = try sut.inspect().emptyView()
+        XCTAssertEqual(try view.onScrollVisibilityChangeThreshold(), 0.1)
+        XCTAssertEqual(try view.onScrollVisibilityChangeThreshold(index: 1), 0.9)
+        try view.callOnScrollVisibilityChange(true)
+        try view.callOnScrollVisibilityChange(false, index: 1)
+        XCTAssertEqual(received, ["first: true", "second: false"])
+    }
+
+    func testOnScrollVisibilityChangeThreshold() throws {
+        let sut = EmptyView().padding()
+            .onScrollVisibilityChange(threshold: 0.3) { _ in }
+            .padding()
+        XCTAssertEqual(try sut.inspect().emptyView().onScrollVisibilityChangeThreshold(), 0.3)
+    }
+
+    func testOnScrollVisibilityChangeMissingModifierError() throws {
+        let sut = EmptyView().padding()
+        XCTAssertThrows(
+            try sut.inspect().emptyView().callOnScrollVisibilityChange(true),
+            "EmptyView does not have 'onScrollVisibilityChange' modifier")
+    }
+}
+
 // MARK: - ViewPublisherEventsTests
 
 @MainActor

--- a/readiness.md
+++ b/readiness.md
@@ -351,6 +351,8 @@ This document reflects the current status of the [ViewInspector](https://github.
 |:technologist:| `func onDrop(of: [UTType], ...) -> some View` |
 |:technologist:| `func deleteDisabled(Bool) -> some View` |
 |:technologist:| `func moveDisabled(Bool) -> some View` |
+|:white_check_mark:| `func onScrollVisibilityChange(threshold: Double, (Bool) -> Void) -> some View` |
+|:technologist:| `func onScrollTargetVisibilityChange<ID>(idType: ID.Type, threshold: Double, ([ID]) -> Void) -> some View` |
 
 ### Handling Publisher Events
 

--- a/unsupported_swiftui_apis.md
+++ b/unsupported_swiftui_apis.md
@@ -312,7 +312,13 @@ scrollPosition(id:anchor:)
 scrollTargetBehavior(_:)
 scrollTargetLayout(isEnabled:)
 scrollTransition(_:)
+onScrollTargetVisibilityChange(idType:threshold:_:)
 ```
+
+Note: `onScrollVisibilityChange(threshold:_:)` is supported.
+`onScrollTargetVisibilityChange(idType:threshold:_:)` is not: SwiftUI stores its
+`([ID]) -> Void` callback with a calling convention that cannot be reproduced from
+Swift, so invoking it corrupts the array of ids.
 
 ### Accessibility
 


### PR DESCRIPTION
Adds inspection support for `onScrollVisibilityChange(threshold:_:)` (iOS 18 / macOS 15 / tvOS 18 / watchOS 11 / visionOS 2):

```swift
func callOnScrollVisibilityChange(_ isVisible: Bool, index: Int = 0) throws
func onScrollVisibilityChangeThreshold(index: Int = 0) throws -> Double
```

```swift
let sut = ScrollView {
    VStack {
        Text("Item").onScrollVisibilityChange { isVisible in ... }
    }
}
try sut.inspect().find(text: "Item").callOnScrollVisibilityChange(true)
```

### Why the callback needs a container struct

SwiftUI stores this modifier's callback with the concrete `(Bool) -> Void` calling convention. Reading it as a closure — `Inspector.cast`, or `bindMemory(to: ((Bool) -> Void).self)` — makes the compiler insert a reabstraction thunk that passes the argument indirectly. The callee then reads it from an unrelated address, and the visibility flag arrives as garbage rather than the value passed in.

Measured against this modifier, calling with `false` then `true`:

| Extraction | Result |
|---|---|
| `Inspector.cast` to `(Bool) -> Void` | `true, true` |
| `bindMemory(to: ((Bool) -> Void).self).first` | `true, false` |
| `load(as: ((Bool) -> Void).self)` | `true, false` |
| `bindMemory(to: BoolActionContainer.self).first` | `false, true` |

A function type carries a calling convention, so it can be re-abstracted at any generic boundary; a struct with a function-typed stored property has its convention pinned by its own declaration and crosses those boundaries untouched. Hence the `private struct BoolActionContainer`, which follows the byte-rebinding pattern `navigationBarItems()` already uses. That call site can bind straight to a function type only because its payload is `EnvironmentValues` — indirect under both conventions, so nothing mismatches. A one-byte `Bool` is not so lucky.

`testOnScrollVisibilityChangeArgumentDelivery` asserts the exact `[false, true, false]` sequence, and the `type(of: action) == ((Bool) -> Void).self` guard makes a future signature change throw `typeMismatch` instead of calling into a mismatched layout.

### Not included

`onScrollTargetVisibilityChange(idType:threshold:_:)` is left unsupported and marked pending in `readiness.md`. Its `([ID]) -> Void` callback is stored with a convention I could not reproduce from Swift — the concrete cast, a bare-generic hop, generic container structs, and an `unsafeBitCast` to a pointer-taking closure all either corrupt the id array or crash. Reasoning recorded in `unsupported_swiftui_apis.md`.

### Testing

- 6 new tests in `ViewScrollEventsTests`
- iOS 26.5 simulator: full suite, 1567 tests, 0 failures
- iOS 27.0 simulator: full suite, 1567 tests, 0 failures
- macOS: full suite green
- SwiftLint clean

tvOS, watchOS and visionOS are covered by the `@available` attributes but not verified — no simulator runtimes for them installed locally.
