### PR TITLE
Fix accessibilityTraits() throwing for an empty trait set

### DIFF
--- a/Sources/ViewInspector/Modifiers/AccessibilityTraitsModifiers.swift
+++ b/Sources/ViewInspector/Modifiers/AccessibilityTraitsModifiers.swift
@@ -14,9 +14,14 @@ public extension InspectableView {
         let call = "accessibilityAddTraits"
         let traitSets = accessibilityTraitSets()
         guard !traitSets.isEmpty else {
-            throw InspectionError
-                .modifierNotFound(parent: Inspector.typeName(value: content.view),
-                                  modifier: call, index: 0)
+            /* A trait modifier that resolves to an empty set may leave no trait value
+               behind at all, in which case the empty set is still the correct answer. */
+            guard hasPropertylessAccessibilityAttachment() else {
+                throw InspectionError
+                    .modifierNotFound(parent: Inspector.typeName(value: content.view),
+                                      modifier: call, index: 0)
+            }
+            return AccessibilityTraits()
         }
         let rawValue = traitSets.reduce(UInt64(0)) { result, traitSet in
             (result & ~traitSet.mask) | (traitSet.value & traitSet.mask)
@@ -97,9 +102,42 @@ private extension InspectableView {
     
     /// The traits from every `AccessibilityAttachmentModifier`, in the order they were applied
     func accessibilityTraitSets() -> [AccessibilityTraitSetValue] {
-        return modifiersMatching { $0.modifierType.contains("AccessibilityAttachmentModifier") }
+        return accessibilityAttachmentModifiers()
             .reversed()
             .flatMap { InspectableView.accessibilityTraitSets(in: $0, depth: 0) }
+    }
+
+    func accessibilityAttachmentModifiers() -> [ModifierNameProvider] {
+        return modifiersMatching { $0.modifierType.contains("AccessibilityAttachmentModifier") }
+    }
+
+    /**
+     Newer versions of SwiftUI keep the accessibility properties in a type-keyed collection,
+     and a trait modifier that resolves to an empty set contributes no entry to it. Such a
+     modifier is only recognizable by the fact that it carries no accessibility properties
+     at all: every other accessibility modifier stores a value under its own key.
+     */
+    func hasPropertylessAccessibilityAttachment() -> Bool {
+        return accessibilityAttachmentModifiers().contains { modifier in
+            InspectableView.accessibilityPropertyStorages(in: modifier, depth: 0)
+                .contains { storage in
+                    let mirror = Mirror(reflecting: storage)
+                    return mirror.displayStyle == .collection && mirror.children.isEmpty
+                }
+        }
+    }
+
+    /// The values backing every `AccessibilityProperties` found in the modifier
+    private static func accessibilityPropertyStorages(in value: Any, depth: Int) -> [Any] {
+        if Inspector.typeName(value: value).contains("AccessibilityProperties") {
+            return Mirror(reflecting: value).children
+                .filter { $0.label == "storage" }
+                .map { $0.value }
+        }
+        guard depth < 8 else { return [] }
+        return Mirror(reflecting: value).children.flatMap {
+            accessibilityPropertyStorages(in: $0.value, depth: depth + 1)
+        }
     }
     
     private static func accessibilityTraitSets(in value: Any, depth: Int) -> [AccessibilityTraitSetValue] {

--- a/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
+++ b/Tests/ViewInspectorTests/ViewModifiers/AccessibilityModifiersTests.swift
@@ -322,7 +322,56 @@ final class ViewAccessibilityActionTests: XCTestCase {
             .inspect().emptyView().accessibilityTraits()
         XCTAssertEqual(sut3, AccessibilityTraits())
     }
-    
+
+    func testAccessibilityEmptyTraitsInspection() throws {
+        let sut1 = try EmptyView().accessibility(addTraits: AccessibilityTraits())
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut1, AccessibilityTraits())
+        let sut2 = try EmptyView().accessibility(removeTraits: AccessibilityTraits())
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut2, AccessibilityTraits())
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+        else { return }
+        let sut3 = try EmptyView().accessibilityAddTraits([])
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut3, AccessibilityTraits())
+        let sut4 = try Text("abc").accessibilityAddTraits([])
+            .inspect().text().accessibilityTraits()
+        XCTAssertEqual(sut4, AccessibilityTraits())
+        let sut5 = try EmptyView().accessibilityRemoveTraits([])
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut5, AccessibilityTraits())
+    }
+
+    func testAccessibilityEmptyAndNonEmptyTraitsInspection() throws {
+        let sut1 = try EmptyView()
+            .accessibility(addTraits: AccessibilityTraits())
+            .accessibility(removeTraits: .isButton)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut1, AccessibilityTraits())
+        let sut2 = try EmptyView()
+            .accessibility(addTraits: .isButton)
+            .accessibility(removeTraits: AccessibilityTraits())
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut2, .isButton)
+        let sut3 = try EmptyView()
+            .accessibility(addTraits: AccessibilityTraits())
+            .accessibility(removeTraits: AccessibilityTraits())
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut3, AccessibilityTraits())
+        guard #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+        else { return }
+        let sut4 = try EmptyView().accessibilityAddTraits([]).accessibilityRemoveTraits(.isButton)
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut4, AccessibilityTraits())
+        let sut5 = try EmptyView().accessibilityAddTraits(.isButton).accessibilityRemoveTraits([])
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut5, .isButton)
+        let sut6 = try EmptyView().accessibilityAddTraits([]).accessibilityRemoveTraits([])
+            .inspect().emptyView().accessibilityTraits()
+        XCTAssertEqual(sut6, AccessibilityTraits())
+    }
+
     func testAccessibilityTraitsInspectionAmongOtherModifiers() throws {
         let sut = try EmptyView()
             .accessibility(label: Text("abc"))


### PR DESCRIPTION
## Problem

`accessibilityTraits()` throws `modifierNotFound` when a view's only trait modifier resolves to an empty set:

```swift
Text("x").accessibilityAddTraits([])                          // throws
Text("x").accessibilityAddTraits(cond ? [.isSelected] : [])   // throws on the false arm
```

```
ViewInspector.InspectionError.modifierNotFound:
  "Text does not have 'accessibilityAddTraits' modifier"
```

The second form is the one that bites in practice — a test covering both arms of a conditional trait passes for one branch and throws for the other.

## Cause

A SwiftUI **runtime** change, not a long-standing bug.

On the iOS 26 runtime, `AccessibilityProperties` is a struct with a named `traits` field that is populated even for an empty set (`value: 0, mask: 0`), so the existing lookup finds it and returns `AccessibilityTraits()`:

```
properties: AccessibilityProperties
  label: Optional<AccessibilityLabelStorage>
  traits: Optional<AccessibilityNullableOptionSet<AccessibilityTraitSet>>
    some: … value.rawValue = 0, mask.rawValue = 0
```

On the iOS 27 runtime the properties moved to a type-keyed collection, and an empty trait set contributes **no entry at all** — there is nothing left for the reflection walk to find:

```
properties: AccessibilityProperties
  storage: Array<Entry> = []            // .accessibilityAddTraits([])
  storage: Array<Entry> = [Entry(key: TraitsKey, value: …)]   // .accessibilityAddTraits(.isButton)
```

It reproduces under both Xcode 26.6 and Xcode 27 whenever the iOS 27 runtime is used, which confirms the trigger is the runtime rather than the SDK.

## Fix

The `AccessibilityAttachmentModifier` itself is still emitted, so the empty set is recoverable. Every other accessibility modifier stores a value under its own key — `LabelKey`, `VisibilityKey`, `IdentifierKey`, `ValueStorageKey`, `HintsKey`, `InputLabelsKey`, `SortPriorityKey`, `ActionsKey` — including the no-op-looking ones (`accessibilityHidden(false)`, `accessibilityLabel("")`, `accessibilityInputLabels([])`, `accessibility(sortPriority: 0)`). That makes an attachment carrying *no* accessibility properties whatsoever the signature of a trait modifier that contributed no bits.

So when no trait value is found, `accessibilityTraits()` now returns `AccessibilityTraits()` if some attachment modifier has an empty property collection, and throws otherwise. The check keys off the collection shape rather than an OS version, so it cannot fire on the iOS 26 layout, where the property bag is a struct.

The throw is preserved where it should be:

- a view with no accessibility modifier at all (`padding()` emits no attachment modifier),
- a view whose only accessibility modifier stores some other property — `testMissingAccessibilityTraits` uses `accessibility(label:)` and still throws on every runtime.

## Known limitation

On the iOS 27 runtime, an empty trait modifier combined with another accessibility modifier is coalesced into a single attachment carrying only the other modifier's key:

```swift
EmptyView().accessibilityAddTraits([]).accessibility(label: Text("abc"))
// → one attachment, storage: [Entry(key: LabelKey, …)]
```

That is byte-identical to `accessibility(label:)` applied alone, which must keep throwing. Nothing distinguishes the two, so this case still throws rather than weakening the throw for a view that genuinely has no trait modifier.

## Tests

Two tests added, both written to fail before the fix:

- `testAccessibilityEmptyTraitsInspection` — empty add and empty remove, both spellings (`accessibility(addTraits:)` / `accessibilityAddTraits`), on `EmptyView` and `Text`.
- `testAccessibilityEmptyAndNonEmptyTraitsInspection` — empty add + non-empty remove, non-empty add + empty remove, and both empty.

Pre-fix, with the tests in place:

| | Xcode 27 / iOS 27.0 | Xcode 26.6 / iOS 26.5 |
|---|---|---|
| both tests | fail | pass |

Post-fix, full suite (1563 tests, 15 skipped, 0 failures in every cell):

| Toolchain | iOS 26.5 | iOS 27.0 |
|---|---|---|
| Xcode 27.0 (27A266a) | pass | pass |
| Xcode 26.6 (17F113) | pass | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)